### PR TITLE
Add Auto-assign Workflow on 'take' Comments.

### DIFF
--- a/.github/workflows/auto-assign-on-comment.yaml
+++ b/.github/workflows/auto-assign-on-comment.yaml
@@ -1,0 +1,50 @@
+name: Auto Assign on 'take' Comment
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  issues: write
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    if: (!github.event.issue.pull_request) && contains(github.event.comment.body, 'take')
+    concurrency:
+      group: ${{ github.actor }}-auto-assign-issue
+      cancel-in-progress: true
+    steps:
+      - name: Auto assign if comment includes 'take'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body.toLowerCase();
+            const author = context.payload.comment.user.login;
+            const issue = context.payload.issue;
+
+            // Check if comment includes 'take'
+            if (!body.includes('take')) {
+              console.log("Comment does not include 'take'; skipping.");
+              return;
+            }
+
+            // Check if already assigned
+            const alreadyAssigned = issue.assignees.find(a => a.login === author);
+            if (alreadyAssigned) {
+              console.log(`${author} is already assigned; skipping.`);
+              return;
+            }
+
+            // Check if there is any other assignee
+            if (issue.assignees.length > 0) {
+              console.log("Issue already has an assignee; skipping assignment.");
+              return;
+            }
+
+            // Assign to commenter
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              assignees: [author],
+            });
+
+            console.log(`Assigned ${author} to issue #${issue.number}`);


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

 - Added `.github/workflows/auto-assign-on-comment.yaml` to enable automatic assignment of issues when a comment includes 'take'.