### PR TITLE
feat: dedicated error types for UC clients (#16)

### DIFF
--- a/crates/build/src/codegen/generation/client.rs
+++ b/crates/build/src/codegen/generation/client.rs
@@ -103,7 +103,9 @@ pub fn client_method(method: MethodHandler<'_>) -> TokenStream {
                 #url_formatting
                 #query_handling
                 let response = self.client.#http_method(url)#body_handling.send().await?;
-                response.error_for_status_ref()?;
+                if !response.status().is_success() {
+                    return Err(crate::error::parse_error_response(response).await);
+                }
                 let result = response.bytes().await?;
                 Ok(serde_json::from_slice(&result)?)
             }
@@ -115,7 +117,9 @@ pub fn client_method(method: MethodHandler<'_>) -> TokenStream {
                 #url_formatting
                 #query_handling
                 let response = self.client.#http_method(url)#body_handling.send().await?;
-                response.error_for_status()?;
+                if !response.status().is_success() {
+                    return Err(crate::error::parse_error_response(response).await);
+                }
                 Ok(())
             }
         }

--- a/crates/build/src/codegen/generation/node/typescript.rs
+++ b/crates/build/src/codegen/generation/node/typescript.rs
@@ -49,12 +49,117 @@ fn is_napi_supported_type(base_type: &BaseType) -> bool {
     }
 }
 
+/// TypeScript error class definitions and `parseNativeError` helper.
+fn generate_error_classes() -> &'static str {
+    r#"// ── UC error hierarchy ────────────────────────────────────────────────────────
+
+/** Base class for all Unity Catalog errors. */
+export class UnityCatalogError extends Error {
+  readonly errorCode: string;
+  constructor(message: string, errorCode: string) {
+    super(message);
+    this.name = "UnityCatalogError";
+    this.errorCode = errorCode;
+  }
+}
+
+export class NotFoundError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "RESOURCE_NOT_FOUND");
+    this.name = "NotFoundError";
+  }
+}
+
+export class AlreadyExistsError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "RESOURCE_ALREADY_EXISTS");
+    this.name = "AlreadyExistsError";
+  }
+}
+
+export class PermissionDeniedError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "PERMISSION_DENIED");
+    this.name = "PermissionDeniedError";
+  }
+}
+
+export class UnauthenticatedError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "UNAUTHENTICATED");
+    this.name = "UnauthenticatedError";
+  }
+}
+
+export class InvalidParameterError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "INVALID_PARAMETER_VALUE");
+    this.name = "InvalidParameterError";
+  }
+}
+
+export class RequestLimitError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "REQUEST_LIMIT_EXCEEDED");
+    this.name = "RequestLimitError";
+  }
+}
+
+export class InternalServerError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "INTERNAL_ERROR");
+    this.name = "InternalServerError";
+  }
+}
+
+export class ServiceUnavailableError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "TEMPORARILY_UNAVAILABLE");
+    this.name = "ServiceUnavailableError";
+  }
+}
+
+type UcErrorConstructor = new (message: string) => UnityCatalogError;
+
+const UC_ERROR_MAP: Record<string, UcErrorConstructor> = {
+  RESOURCE_NOT_FOUND: NotFoundError,
+  RESOURCE_ALREADY_EXISTS: AlreadyExistsError,
+  PERMISSION_DENIED: PermissionDeniedError,
+  UNAUTHENTICATED: UnauthenticatedError,
+  INVALID_PARAMETER_VALUE: InvalidParameterError,
+  REQUEST_LIMIT_EXCEEDED: RequestLimitError,
+  INTERNAL_ERROR: InternalServerError,
+  TEMPORARILY_UNAVAILABLE: ServiceUnavailableError,
+};
+
+/**
+ * Parse a native NAPI error that may carry a `UC:<CODE>:<message>` prefix
+ * and re-throw as the appropriate typed subclass of `UnityCatalogError`.
+ */
+function parseNativeError(e: unknown): never {
+  if (e instanceof Error) {
+    const match = e.message.match(/^UC:([^:]+):([\s\S]*)$/);
+    if (match) {
+      const [, code, message] = match;
+      const Ctor = UC_ERROR_MAP[code] ?? UnityCatalogError;
+      throw new Ctor(message);
+    }
+  }
+  throw e;
+}
+
+// ── end UC error hierarchy ─────────────────────────────────────────────────────
+
+"#
+}
+
 /// Generate the complete `client.ts` file for all services.
 pub(crate) fn generate_client_ts(services: &[ServiceHandler<'_>]) -> String {
     let mut out = String::new();
 
     out.push_str(&generate_imports(services));
     out.push('\n');
+    out.push_str(generate_error_classes());
 
     // Generate options interfaces for all services
     for service in services {
@@ -249,7 +354,9 @@ fn generate_resource_get_method(method: &MethodHandler<'_>, type_name: &str) -> 
     if optional_params.is_empty() {
         return format!(
             r#"{jsdoc}  async get(): Promise<{type_name}> {{
-    return fromBinary({schema_name}, await this.inner.get());
+    try {{
+      return fromBinary({schema_name}, await this.inner.get());
+    }} catch (e) {{ parseNativeError(e); }}
   }}
 
 "#
@@ -271,7 +378,9 @@ fn generate_resource_get_method(method: &MethodHandler<'_>, type_name: &str) -> 
     format!(
         r#"{jsdoc}  async get(options?: {options_type}): Promise<{type_name}> {{
     const {{ {destructure_fields} }} = options || {{}};
-    return fromBinary({schema_name}, await this.inner.get({call_args}));
+    try {{
+      return fromBinary({schema_name}, await this.inner.get({call_args}));
+    }} catch (e) {{ parseNativeError(e); }}
   }}
 
 "#
@@ -291,7 +400,9 @@ fn generate_resource_update_method(method: &MethodHandler<'_>, type_name: &str) 
     if optional_params.is_empty() {
         return format!(
             r#"{jsdoc}  async update(): Promise<{type_name}> {{
-    return fromBinary({schema_name}, await this.inner.update());
+    try {{
+      return fromBinary({schema_name}, await this.inner.update());
+    }} catch (e) {{ parseNativeError(e); }}
   }}
 
 "#
@@ -313,7 +424,9 @@ fn generate_resource_update_method(method: &MethodHandler<'_>, type_name: &str) 
     format!(
         r#"{jsdoc}  async update(options?: {options_type}): Promise<{type_name}> {{
     const {{ {destructure_fields} }} = options || {{}};
-    return fromBinary({schema_name}, await this.inner.update({call_args}));
+    try {{
+      return fromBinary({schema_name}, await this.inner.update({call_args}));
+    }} catch (e) {{ parseNativeError(e); }}
   }}
 
 "#
@@ -330,7 +443,9 @@ fn generate_resource_delete_method(method: &MethodHandler<'_>) -> String {
     if optional_params.is_empty() {
         return format!(
             r#"{jsdoc}  async delete(): Promise<void> {{
-    await this.inner.delete();
+    try {{
+      await this.inner.delete();
+    }} catch (e) {{ parseNativeError(e); }}
   }}
 
 "#
@@ -354,7 +469,9 @@ fn generate_resource_delete_method(method: &MethodHandler<'_>) -> String {
     format!(
         r#"{jsdoc}  async delete(options?: {options_type}): Promise<void> {{
     const {{ {destructure_fields} }} = options || {{}};
-    await this.inner.delete({call_args});
+    try {{
+      await this.inner.delete({call_args});
+    }} catch (e) {{ parseNativeError(e); }}
   }}
 
 "#
@@ -479,9 +596,11 @@ fn generate_collection_list_method(
 
     format!(
         r#"{jsdoc}  async {method_name}({full_param_list}): Promise<{item_type_name}[]> {{
-{optional_destructure}    return (await this.inner.{method_name}({all_args})).map((data) =>
-      fromBinary({schema_name}, data),
-    );
+{optional_destructure}    try {{
+      return (await this.inner.{method_name}({all_args})).map((data) =>
+        fromBinary({schema_name}, data),
+      );
+    }} catch (e) {{ parseNativeError(e); }}
   }}
 
 "#
@@ -562,7 +681,9 @@ fn generate_collection_create_method(
 
     format!(
         r#"{jsdoc}  async {method_name}({full_param_list}): Promise<{output_type}> {{
-{optional_destructure}    return fromBinary({schema_name}, await this.inner.{method_name}({all_args}));
+{optional_destructure}    try {{
+      return fromBinary({schema_name}, await this.inner.{method_name}({all_args}));
+    }} catch (e) {{ parseNativeError(e); }}
   }}
 
 "#
@@ -634,7 +755,9 @@ fn generate_void_create_method(method: &MethodHandler<'_>) -> String {
 
     format!(
         r#"{jsdoc}  async {method_name}({full_param_list}): Promise<void> {{
-{optional_destructure}    await this.inner.{method_name}({all_args});
+{optional_destructure}    try {{
+      await this.inner.{method_name}({all_args});
+    }} catch (e) {{ parseNativeError(e); }}
   }}
 
 "#

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -26,6 +26,8 @@ futures = { version = "0.3" }
 [dev-dependencies]
 rstest = "0.18"
 mockito = "1.4"
+http = "1"
+bytes = { workspace = true }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tokio-test = "0.4"
 serde = { workspace = true }

--- a/crates/client/src/codegen/catalogs/client.rs
+++ b/crates/client/src/codegen/catalogs/client.rs
@@ -38,7 +38,9 @@ impl CatalogClient {
                 .append_pair("page_token", &value.to_string());
         }
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -49,7 +51,9 @@ impl CatalogClient {
     pub async fn create_catalog(&self, request: &CreateCatalogRequest) -> Result<Catalog> {
         let mut url = self.base_url.join("catalogs")?;
         let response = self.client.post(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -65,7 +69,9 @@ impl CatalogClient {
                 .append_pair("include_browse", &value.to_string());
         }
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -77,7 +83,9 @@ impl CatalogClient {
         let formatted_path = format!("catalogs/{}", request.name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.patch(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -93,7 +101,9 @@ impl CatalogClient {
                 .append_pair("force", &value.to_string());
         }
         let response = self.client.delete(url).send().await?;
-        response.error_for_status()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         Ok(())
     }
 }

--- a/crates/client/src/codegen/credentials/client.rs
+++ b/crates/client/src/codegen/credentials/client.rs
@@ -36,14 +36,18 @@ impl CredentialClient {
                 .append_pair("page_token", &value.to_string());
         }
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
     pub async fn create_credential(&self, request: &CreateCredentialRequest) -> Result<Credential> {
         let mut url = self.base_url.join("credentials")?;
         let response = self.client.post(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -51,7 +55,9 @@ impl CredentialClient {
         let formatted_path = format!("credentials/{}", request.name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -59,7 +65,9 @@ impl CredentialClient {
         let formatted_path = format!("credentials/{}", request.name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.patch(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -67,7 +75,9 @@ impl CredentialClient {
         let formatted_path = format!("credentials/{}", request.name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.delete(url).send().await?;
-        response.error_for_status()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         Ok(())
     }
 }

--- a/crates/client/src/codegen/external_locations/client.rs
+++ b/crates/client/src/codegen/external_locations/client.rs
@@ -37,7 +37,9 @@ impl ExternalLocationClient {
                 .append_pair("include_browse", &value.to_string());
         }
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -48,7 +50,9 @@ impl ExternalLocationClient {
     ) -> Result<ExternalLocation> {
         let mut url = self.base_url.join("external-locations")?;
         let response = self.client.post(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -60,7 +64,9 @@ impl ExternalLocationClient {
         let formatted_path = format!("external-locations/{}", request.name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -72,7 +78,9 @@ impl ExternalLocationClient {
         let formatted_path = format!("external-locations/{}", request.name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.patch(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -88,7 +96,9 @@ impl ExternalLocationClient {
                 .append_pair("force", &value.to_string());
         }
         let response = self.client.delete(url).send().await?;
-        response.error_for_status()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         Ok(())
     }
 }

--- a/crates/client/src/codegen/recipients/client.rs
+++ b/crates/client/src/codegen/recipients/client.rs
@@ -33,7 +33,9 @@ impl RecipientClient {
                 .append_pair("page_token", &value.to_string());
         }
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -41,7 +43,9 @@ impl RecipientClient {
     pub async fn create_recipient(&self, request: &CreateRecipientRequest) -> Result<Recipient> {
         let mut url = self.base_url.join("recipients")?;
         let response = self.client.post(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -50,7 +54,9 @@ impl RecipientClient {
         let formatted_path = format!("recipients/{}", request.name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -59,7 +65,9 @@ impl RecipientClient {
         let formatted_path = format!("recipients/{}", request.name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.patch(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -68,7 +76,9 @@ impl RecipientClient {
         let formatted_path = format!("recipients/{}", request.name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.delete(url).send().await?;
-        response.error_for_status()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         Ok(())
     }
 }

--- a/crates/client/src/codegen/schemas/client.rs
+++ b/crates/client/src/codegen/schemas/client.rs
@@ -39,7 +39,9 @@ impl SchemaClient {
                 .append_pair("include_browse", &value.to_string());
         }
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -48,7 +50,9 @@ impl SchemaClient {
     pub async fn create_schema(&self, request: &CreateSchemaRequest) -> Result<Schema> {
         let mut url = self.base_url.join("schemas")?;
         let response = self.client.post(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -59,7 +63,9 @@ impl SchemaClient {
         let formatted_path = format!("schemas/{}", request.full_name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -71,7 +77,9 @@ impl SchemaClient {
         let formatted_path = format!("schemas/{}", request.full_name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.patch(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -85,7 +93,9 @@ impl SchemaClient {
                 .append_pair("force", &value.to_string());
         }
         let response = self.client.delete(url).send().await?;
-        response.error_for_status()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         Ok(())
     }
 }

--- a/crates/client/src/codegen/shares/client.rs
+++ b/crates/client/src/codegen/shares/client.rs
@@ -30,7 +30,9 @@ impl ShareClient {
                 .append_pair("page_token", &value.to_string());
         }
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -38,7 +40,9 @@ impl ShareClient {
     pub async fn create_share(&self, request: &CreateShareRequest) -> Result<Share> {
         let mut url = self.base_url.join("shares")?;
         let response = self.client.post(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -51,7 +55,9 @@ impl ShareClient {
                 .append_pair("include_shared_data", &value.to_string());
         }
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -60,7 +66,9 @@ impl ShareClient {
         let formatted_path = format!("shares/{}", request.name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.patch(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -69,7 +77,9 @@ impl ShareClient {
         let formatted_path = format!("shares/{}", request.name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.delete(url).send().await?;
-        response.error_for_status()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         Ok(())
     }
     /// Gets the permissions for a data share from the metastore.
@@ -88,7 +98,9 @@ impl ShareClient {
                 .append_pair("page_token", &value.to_string());
         }
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -100,7 +112,9 @@ impl ShareClient {
         let formatted_path = format!("shares/{}/permissions", request.name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.patch(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }

--- a/crates/client/src/codegen/tables/client.rs
+++ b/crates/client/src/codegen/tables/client.rs
@@ -53,7 +53,9 @@ impl TableClient {
                 .append_pair("include_manifest_capabilities", &value.to_string());
         }
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -102,7 +104,9 @@ impl TableClient {
                 .append_pair("include_manifest_capabilities", &value.to_string());
         }
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -110,7 +114,9 @@ impl TableClient {
     pub async fn create_table(&self, request: &CreateTableRequest) -> Result<Table> {
         let mut url = self.base_url.join("tables")?;
         let response = self.client.post(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -131,7 +137,9 @@ impl TableClient {
                 .append_pair("include_manifest_capabilities", &value.to_string());
         }
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -143,7 +151,9 @@ impl TableClient {
         let formatted_path = format!("tables/{}/exists", request.full_name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -152,7 +162,9 @@ impl TableClient {
         let formatted_path = format!("tables/{}", request.full_name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.delete(url).send().await?;
-        response.error_for_status()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         Ok(())
     }
 }

--- a/crates/client/src/codegen/temporary_credentials/client.rs
+++ b/crates/client/src/codegen/temporary_credentials/client.rs
@@ -25,7 +25,9 @@ impl TemporaryCredentialClient {
     ) -> Result<TemporaryCredential> {
         let mut url = self.base_url.join("temporary-table-credentials")?;
         let response = self.client.post(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -36,7 +38,9 @@ impl TemporaryCredentialClient {
     ) -> Result<TemporaryCredential> {
         let mut url = self.base_url.join("temporary-path-credentials")?;
         let response = self.client.post(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }

--- a/crates/client/src/codegen/volumes/client.rs
+++ b/crates/client/src/codegen/volumes/client.rs
@@ -38,14 +38,18 @@ impl VolumeClient {
                 .append_pair("include_browse", &value.to_string());
         }
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
     pub async fn create_volume(&self, request: &CreateVolumeRequest) -> Result<Volume> {
         let mut url = self.base_url.join("volumes")?;
         let response = self.client.post(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -57,7 +61,9 @@ impl VolumeClient {
                 .append_pair("include_browse", &value.to_string());
         }
         let response = self.client.get(url).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -65,7 +71,9 @@ impl VolumeClient {
         let formatted_path = format!("volumes/{}", request.name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.patch(url).json(request).send().await?;
-        response.error_for_status_ref()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         let result = response.bytes().await?;
         Ok(serde_json::from_slice(&result)?)
     }
@@ -73,7 +81,9 @@ impl VolumeClient {
         let formatted_path = format!("volumes/{}", request.name);
         let mut url = self.base_url.join(&formatted_path)?;
         let response = self.client.delete(url).send().await?;
-        response.error_for_status()?;
+        if !response.status().is_success() {
+            return Err(crate::error::parse_error_response(response).await);
+        }
         Ok(())
     }
 }

--- a/crates/client/src/error.rs
+++ b/crates/client/src/error.rs
@@ -29,6 +29,9 @@ pub enum Error {
     #[error("Reqwuest error: {0}")]
     RequestError(#[from] reqwest::Error),
 
+    #[error("API error: {0}")]
+    Api(#[from] UcApiError),
+
     #[error("Generic error: {0}")]
     Generic(String),
 }
@@ -36,5 +39,197 @@ pub enum Error {
 impl Error {
     pub fn generic(message: impl ToString) -> Self {
         Error::Generic(message.to_string())
+    }
+
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, Error::Api(UcApiError::NotFound { .. }))
+    }
+
+    pub fn is_already_exists(&self) -> bool {
+        matches!(self, Error::Api(UcApiError::AlreadyExists { .. }))
+    }
+
+    pub fn is_permission_denied(&self) -> bool {
+        matches!(self, Error::Api(UcApiError::PermissionDenied { .. }))
+    }
+
+    pub fn is_unauthenticated(&self) -> bool {
+        matches!(self, Error::Api(UcApiError::Unauthenticated { .. }))
+    }
+}
+
+/// Typed error variants mapped to the Databricks Unity Catalog API error code spec.
+#[derive(Debug, thiserror::Error, PartialEq, Eq, Clone)]
+#[non_exhaustive]
+pub enum UcApiError {
+    #[error("Invalid parameter: {message}")]
+    InvalidParameter { message: String },
+
+    #[error("Unauthenticated: {message}")]
+    Unauthenticated { message: String },
+
+    #[error("Permission denied: {message}")]
+    PermissionDenied { message: String },
+
+    #[error("Resource not found: {message}")]
+    NotFound { message: String },
+
+    #[error("Resource already exists: {message}")]
+    AlreadyExists { message: String },
+
+    #[error("Request limit exceeded: {message}")]
+    RequestLimitExceeded { message: String },
+
+    #[error("Internal server error: {message}")]
+    InternalError { message: String },
+
+    #[error("Temporarily unavailable: {message}")]
+    TemporarilyUnavailable { message: String },
+
+    #[error("API error {status}: [{error_code}] {message}")]
+    Other {
+        status: u16,
+        error_code: String,
+        message: String,
+    },
+}
+
+impl UcApiError {
+    /// Returns the UC API error code string.
+    pub fn error_code(&self) -> &str {
+        match self {
+            UcApiError::InvalidParameter { .. } => "INVALID_PARAMETER_VALUE",
+            UcApiError::Unauthenticated { .. } => "UNAUTHENTICATED",
+            UcApiError::PermissionDenied { .. } => "PERMISSION_DENIED",
+            UcApiError::NotFound { .. } => "RESOURCE_NOT_FOUND",
+            UcApiError::AlreadyExists { .. } => "RESOURCE_ALREADY_EXISTS",
+            UcApiError::RequestLimitExceeded { .. } => "REQUEST_LIMIT_EXCEEDED",
+            UcApiError::InternalError { .. } => "INTERNAL_ERROR",
+            UcApiError::TemporarilyUnavailable { .. } => "TEMPORARILY_UNAVAILABLE",
+            UcApiError::Other { error_code, .. } => error_code,
+        }
+    }
+
+    /// Returns the HTTP status code associated with this error.
+    pub fn http_status(&self) -> u16 {
+        match self {
+            UcApiError::InvalidParameter { .. } => 400,
+            UcApiError::Unauthenticated { .. } => 401,
+            UcApiError::PermissionDenied { .. } => 403,
+            UcApiError::NotFound { .. } => 404,
+            UcApiError::AlreadyExists { .. } => 409,
+            UcApiError::RequestLimitExceeded { .. } => 429,
+            UcApiError::InternalError { .. } => 500,
+            UcApiError::TemporarilyUnavailable { .. } => 503,
+            UcApiError::Other { status, .. } => *status,
+        }
+    }
+
+    /// Construct from an API response with status code, error code string, and message.
+    pub fn from_api_response(status: u16, error_code: &str, message: String) -> Self {
+        match error_code {
+            "INVALID_PARAMETER_VALUE" => UcApiError::InvalidParameter { message },
+            "UNAUTHENTICATED" => UcApiError::Unauthenticated { message },
+            "PERMISSION_DENIED" => UcApiError::PermissionDenied { message },
+            "RESOURCE_NOT_FOUND" => UcApiError::NotFound { message },
+            "RESOURCE_ALREADY_EXISTS" => UcApiError::AlreadyExists { message },
+            "REQUEST_LIMIT_EXCEEDED" => UcApiError::RequestLimitExceeded { message },
+            "INTERNAL_ERROR" => UcApiError::InternalError { message },
+            "TEMPORARILY_UNAVAILABLE" => UcApiError::TemporarilyUnavailable { message },
+            other => UcApiError::Other {
+                status,
+                error_code: other.to_string(),
+                message,
+            },
+        }
+    }
+}
+
+/// Serde helper for parsing the UC API error body.
+#[derive(serde::Deserialize)]
+struct ApiErrorBody {
+    #[serde(alias = "errorCode")]
+    error_code: String,
+    message: String,
+}
+
+/// Read an error HTTP response, parse the UC API JSON body, and return a typed [`Error`].
+pub(crate) async fn parse_error_response(response: reqwest::Response) -> Error {
+    let status = response.status().as_u16();
+    match response.bytes().await {
+        Ok(body) => match serde_json::from_slice::<ApiErrorBody>(&body) {
+            Ok(api_err) => {
+                UcApiError::from_api_response(status, &api_err.error_code, api_err.message).into()
+            }
+            Err(_) => UcApiError::Other {
+                status,
+                error_code: String::new(),
+                message: String::from_utf8_lossy(&body).into_owned(),
+            }
+            .into(),
+        },
+        Err(e) => Error::RequestError(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_response(status: u16, body: &'static str) -> reqwest::Response {
+        http::Response::builder()
+            .status(status)
+            .header("content-type", "application/json")
+            .body(bytes::Bytes::from_static(body.as_bytes()))
+            .map(reqwest::Response::from)
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_parse_error_resource_not_found() {
+        let resp = make_response(
+            404,
+            r#"{"error_code":"RESOURCE_NOT_FOUND","message":"catalog 'foo' not found"}"#,
+        );
+        let err = parse_error_response(resp).await;
+        assert!(err.is_not_found());
+        assert!(matches!(
+            err,
+            Error::Api(UcApiError::NotFound { ref message }) if message == "catalog 'foo' not found"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_parse_error_camel_case_alias() {
+        let resp = make_response(
+            404,
+            r#"{"errorCode":"RESOURCE_NOT_FOUND","message":"not found"}"#,
+        );
+        let err = parse_error_response(resp).await;
+        assert!(err.is_not_found());
+    }
+
+    #[tokio::test]
+    async fn test_parse_error_non_json_body() {
+        let resp = make_response(500, "Internal Server Error");
+        let err = parse_error_response(resp).await;
+        assert!(matches!(
+            err,
+            Error::Api(UcApiError::Other {
+                status: 500,
+                ref message,
+                ..
+            }) if message == "Internal Server Error"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_parse_error_already_exists() {
+        let resp = make_response(
+            409,
+            r#"{"error_code":"RESOURCE_ALREADY_EXISTS","message":"already exists"}"#,
+        );
+        let err = parse_error_response(resp).await;
+        assert!(err.is_already_exists());
     }
 }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -27,14 +27,6 @@ tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 
-futures-util = { version = "0.3.28" }
-reqwest = { version = "0.12", default-features = false, features = [
-  "rustls-tls-native-roots",
-  "http2",
-  "json",
-  "stream",
-] }
-
 # rest server dependencies (in alphabetical order)
 axum = { workspace = true, optional = true }
 

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -24,9 +24,8 @@ pub enum Error {
     #[error("invalid url: {0}")]
     InvalidUrl(#[from] url::ParseError),
 
-    #[error("Reqwuest error: {0}")]
-    RequestError(#[from] reqwest::Error),
-
+    // TODO(follow-up): migrate AxumPath/AxumQuery to crates/server so that
+    // crates/common does not depend on axum.
     #[cfg(feature = "axum")]
     #[error("Axum path: {0}")]
     AxumPath(#[from] axum::extract::rejection::PathRejection),
@@ -54,7 +53,6 @@ impl Error {
             Error::InvalidTableLocation(_) => "INVALID_PARAMETER_VALUE",
             Error::InvalidUrl(_) => "INVALID_PARAMETER_VALUE",
             Error::SerDe(_) => "INTERNAL_ERROR",
-            Error::RequestError(_) => "INTERNAL_ERROR",
             Error::Generic(_) => "INTERNAL_ERROR",
             #[cfg(feature = "axum")]
             Error::AxumPath(_) => "INVALID_PARAMETER_VALUE",
@@ -103,11 +101,6 @@ mod server {
                 }
                 Error::InvalidUrl(_) => {
                     error!("Invalid url");
-                    INTERNAL_ERROR
-                }
-                Error::RequestError(error) => {
-                    let message = format!("Request error: {}", error);
-                    error!("{}", message);
                     INTERNAL_ERROR
                 }
                 Error::InvalidIdentifier(_) => {

--- a/node/client/src/error.rs
+++ b/node/client/src/error.rs
@@ -14,17 +14,23 @@ impl<T> NapiErrorExt<T> for std::result::Result<T, unitycatalog_client::Error> {
     }
 }
 
-pub fn convert_error(err: &dyn std::error::Error) -> napi::Error {
+pub fn convert_error(err: &unitycatalog_client::Error) -> napi::Error {
+    // Emit a structured prefix for typed TS errors so the generated
+    // `parseNativeError` function can match on the error code.
+    if let unitycatalog_client::Error::Api(api_err) = err {
+        return napi::Error::from_reason(format!("UC:{}:{}", api_err.error_code(), api_err));
+    }
+
     let mut message = err.to_string();
 
     // Append causes
-    let mut cause = err.source();
+    let mut cause = std::error::Error::source(err);
     let mut indent = 2;
-    while let Some(err) = cause {
-        let cause_message = format!("Caused by: {}", err);
+    while let Some(e) = cause {
+        let cause_message = format!("Caused by: {}", e);
         message.push_str(&indent_string(&cause_message, indent));
 
-        cause = err.source();
+        cause = e.source();
         indent += 2;
     }
 

--- a/node/client/unitycatalog/client.ts
+++ b/node/client/unitycatalog/client.ts
@@ -32,6 +32,105 @@ import {
   NapiVolumeClient as NativeVolumeClient,
 } from "./native";
 
+// ── UC error hierarchy ────────────────────────────────────────────────────────
+
+/** Base class for all Unity Catalog errors. */
+export class UnityCatalogError extends Error {
+  readonly errorCode: string;
+  constructor(message: string, errorCode: string) {
+    super(message);
+    this.name = "UnityCatalogError";
+    this.errorCode = errorCode;
+  }
+}
+
+export class NotFoundError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "RESOURCE_NOT_FOUND");
+    this.name = "NotFoundError";
+  }
+}
+
+export class AlreadyExistsError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "RESOURCE_ALREADY_EXISTS");
+    this.name = "AlreadyExistsError";
+  }
+}
+
+export class PermissionDeniedError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "PERMISSION_DENIED");
+    this.name = "PermissionDeniedError";
+  }
+}
+
+export class UnauthenticatedError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "UNAUTHENTICATED");
+    this.name = "UnauthenticatedError";
+  }
+}
+
+export class InvalidParameterError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "INVALID_PARAMETER_VALUE");
+    this.name = "InvalidParameterError";
+  }
+}
+
+export class RequestLimitError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "REQUEST_LIMIT_EXCEEDED");
+    this.name = "RequestLimitError";
+  }
+}
+
+export class InternalServerError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "INTERNAL_ERROR");
+    this.name = "InternalServerError";
+  }
+}
+
+export class ServiceUnavailableError extends UnityCatalogError {
+  constructor(message: string) {
+    super(message, "TEMPORARILY_UNAVAILABLE");
+    this.name = "ServiceUnavailableError";
+  }
+}
+
+type UcErrorConstructor = new (message: string) => UnityCatalogError;
+
+const UC_ERROR_MAP: Record<string, UcErrorConstructor> = {
+  RESOURCE_NOT_FOUND: NotFoundError,
+  RESOURCE_ALREADY_EXISTS: AlreadyExistsError,
+  PERMISSION_DENIED: PermissionDeniedError,
+  UNAUTHENTICATED: UnauthenticatedError,
+  INVALID_PARAMETER_VALUE: InvalidParameterError,
+  REQUEST_LIMIT_EXCEEDED: RequestLimitError,
+  INTERNAL_ERROR: InternalServerError,
+  TEMPORARILY_UNAVAILABLE: ServiceUnavailableError,
+};
+
+/**
+ * Parse a native NAPI error that may carry a `UC:<CODE>:<message>` prefix
+ * and re-throw as the appropriate typed subclass of `UnityCatalogError`.
+ */
+function parseNativeError(e: unknown): never {
+  if (e instanceof Error) {
+    const match = e.message.match(/^UC:([^:]+):([\s\S]*)$/);
+    if (match) {
+      const [, code, message] = match;
+      const Ctor = UC_ERROR_MAP[code] ?? UnityCatalogError;
+      throw new Ctor(message);
+    }
+  }
+  throw e;
+}
+
+// ── end UC error hierarchy ─────────────────────────────────────────────────────
+
 export interface ListRecipientsOptions {
   /** The maximum number of results per page that should be returned. */
   maxResults?: number;
@@ -67,74 +166,57 @@ export interface UpdateRecipientOptions {
   expirationTime?: number;
 }
 
-export interface ListSharesOptions {
+export interface ListCredentialsOptions {
+  /** Return only credentials for the specified purpose. */
+  purpose?: number;
   /** The maximum number of results per page that should be returned. */
   maxResults?: number;
   /** Opaque pagination token to go to next page based on previous query. */
   pageToken?: string;
 }
 
-export interface CreateShareOptions {
-  /** User-provided free-form text description. */
+export interface CreateCredentialOptions {
+  /** Comment associated with the credential. */
   comment?: string;
+  /** Whether the credential is usable only for read operations. Only applicable when purpose is STORAGE. */
+  readOnly?: boolean;
+  /** Supplying true to this argument skips validation of the created set of credentials. */
+  skipValidation?: boolean;
 }
 
-export interface GetShareOptions {
-  /** Query for data to include in the share. */
-  includeSharedData?: boolean;
-}
-
-export interface UpdateShareOptions {
-  /** A new name for the share. */
+export interface UpdateCredentialOptions {
+  /** Name of credential. */
   newName?: string;
-  /** Owner of the share. */
-  owner?: string;
-  /** User-provided free-form text description. */
+  /** Comment associated with the credential. */
   comment?: string;
+  /** Whether the credential is usable only for read operations. Only applicable when purpose is STORAGE. */
+  readOnly?: boolean;
+  /** Username of current owner of credential. */
+  owner?: string;
+  /** Supply true to this argument to skip validation of the updated credential. */
+  skipValidation?: boolean;
+  /** Force an update even if there are dependent services (when purpose is SERVICE)
+   *  or dependent external locations and external tables (when purpose is STORAGE). */
+  force?: boolean;
 }
 
-export interface GetPermissionsOptions {
+export interface ListSchemasOptions {
   /** The maximum number of results per page that should be returned. */
   maxResults?: number;
   /** Opaque pagination token to go to next page based on previous query. */
   pageToken?: string;
+  /** Whether to include schemas in the response for which the principal can only access selective metadata for */
+  includeBrowse?: boolean;
 }
 
-export interface UpdatePermissionsOptions {
-  /** Whether to return the latest permissions list of the share in the response. */
-  omitPermissionsList?: boolean;
-}
-
-export interface ListCatalogsOptions {
-  /** The maximum number of results per page that should be returned. */
-  maxResults?: number;
-  /** Opaque pagination token to go to next page based on previous query. */
-  pageToken?: string;
-}
-
-export interface CreateCatalogOptions {
+export interface CreateSchemaOptions {
   /** User-provided free-form text description. */
   comment?: string;
   /** A map of key-value properties attached to the securable. */
   properties?: Record<string, string>;
-  /** Storage root URL for managed tables within catalog. */
-  storageRoot?: string;
-  /** The name of delta sharing provider.
-   * 
-   *  A Delta Sharing catalog is a catalog that is based on a Delta share on a remote sharing server. */
-  providerName?: string;
-  /** The name of the share under the share provider. */
-  shareName?: string;
 }
 
-export interface GetCatalogOptions {
-  /** Whether to include catalogs in the response for which the principal can only access selective metadata for */
-  includeBrowse?: boolean;
-}
-
-export interface UpdateCatalogOptions {
-  /** Username of new owner of catalog. */
-  owner?: string;
+export interface UpdateSchemaOptions {
   /** User-provided free-form text description. */
   comment?: string;
   /** A map of key-value properties attached to the securable.
@@ -142,43 +224,13 @@ export interface UpdateCatalogOptions {
    *  When provided in update request, the specified properties will override the existing properties.
    *  To add and remove properties, one would need to perform a read-modify-write. */
   properties?: Record<string, string>;
-  /** Name of catalog. */
+  /** Name of schema. */
   newName?: string;
 }
 
-export interface DeleteCatalogOptions {
-  /** Force deletion even if the catalog is not empty. */
+export interface DeleteSchemaOptions {
+  /** Force deletion even if the schema is not empty. */
   force?: boolean;
-}
-
-export interface ListVolumesOptions {
-  /** The maximum number of results per page that should be returned. */
-  maxResults?: number;
-  /** Opaque pagination token to go to next page based on previous query. */
-  pageToken?: string;
-  /** Whether to include schemas in the response for which the principal can only access selective metadata for */
-  includeBrowse?: boolean;
-}
-
-export interface CreateVolumeOptions {
-  /** The storage location on the cloud */
-  storageLocation?: string;
-  /** The storage location on the cloud */
-  comment?: string;
-}
-
-export interface GetVolumeOptions {
-  /** Whether to include schemas in the response for which the principal can only access selective metadata for */
-  includeBrowse?: boolean;
-}
-
-export interface UpdateVolumeOptions {
-  /** New name for the volume. */
-  newName?: string;
-  /** The comment attached to the volume */
-  comment?: string;
-  /** The identifier of the user who owns the volume */
-  owner?: string;
 }
 
 export interface GenerateTemporaryPathCredentialsOptions {
@@ -235,38 +287,118 @@ export interface GetTableOptions {
   includeManifestCapabilities?: boolean;
 }
 
-export interface ListCredentialsOptions {
-  /** Return only credentials for the specified purpose. */
-  purpose?: number;
+export interface ListCatalogsOptions {
   /** The maximum number of results per page that should be returned. */
   maxResults?: number;
   /** Opaque pagination token to go to next page based on previous query. */
   pageToken?: string;
 }
 
-export interface CreateCredentialOptions {
-  /** Comment associated with the credential. */
+export interface CreateCatalogOptions {
+  /** User-provided free-form text description. */
   comment?: string;
-  /** Whether the credential is usable only for read operations. Only applicable when purpose is STORAGE. */
-  readOnly?: boolean;
-  /** Supplying true to this argument skips validation of the created set of credentials. */
-  skipValidation?: boolean;
+  /** A map of key-value properties attached to the securable. */
+  properties?: Record<string, string>;
+  /** Storage root URL for managed tables within catalog. */
+  storageRoot?: string;
+  /** The name of delta sharing provider.
+   * 
+   *  A Delta Sharing catalog is a catalog that is based on a Delta share on a remote sharing server. */
+  providerName?: string;
+  /** The name of the share under the share provider. */
+  shareName?: string;
 }
 
-export interface UpdateCredentialOptions {
-  /** Name of credential. */
-  newName?: string;
-  /** Comment associated with the credential. */
-  comment?: string;
-  /** Whether the credential is usable only for read operations. Only applicable when purpose is STORAGE. */
-  readOnly?: boolean;
-  /** Username of current owner of credential. */
+export interface GetCatalogOptions {
+  /** Whether to include catalogs in the response for which the principal can only access selective metadata for */
+  includeBrowse?: boolean;
+}
+
+export interface UpdateCatalogOptions {
+  /** Username of new owner of catalog. */
   owner?: string;
-  /** Supply true to this argument to skip validation of the updated credential. */
-  skipValidation?: boolean;
-  /** Force an update even if there are dependent services (when purpose is SERVICE)
-   *  or dependent external locations and external tables (when purpose is STORAGE). */
+  /** User-provided free-form text description. */
+  comment?: string;
+  /** A map of key-value properties attached to the securable.
+   * 
+   *  When provided in update request, the specified properties will override the existing properties.
+   *  To add and remove properties, one would need to perform a read-modify-write. */
+  properties?: Record<string, string>;
+  /** Name of catalog. */
+  newName?: string;
+}
+
+export interface DeleteCatalogOptions {
+  /** Force deletion even if the catalog is not empty. */
   force?: boolean;
+}
+
+export interface ListSharesOptions {
+  /** The maximum number of results per page that should be returned. */
+  maxResults?: number;
+  /** Opaque pagination token to go to next page based on previous query. */
+  pageToken?: string;
+}
+
+export interface CreateShareOptions {
+  /** User-provided free-form text description. */
+  comment?: string;
+}
+
+export interface GetShareOptions {
+  /** Query for data to include in the share. */
+  includeSharedData?: boolean;
+}
+
+export interface UpdateShareOptions {
+  /** A new name for the share. */
+  newName?: string;
+  /** Owner of the share. */
+  owner?: string;
+  /** User-provided free-form text description. */
+  comment?: string;
+}
+
+export interface GetPermissionsOptions {
+  /** The maximum number of results per page that should be returned. */
+  maxResults?: number;
+  /** Opaque pagination token to go to next page based on previous query. */
+  pageToken?: string;
+}
+
+export interface UpdatePermissionsOptions {
+  /** Whether to return the latest permissions list of the share in the response. */
+  omitPermissionsList?: boolean;
+}
+
+export interface ListVolumesOptions {
+  /** The maximum number of results per page that should be returned. */
+  maxResults?: number;
+  /** Opaque pagination token to go to next page based on previous query. */
+  pageToken?: string;
+  /** Whether to include schemas in the response for which the principal can only access selective metadata for */
+  includeBrowse?: boolean;
+}
+
+export interface CreateVolumeOptions {
+  /** The storage location on the cloud */
+  storageLocation?: string;
+  /** The storage location on the cloud */
+  comment?: string;
+}
+
+export interface GetVolumeOptions {
+  /** Whether to include schemas in the response for which the principal can only access selective metadata for */
+  includeBrowse?: boolean;
+}
+
+export interface UpdateVolumeOptions {
+  /** New name for the volume. */
+  newName?: string;
+  /** The comment attached to the volume */
+  comment?: string;
+  /** The identifier of the user who owns the volume */
+  owner?: string;
 }
 
 export interface ListExternalLocationsOptions {
@@ -311,39 +443,6 @@ export interface DeleteExternalLocationOptions {
   force?: boolean;
 }
 
-export interface ListSchemasOptions {
-  /** The maximum number of results per page that should be returned. */
-  maxResults?: number;
-  /** Opaque pagination token to go to next page based on previous query. */
-  pageToken?: string;
-  /** Whether to include schemas in the response for which the principal can only access selective metadata for */
-  includeBrowse?: boolean;
-}
-
-export interface CreateSchemaOptions {
-  /** User-provided free-form text description. */
-  comment?: string;
-  /** A map of key-value properties attached to the securable. */
-  properties?: Record<string, string>;
-}
-
-export interface UpdateSchemaOptions {
-  /** User-provided free-form text description. */
-  comment?: string;
-  /** A map of key-value properties attached to the securable.
-   * 
-   *  When provided in update request, the specified properties will override the existing properties.
-   *  To add and remove properties, one would need to perform a read-modify-write. */
-  properties?: Record<string, string>;
-  /** Name of schema. */
-  newName?: string;
-}
-
-export interface DeleteSchemaOptions {
-  /** Force deletion even if the schema is not empty. */
-  force?: boolean;
-}
-
 export class RecipientClient {
   private readonly inner: NativeRecipientClient;
 
@@ -356,7 +455,9 @@ export class RecipientClient {
      * Get a recipient by name.
      */
   async get(): Promise<Recipient> {
-    return fromBinary(RecipientSchema, await this.inner.get());
+    try {
+      return fromBinary(RecipientSchema, await this.inner.get());
+    } catch (e) { parseNativeError(e); }
   }
 
   /**
@@ -364,47 +465,121 @@ export class RecipientClient {
      */
   async update(options?: UpdateRecipientOptions): Promise<Recipient> {
     const { newName, owner, comment, properties, expirationTime } = options || {};
-    return fromBinary(RecipientSchema, await this.inner.update(newName, owner, comment, properties, expirationTime));
+    try {
+      return fromBinary(RecipientSchema, await this.inner.update(newName, owner, comment, properties, expirationTime));
+    } catch (e) { parseNativeError(e); }
   }
 
   /**
      * Delete a recipient.
      */
   async delete(): Promise<void> {
-    await this.inner.delete();
+    try {
+      await this.inner.delete();
+    } catch (e) { parseNativeError(e); }
   }
 
 }
 
-export class ShareClient {
-  private readonly inner: NativeShareClient;
+export class CredentialClient {
+  private readonly inner: NativeCredentialClient;
 
   /** @internal */
-  constructor(inner: NativeShareClient) {
+  constructor(inner: NativeCredentialClient) {
+    this.inner = inner;
+  }
+
+  async get(): Promise<Credential> {
+    try {
+      return fromBinary(CredentialSchema, await this.inner.get());
+    } catch (e) { parseNativeError(e); }
+  }
+
+  async update(options?: UpdateCredentialOptions): Promise<Credential> {
+    const { newName, comment, readOnly, owner, skipValidation, force } = options || {};
+    try {
+      return fromBinary(CredentialSchema, await this.inner.update(newName, comment, readOnly, owner, skipValidation, force));
+    } catch (e) { parseNativeError(e); }
+  }
+
+  async delete(): Promise<void> {
+    try {
+      await this.inner.delete();
+    } catch (e) { parseNativeError(e); }
+  }
+
+}
+
+export class SchemaClient {
+  private readonly inner: NativeSchemaClient;
+
+  /** @internal */
+  constructor(inner: NativeSchemaClient) {
     this.inner = inner;
   }
 
   /**
-     * Get a share by name.
+     * Gets the specified schema within the metastore.
+     * The caller must be a metastore admin, the owner of the schema,
+     * or a user that has the USE_SCHEMA privilege on the schema.
      */
-  async get(options?: GetShareOptions): Promise<Share> {
-    const { includeSharedData } = options || {};
-    return fromBinary(ShareSchema, await this.inner.get(includeSharedData));
+  async get(): Promise<Schema> {
+    try {
+      return fromBinary(SchemaSchema, await this.inner.get());
+    } catch (e) { parseNativeError(e); }
   }
 
   /**
-     * Update a share.
+     * Updates a schema for a catalog. The caller must be the owner of the schema or a metastore admin.
+     * If the caller is a metastore admin, only the owner field can be changed in the update.
+     * If the name field must be updated, the caller must be a metastore admin or have the CREATE_SCHEMA
+     * privilege on the parent catalog.
      */
-  async update(options?: UpdateShareOptions): Promise<Share> {
-    const { newName, owner, comment } = options || {};
-    return fromBinary(ShareSchema, await this.inner.update(newName, owner, comment));
+  async update(options?: UpdateSchemaOptions): Promise<Schema> {
+    const { comment, properties, newName } = options || {};
+    try {
+      return fromBinary(SchemaSchema, await this.inner.update(comment, properties, newName));
+    } catch (e) { parseNativeError(e); }
   }
 
   /**
-     * Deletes a share.
+     * Deletes the specified schema from the parent catalog. The caller must be the owner
+     * of the schema or an owner of the parent catalog.
+     */
+  async delete(options?: DeleteSchemaOptions): Promise<void> {
+    const { force } = options || {};
+    try {
+      await this.inner.delete(force);
+    } catch (e) { parseNativeError(e); }
+  }
+
+}
+
+export class TableClient {
+  private readonly inner: NativeTableClient;
+
+  /** @internal */
+  constructor(inner: NativeTableClient) {
+    this.inner = inner;
+  }
+
+  /**
+     * Get a table
+     */
+  async get(options?: GetTableOptions): Promise<Table> {
+    const { includeDeltaMetadata, includeBrowse, includeManifestCapabilities } = options || {};
+    try {
+      return fromBinary(TableSchema, await this.inner.get(includeDeltaMetadata, includeBrowse, includeManifestCapabilities));
+    } catch (e) { parseNativeError(e); }
+  }
+
+  /**
+     * Delete a table
      */
   async delete(): Promise<void> {
-    await this.inner.delete();
+    try {
+      await this.inner.delete();
+    } catch (e) { parseNativeError(e); }
   }
 
 }
@@ -425,7 +600,9 @@ export class CatalogClient {
      */
   async get(options?: GetCatalogOptions): Promise<Catalog> {
     const { includeBrowse } = options || {};
-    return fromBinary(CatalogSchema, await this.inner.get(includeBrowse));
+    try {
+      return fromBinary(CatalogSchema, await this.inner.get(includeBrowse));
+    } catch (e) { parseNativeError(e); }
   }
 
   /**
@@ -436,7 +613,9 @@ export class CatalogClient {
      */
   async update(options?: UpdateCatalogOptions): Promise<Catalog> {
     const { owner, comment, properties, newName } = options || {};
-    return fromBinary(CatalogSchema, await this.inner.update(owner, comment, properties, newName));
+    try {
+      return fromBinary(CatalogSchema, await this.inner.update(owner, comment, properties, newName));
+    } catch (e) { parseNativeError(e); }
   }
 
   /**
@@ -447,7 +626,48 @@ export class CatalogClient {
      */
   async delete(options?: DeleteCatalogOptions): Promise<void> {
     const { force } = options || {};
-    await this.inner.delete(force);
+    try {
+      await this.inner.delete(force);
+    } catch (e) { parseNativeError(e); }
+  }
+
+}
+
+export class ShareClient {
+  private readonly inner: NativeShareClient;
+
+  /** @internal */
+  constructor(inner: NativeShareClient) {
+    this.inner = inner;
+  }
+
+  /**
+     * Get a share by name.
+     */
+  async get(options?: GetShareOptions): Promise<Share> {
+    const { includeSharedData } = options || {};
+    try {
+      return fromBinary(ShareSchema, await this.inner.get(includeSharedData));
+    } catch (e) { parseNativeError(e); }
+  }
+
+  /**
+     * Update a share.
+     */
+  async update(options?: UpdateShareOptions): Promise<Share> {
+    const { newName, owner, comment } = options || {};
+    try {
+      return fromBinary(ShareSchema, await this.inner.update(newName, owner, comment));
+    } catch (e) { parseNativeError(e); }
+  }
+
+  /**
+     * Deletes a share.
+     */
+  async delete(): Promise<void> {
+    try {
+      await this.inner.delete();
+    } catch (e) { parseNativeError(e); }
   }
 
 }
@@ -462,64 +682,22 @@ export class VolumeClient {
 
   async get(options?: GetVolumeOptions): Promise<Volume> {
     const { includeBrowse } = options || {};
-    return fromBinary(VolumeSchema, await this.inner.get(includeBrowse));
+    try {
+      return fromBinary(VolumeSchema, await this.inner.get(includeBrowse));
+    } catch (e) { parseNativeError(e); }
   }
 
   async update(options?: UpdateVolumeOptions): Promise<Volume> {
     const { newName, comment, owner } = options || {};
-    return fromBinary(VolumeSchema, await this.inner.update(newName, comment, owner));
+    try {
+      return fromBinary(VolumeSchema, await this.inner.update(newName, comment, owner));
+    } catch (e) { parseNativeError(e); }
   }
 
   async delete(): Promise<void> {
-    await this.inner.delete();
-  }
-
-}
-
-export class TableClient {
-  private readonly inner: NativeTableClient;
-
-  /** @internal */
-  constructor(inner: NativeTableClient) {
-    this.inner = inner;
-  }
-
-  /**
-     * Get a table
-     */
-  async get(options?: GetTableOptions): Promise<Table> {
-    const { includeDeltaMetadata, includeBrowse, includeManifestCapabilities } = options || {};
-    return fromBinary(TableSchema, await this.inner.get(includeDeltaMetadata, includeBrowse, includeManifestCapabilities));
-  }
-
-  /**
-     * Delete a table
-     */
-  async delete(): Promise<void> {
-    await this.inner.delete();
-  }
-
-}
-
-export class CredentialClient {
-  private readonly inner: NativeCredentialClient;
-
-  /** @internal */
-  constructor(inner: NativeCredentialClient) {
-    this.inner = inner;
-  }
-
-  async get(): Promise<Credential> {
-    return fromBinary(CredentialSchema, await this.inner.get());
-  }
-
-  async update(options?: UpdateCredentialOptions): Promise<Credential> {
-    const { newName, comment, readOnly, owner, skipValidation, force } = options || {};
-    return fromBinary(CredentialSchema, await this.inner.update(newName, comment, readOnly, owner, skipValidation, force));
-  }
-
-  async delete(): Promise<void> {
-    await this.inner.delete();
+    try {
+      await this.inner.delete();
+    } catch (e) { parseNativeError(e); }
   }
 
 }
@@ -536,7 +714,9 @@ export class ExternalLocationClient {
      * Get an external location
      */
   async get(): Promise<ExternalLocation> {
-    return fromBinary(ExternalLocationSchema, await this.inner.get());
+    try {
+      return fromBinary(ExternalLocationSchema, await this.inner.get());
+    } catch (e) { parseNativeError(e); }
   }
 
   /**
@@ -544,7 +724,9 @@ export class ExternalLocationClient {
      */
   async update(options?: UpdateExternalLocationOptions): Promise<ExternalLocation> {
     const { url, credentialName, readOnly, owner, comment, newName, force, skipValidation } = options || {};
-    return fromBinary(ExternalLocationSchema, await this.inner.update(url, credentialName, readOnly, owner, comment, newName, force, skipValidation));
+    try {
+      return fromBinary(ExternalLocationSchema, await this.inner.update(url, credentialName, readOnly, owner, comment, newName, force, skipValidation));
+    } catch (e) { parseNativeError(e); }
   }
 
   /**
@@ -552,46 +734,9 @@ export class ExternalLocationClient {
      */
   async delete(options?: DeleteExternalLocationOptions): Promise<void> {
     const { force } = options || {};
-    await this.inner.delete(force);
-  }
-
-}
-
-export class SchemaClient {
-  private readonly inner: NativeSchemaClient;
-
-  /** @internal */
-  constructor(inner: NativeSchemaClient) {
-    this.inner = inner;
-  }
-
-  /**
-     * Gets the specified schema within the metastore.
-     * The caller must be a metastore admin, the owner of the schema,
-     * or a user that has the USE_SCHEMA privilege on the schema.
-     */
-  async get(): Promise<Schema> {
-    return fromBinary(SchemaSchema, await this.inner.get());
-  }
-
-  /**
-     * Updates a schema for a catalog. The caller must be the owner of the schema or a metastore admin.
-     * If the caller is a metastore admin, only the owner field can be changed in the update.
-     * If the name field must be updated, the caller must be a metastore admin or have the CREATE_SCHEMA
-     * privilege on the parent catalog.
-     */
-  async update(options?: UpdateSchemaOptions): Promise<Schema> {
-    const { comment, properties, newName } = options || {};
-    return fromBinary(SchemaSchema, await this.inner.update(comment, properties, newName));
-  }
-
-  /**
-     * Deletes the specified schema from the parent catalog. The caller must be the owner
-     * of the schema or an owner of the parent catalog.
-     */
-  async delete(options?: DeleteSchemaOptions): Promise<void> {
-    const { force } = options || {};
-    await this.inner.delete(force);
+    try {
+      await this.inner.delete(force);
+    } catch (e) { parseNativeError(e); }
   }
 
 }
@@ -613,9 +758,11 @@ export class UnityCatalogClient {
      */
   async listCatalogs(options?: ListCatalogsOptions): Promise<Catalog[]> {
     const { maxResults } = options || {};
-    return (await this.inner.listCatalogs(maxResults)).map((data) =>
-      fromBinary(CatalogSchema, data),
-    );
+    try {
+      return (await this.inner.listCatalogs(maxResults)).map((data) =>
+        fromBinary(CatalogSchema, data),
+      );
+    } catch (e) { parseNativeError(e); }
   }
 
   /**
@@ -626,7 +773,9 @@ export class UnityCatalogClient {
      */
   async createCatalog(name: string, options?: CreateCatalogOptions): Promise<Catalog> {
     const { comment, properties, storageRoot, providerName, shareName } = options || {};
-    return fromBinary(CatalogSchema, await this.inner.createCatalog(name, comment, properties, storageRoot, providerName, shareName));
+    try {
+      return fromBinary(CatalogSchema, await this.inner.createCatalog(name, comment, properties, storageRoot, providerName, shareName));
+    } catch (e) { parseNativeError(e); }
   }
 
   catalog(name: string): CatalogClient {
@@ -635,14 +784,18 @@ export class UnityCatalogClient {
 
   async listCredentials(options?: ListCredentialsOptions): Promise<Credential[]> {
     const { purpose, maxResults } = options || {};
-    return (await this.inner.listCredentials(purpose, maxResults)).map((data) =>
-      fromBinary(CredentialSchema, data),
-    );
+    try {
+      return (await this.inner.listCredentials(purpose, maxResults)).map((data) =>
+        fromBinary(CredentialSchema, data),
+      );
+    } catch (e) { parseNativeError(e); }
   }
 
   async createCredential(name: string, purpose: number, options?: CreateCredentialOptions): Promise<Credential> {
     const { comment, readOnly, skipValidation } = options || {};
-    return fromBinary(CredentialSchema, await this.inner.createCredential(name, purpose, comment, readOnly, skipValidation));
+    try {
+      return fromBinary(CredentialSchema, await this.inner.createCredential(name, purpose, comment, readOnly, skipValidation));
+    } catch (e) { parseNativeError(e); }
   }
 
   credential(name: string): CredentialClient {
@@ -654,9 +807,11 @@ export class UnityCatalogClient {
      */
   async listExternalLocations(options?: ListExternalLocationsOptions): Promise<ExternalLocation[]> {
     const { maxResults, includeBrowse } = options || {};
-    return (await this.inner.listExternalLocations(maxResults, includeBrowse)).map((data) =>
-      fromBinary(ExternalLocationSchema, data),
-    );
+    try {
+      return (await this.inner.listExternalLocations(maxResults, includeBrowse)).map((data) =>
+        fromBinary(ExternalLocationSchema, data),
+      );
+    } catch (e) { parseNativeError(e); }
   }
 
   /**
@@ -664,7 +819,9 @@ export class UnityCatalogClient {
      */
   async createExternalLocation(name: string, url: string, credentialName: string, options?: CreateExternalLocationOptions): Promise<ExternalLocation> {
     const { readOnly, comment, skipValidation } = options || {};
-    return fromBinary(ExternalLocationSchema, await this.inner.createExternalLocation(name, url, credentialName, readOnly, comment, skipValidation));
+    try {
+      return fromBinary(ExternalLocationSchema, await this.inner.createExternalLocation(name, url, credentialName, readOnly, comment, skipValidation));
+    } catch (e) { parseNativeError(e); }
   }
 
   externalLocation(name: string): ExternalLocationClient {
@@ -676,9 +833,11 @@ export class UnityCatalogClient {
      */
   async listRecipients(options?: ListRecipientsOptions): Promise<Recipient[]> {
     const { maxResults } = options || {};
-    return (await this.inner.listRecipients(maxResults)).map((data) =>
-      fromBinary(RecipientSchema, data),
-    );
+    try {
+      return (await this.inner.listRecipients(maxResults)).map((data) =>
+        fromBinary(RecipientSchema, data),
+      );
+    } catch (e) { parseNativeError(e); }
   }
 
   /**
@@ -686,7 +845,9 @@ export class UnityCatalogClient {
      */
   async createRecipient(name: string, authenticationType: number, owner: string, options?: CreateRecipientOptions): Promise<Recipient> {
     const { comment, properties, expirationTime } = options || {};
-    return fromBinary(RecipientSchema, await this.inner.createRecipient(name, authenticationType, owner, comment, properties, expirationTime));
+    try {
+      return fromBinary(RecipientSchema, await this.inner.createRecipient(name, authenticationType, owner, comment, properties, expirationTime));
+    } catch (e) { parseNativeError(e); }
   }
 
   recipient(name: string): RecipientClient {
@@ -701,9 +862,11 @@ export class UnityCatalogClient {
      */
   async listSchemas(catalogName: string, options?: ListSchemasOptions): Promise<Schema[]> {
     const { maxResults, includeBrowse } = options || {};
-    return (await this.inner.listSchemas(catalogName, maxResults, includeBrowse)).map((data) =>
-      fromBinary(SchemaSchema, data),
-    );
+    try {
+      return (await this.inner.listSchemas(catalogName, maxResults, includeBrowse)).map((data) =>
+        fromBinary(SchemaSchema, data),
+      );
+    } catch (e) { parseNativeError(e); }
   }
 
   /**
@@ -712,7 +875,9 @@ export class UnityCatalogClient {
      */
   async createSchema(name: string, catalogName: string, options?: CreateSchemaOptions): Promise<Schema> {
     const { comment, properties } = options || {};
-    return fromBinary(SchemaSchema, await this.inner.createSchema(name, catalogName, comment, properties));
+    try {
+      return fromBinary(SchemaSchema, await this.inner.createSchema(name, catalogName, comment, properties));
+    } catch (e) { parseNativeError(e); }
   }
 
   schema(catalogName: string, schemaName: string): SchemaClient {
@@ -724,9 +889,11 @@ export class UnityCatalogClient {
      */
   async listShares(options?: ListSharesOptions): Promise<Share[]> {
     const { maxResults } = options || {};
-    return (await this.inner.listShares(maxResults)).map((data) =>
-      fromBinary(ShareSchema, data),
-    );
+    try {
+      return (await this.inner.listShares(maxResults)).map((data) =>
+        fromBinary(ShareSchema, data),
+      );
+    } catch (e) { parseNativeError(e); }
   }
 
   /**
@@ -734,7 +901,9 @@ export class UnityCatalogClient {
      */
   async createShare(name: string, options?: CreateShareOptions): Promise<Share> {
     const { comment } = options || {};
-    return fromBinary(ShareSchema, await this.inner.createShare(name, comment));
+    try {
+      return fromBinary(ShareSchema, await this.inner.createShare(name, comment));
+    } catch (e) { parseNativeError(e); }
   }
 
   share(name: string): ShareClient {
@@ -751,9 +920,11 @@ export class UnityCatalogClient {
      */
   async listTables(catalogName: string, schemaName: string, options?: ListTablesOptions): Promise<Table[]> {
     const { maxResults, includeDeltaMetadata, omitColumns, omitProperties, omitUsername, includeBrowse, includeManifestCapabilities } = options || {};
-    return (await this.inner.listTables(catalogName, schemaName, maxResults, includeDeltaMetadata, omitColumns, omitProperties, omitUsername, includeBrowse, includeManifestCapabilities)).map((data) =>
-      fromBinary(TableSchema, data),
-    );
+    try {
+      return (await this.inner.listTables(catalogName, schemaName, maxResults, includeDeltaMetadata, omitColumns, omitProperties, omitUsername, includeBrowse, includeManifestCapabilities)).map((data) =>
+        fromBinary(TableSchema, data),
+      );
+    } catch (e) { parseNativeError(e); }
   }
 
   /**
@@ -761,7 +932,9 @@ export class UnityCatalogClient {
      */
   async createTable(name: string, schemaName: string, catalogName: string, tableType: number, dataSourceFormat: number, options?: CreateTableOptions): Promise<Table> {
     const { storageLocation, comment, properties } = options || {};
-    return fromBinary(TableSchema, await this.inner.createTable(name, schemaName, catalogName, tableType, dataSourceFormat, storageLocation, comment, properties));
+    try {
+      return fromBinary(TableSchema, await this.inner.createTable(name, schemaName, catalogName, tableType, dataSourceFormat, storageLocation, comment, properties));
+    } catch (e) { parseNativeError(e); }
   }
 
   table(name: string): TableClient {
@@ -773,14 +946,18 @@ export class UnityCatalogClient {
      */
   async listVolumes(catalogName: string, schemaName: string, options?: ListVolumesOptions): Promise<Volume[]> {
     const { maxResults, includeBrowse } = options || {};
-    return (await this.inner.listVolumes(catalogName, schemaName, maxResults, includeBrowse)).map((data) =>
-      fromBinary(VolumeSchema, data),
-    );
+    try {
+      return (await this.inner.listVolumes(catalogName, schemaName, maxResults, includeBrowse)).map((data) =>
+        fromBinary(VolumeSchema, data),
+      );
+    } catch (e) { parseNativeError(e); }
   }
 
   async createVolume(catalogName: string, schemaName: string, name: string, volumeType: number, options?: CreateVolumeOptions): Promise<Volume> {
     const { storageLocation, comment } = options || {};
-    return fromBinary(VolumeSchema, await this.inner.createVolume(catalogName, schemaName, name, volumeType, storageLocation, comment));
+    try {
+      return fromBinary(VolumeSchema, await this.inner.createVolume(catalogName, schemaName, name, volumeType, storageLocation, comment));
+    } catch (e) { parseNativeError(e); }
   }
 
   volume(catalogName: string, schemaName: string, volumeName: string): VolumeClient {

--- a/python/client/src/error.rs
+++ b/python/client/src/error.rs
@@ -2,6 +2,7 @@ use pyo3::create_exception;
 use pyo3::exceptions::{PyIOError, PyValueError};
 use pyo3::prelude::*;
 use thiserror::Error;
+use unitycatalog_client::error::UcApiError;
 use unitycatalog_common::error::Error as UCError;
 
 /// A type wrapper around `Result<T, PyUnityCatalogError>`.
@@ -21,6 +22,62 @@ create_exception!(
     GenericError,
     UnityCatalogError,
     "A Python-facing exception wrapping [unitycatalog_common::Error::Generic]."
+);
+
+create_exception!(
+    unitycatalog_client,
+    NotFoundError,
+    UnityCatalogError,
+    "Raised when a requested resource does not exist (RESOURCE_NOT_FOUND)."
+);
+
+create_exception!(
+    unitycatalog_client,
+    AlreadyExistsError,
+    UnityCatalogError,
+    "Raised when a resource already exists (RESOURCE_ALREADY_EXISTS)."
+);
+
+create_exception!(
+    unitycatalog_client,
+    PermissionDeniedError,
+    UnityCatalogError,
+    "Raised when the caller lacks permission (PERMISSION_DENIED)."
+);
+
+create_exception!(
+    unitycatalog_client,
+    UnauthenticatedError,
+    UnityCatalogError,
+    "Raised when the request is not authenticated (UNAUTHENTICATED)."
+);
+
+create_exception!(
+    unitycatalog_client,
+    InvalidParameterError,
+    UnityCatalogError,
+    "Raised when a request parameter is invalid (INVALID_PARAMETER_VALUE)."
+);
+
+create_exception!(
+    unitycatalog_client,
+    RequestLimitError,
+    UnityCatalogError,
+    "Raised when the request rate limit is exceeded (REQUEST_LIMIT_EXCEEDED)."
+);
+
+create_exception!(
+    unitycatalog_client,
+    InternalServerError,
+    UnityCatalogError,
+    "Raised when the server encounters an internal error (INTERNAL_ERROR)."
+);
+
+create_exception!(
+    unitycatalog_client,
+    ServiceUnavailableError,
+    UnityCatalogError,
+    "Raised when the service is temporarily unavailable (TEMPORARILY_UNAVAILABLE)."
 );
 
 /// The Error variants returned by this crate.
@@ -56,9 +113,35 @@ impl From<PyUnityCatalogError> for PyErr {
                 UCError::Generic(_) => GenericError::new_err(print_with_debug(err)),
                 _ => GenericError::new_err(print_with_debug(err)),
             },
-            PyUnityCatalogError::UnityCatalogClientError(ref err) => {
-                GenericError::new_err(print_with_debug_client(err))
-            }
+            PyUnityCatalogError::UnityCatalogClientError(ref err) => match err {
+                unitycatalog_client::Error::Api(api_err) => match api_err {
+                    UcApiError::NotFound { .. } => NotFoundError::new_err(api_err.to_string()),
+                    UcApiError::AlreadyExists { .. } => {
+                        AlreadyExistsError::new_err(api_err.to_string())
+                    }
+                    UcApiError::PermissionDenied { .. } => {
+                        PermissionDeniedError::new_err(api_err.to_string())
+                    }
+                    UcApiError::Unauthenticated { .. } => {
+                        UnauthenticatedError::new_err(api_err.to_string())
+                    }
+                    UcApiError::InvalidParameter { .. } => {
+                        InvalidParameterError::new_err(api_err.to_string())
+                    }
+                    UcApiError::RequestLimitExceeded { .. } => {
+                        RequestLimitError::new_err(api_err.to_string())
+                    }
+                    UcApiError::InternalError { .. } => {
+                        InternalServerError::new_err(api_err.to_string())
+                    }
+                    UcApiError::TemporarilyUnavailable { .. } => {
+                        ServiceUnavailableError::new_err(api_err.to_string())
+                    }
+                    UcApiError::Other { .. } => GenericError::new_err(api_err.to_string()),
+                    _ => GenericError::new_err(api_err.to_string()),
+                },
+                _ => GenericError::new_err(print_with_debug_client(err)),
+            },
             PyUnityCatalogError::IOError(err) => PyIOError::new_err(err),
             PyUnityCatalogError::InvalidUrl(err) => PyValueError::new_err(err.to_string()),
         }
@@ -75,4 +158,37 @@ fn print_with_debug_client(err: &unitycatalog_client::Error) -> String {
     // #? gives "pretty-printing" for debug
     // https://doc.rust-lang.org/std/fmt/trait.Debug.html
     format!("{err}\n\nDebug source:\n{err:#?}")
+}
+
+/// Register all exception types with the given PyO3 module.
+pub(crate) fn register_exceptions(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("UnityCatalogError", m.py().get_type::<UnityCatalogError>())?;
+    m.add("GenericError", m.py().get_type::<GenericError>())?;
+    m.add("NotFoundError", m.py().get_type::<NotFoundError>())?;
+    m.add(
+        "AlreadyExistsError",
+        m.py().get_type::<AlreadyExistsError>(),
+    )?;
+    m.add(
+        "PermissionDeniedError",
+        m.py().get_type::<PermissionDeniedError>(),
+    )?;
+    m.add(
+        "UnauthenticatedError",
+        m.py().get_type::<UnauthenticatedError>(),
+    )?;
+    m.add(
+        "InvalidParameterError",
+        m.py().get_type::<InvalidParameterError>(),
+    )?;
+    m.add("RequestLimitError", m.py().get_type::<RequestLimitError>())?;
+    m.add(
+        "InternalServerError",
+        m.py().get_type::<InternalServerError>(),
+    )?;
+    m.add(
+        "ServiceUnavailableError",
+        m.py().get_type::<ServiceUnavailableError>(),
+    )?;
+    Ok(())
 }

--- a/python/client/src/lib.rs
+++ b/python/client/src/lib.rs
@@ -26,6 +26,9 @@ mod runtime;
 /// A Python module implemented in Rust.
 #[pymodule]
 fn unitycatalog_client(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // exception types
+    error::register_exceptions(m)?;
+
     // objects and enums
     m.add_class::<Catalog>()?;
     m.add_class::<CatalogType>()?;


### PR DESCRIPTION
## Summary

- Adds `UcApiError` enum to `crates/client` with typed variants for every UC API error code (`RESOURCE_NOT_FOUND`, `RESOURCE_ALREADY_EXISTS`, `PERMISSION_DENIED`, `UNAUTHENTICATED`, `INVALID_PARAMETER_VALUE`, `REQUEST_LIMIT_EXCEEDED`, `INTERNAL_ERROR`, `TEMPORARILY_UNAVAILABLE`) plus an `Other` fallback
- Replaces `error_for_status*` in the HTTP code generator with `parse_error_response`, which reads the response body and maps the JSON `error_code` field to the correct typed variant — all 9 generated client files updated
- Removes `reqwest` from `crates/common` (shared-types crate no longer needs a network dep); adds TODO for follow-up #65
- Extends Python bindings with a full typed exception hierarchy (`NotFoundError`, `AlreadyExistsError`, etc.) all subclassing `UnityCatalogError`, registered in the PyO3 module
- Node.js layer emits a `UC:CODE:message` prefix for API errors; generated TypeScript client exports `UnityCatalogError` subclasses and a `parseNativeError()` helper; all async methods wrapped in `try/catch`

Closes #16. Follow-up issues: #65, #66.

## Test plan

- [x] `cargo test --workspace --lib` — all 100+ unit tests pass (including 4 new error parsing tests)
- [x] `just integration` — integration journeys pass with recorded responses
- [x] `cargo clippy --workspace` — no errors
- [x] `just generate-code` — regenerated files match expected output

This pull request was AI-assisted by Isaac.