### PR TITLE
feat: add background task queue framework (unitycatalog-tasks)

### DIFF
--- a/crates/postgres/Cargo.toml
+++ b/crates/postgres/Cargo.toml
@@ -13,6 +13,7 @@ rust-version.workspace = true
 # path dependencies (in alphabetical order)
 unitycatalog-common = { path = "../common", default-features = false }
 unitycatalog-server = { path = "../server", default-features = false }
+unitycatalog-tasks = { path = "../tasks" }
 
 # workspace dependencies (in alphabetical order)
 async-trait = { workspace = true }

--- a/crates/postgres/migrations/06_tasks.down.sql
+++ b/crates/postgres/migrations/06_tasks.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS task_log;
+DROP TABLE IF EXISTS task_config;
+DROP TABLE IF EXISTS task;
+DROP TYPE IF EXISTS task_final_status;
+DROP TYPE IF EXISTS task_intermediate_status;

--- a/crates/postgres/migrations/06_tasks.up.sql
+++ b/crates/postgres/migrations/06_tasks.up.sql
@@ -1,0 +1,104 @@
+-- Background task queue tables, ported from lakekeeper/lakekeeper, Apache-2.0.
+-- Adapted (collapsed) from the lakekeeper migrations:
+--   * 20250523101407_tasks_store_their_state.sql
+--   * 20250826171037_task_runtime_information.sql
+--   * 20251228101923_enable_tasks_on_project_level.sql
+-- Source: https://github.com/lakekeeper/lakekeeper/tree/05cce5797d3321ce30c59e034f19a3861c39cd88/crates/lakekeeper/migrations
+--
+-- Adjustments vs upstream:
+--   * Unity Catalog has no Iceberg `project` or `warehouse` concepts. Those
+--     columns are dropped; tasks are scoped on `(entity_type, entity_id)`.
+--   * `entity_type` is stored as `text` rather than a closed PostgreSQL enum
+--     so the framework stays generic and doesn't need a schema migration
+--     every time a new UC resource kind is added.
+
+CREATE TYPE task_intermediate_status AS ENUM ('scheduled', 'running', 'should-stop');
+CREATE TYPE task_final_status AS ENUM ('failed', 'cancelled', 'success');
+
+-- Active queue. One row per logical task; on pickup `attempt` is incremented.
+CREATE TABLE task (
+    task_id uuid PRIMARY KEY DEFAULT uuidv7(),
+    queue_name text NOT NULL,
+    status task_intermediate_status NOT NULL DEFAULT 'scheduled',
+    parent_task_id uuid,
+    scheduled_for timestamptz NOT NULL DEFAULT now(),
+    picked_up_at timestamptz,
+    last_heartbeat_at timestamptz,
+    attempt integer NOT NULL DEFAULT 0,
+    task_data jsonb NOT NULL,
+    progress real NOT NULL DEFAULT 0.0,
+    execution_details jsonb,
+    -- `entity_type` is free-form text; `entity_id` / `entity_name` are NULL
+    -- for system-level (catalog-wide) tasks.
+    entity_type text,
+    entity_id uuid,
+    entity_name text[],
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz,
+    -- Either both entity_id and entity_name are set (resource-scoped task)
+    -- or both are NULL (system-level task). `entity_type` must be set when
+    -- the task is resource-scoped.
+    CONSTRAINT task_entity_check CHECK (
+        (entity_type IS NULL AND entity_id IS NULL AND entity_name IS NULL)
+        OR (entity_type IS NOT NULL AND entity_id IS NOT NULL AND entity_name IS NOT NULL)
+    )
+);
+
+SELECT trigger_updated_at('task');
+
+-- Deduplication index: one active task per (queue, entity) tuple. NULLS NOT
+-- DISTINCT ensures system-level tasks (NULL entity) for the same queue are
+-- also deduplicated.
+CREATE UNIQUE INDEX task_entity_queue_name_idx
+    ON task (entity_type, entity_id, queue_name)
+    NULLS NOT DISTINCT;
+
+-- Picker query covering index.
+CREATE INDEX task_queue_name_status_scheduled_for_idx
+    ON task (queue_name, status, scheduled_for);
+
+CREATE INDEX task_entity_type_entity_id_created_at_idx
+    ON task (entity_type, entity_id, created_at DESC);
+
+-- Per-queue runtime configuration. Optional `max_time_since_last_heartbeat`
+-- overrides the framework-provided default in `TaskConfig`.
+CREATE TABLE task_config (
+    task_config_id uuid PRIMARY KEY DEFAULT uuidv7(),
+    queue_name text NOT NULL,
+    config jsonb NOT NULL,
+    max_time_since_last_heartbeat interval,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz,
+    UNIQUE (queue_name)
+);
+
+SELECT trigger_updated_at('task_config');
+
+-- Append-only audit log of completed/failed/cancelled task attempts.
+CREATE TABLE task_log (
+    task_id uuid NOT NULL,
+    attempt integer NOT NULL,
+    queue_name text NOT NULL,
+    task_data jsonb NOT NULL,
+    status task_final_status NOT NULL,
+    message text,
+    progress real NOT NULL DEFAULT 0.0,
+    execution_details jsonb,
+    parent_task_id uuid,
+    entity_type text,
+    entity_id uuid,
+    entity_name text[],
+    attempt_scheduled_for timestamptz NOT NULL,
+    last_heartbeat_at timestamptz,
+    started_at timestamptz,
+    duration interval,
+    task_created_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (task_id, attempt)
+);
+
+CREATE INDEX task_log_queue_name_created_at_idx
+    ON task_log (queue_name, created_at DESC);
+
+CREATE INDEX task_log_entity_type_entity_id_task_created_at_idx
+    ON task_log (entity_type, entity_id, task_created_at DESC);

--- a/crates/postgres/src/lib.rs
+++ b/crates/postgres/src/lib.rs
@@ -7,6 +7,7 @@ mod graph;
 mod pagination;
 mod resources;
 mod secrets;
+mod tasks;
 
 #[cfg(all(test, feature = "integration-pg"))]
 mod tests {

--- a/crates/postgres/src/tasks.rs
+++ b/crates/postgres/src/tasks.rs
@@ -1,0 +1,709 @@
+//! Postgres implementation of [`unitycatalog_tasks::TaskStore`].
+//!
+//! The SQL queries below are ported from
+//! [lakekeeper/lakekeeper](https://github.com/lakekeeper/lakekeeper) (Apache-2.0),
+//! specifically
+//! <https://github.com/lakekeeper/lakekeeper/blob/05cce5797d3321ce30c59e034f19a3861c39cd88/crates/lakekeeper/src/implementations/postgres/tasks.rs>.
+//!
+//! Notable adaptations:
+//!   * No `warehouse_id` / `project_id` joins (UC has neither).
+//!   * `entity_type` is stored as `text`, not a closed enum, so the framework
+//!     stays generic.
+//!   * Queries are written with the *dynamic* `sqlx::query` / `sqlx::query_as`
+//!     APIs rather than the compile-time-checked macros so we can ship the
+//!     migration without immediately regenerating the workspace `.sqlx`
+//!     offline cache. Integration tests cover correctness against a real DB.
+
+use async_trait::async_trait;
+use chrono::Duration;
+use sqlx::postgres::types::PgInterval;
+use sqlx::{PgPool, Postgres, Row, Transaction};
+use unitycatalog_tasks::{
+    Result as TaskResult, Task, TaskAttemptId, TaskCheckState, TaskEntity, TaskError, TaskId,
+    TaskInput, TaskIntermediateStatus, TaskMetadata, TaskQueueName, TaskStore,
+};
+use uuid::Uuid;
+
+use crate::GraphStore;
+
+#[async_trait]
+impl TaskStore for GraphStore {
+    async fn pick_new_task(
+        &self,
+        queue_name: &TaskQueueName,
+        default_max_time_since_last_heartbeat: Duration,
+    ) -> TaskResult<Option<Task>> {
+        let interval = duration_to_pg_interval(default_max_time_since_last_heartbeat)?;
+
+        let row = sqlx::query(PICK_TASK_SQL)
+            .bind(queue_name.as_str())
+            .bind(interval)
+            .fetch_optional(&self.pool)
+            .await?;
+
+        let Some(row) = row else {
+            return Ok(None);
+        };
+
+        Ok(Some(row_to_task(&row)?))
+    }
+
+    async fn enqueue_tasks(
+        &self,
+        queue_name: &TaskQueueName,
+        inputs: Vec<TaskInput>,
+        tx: &mut Transaction<'_, Postgres>,
+    ) -> TaskResult<Vec<TaskId>> {
+        if inputs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut task_ids = Vec::with_capacity(inputs.len());
+        let mut parent_task_ids = Vec::with_capacity(inputs.len());
+        let mut scheduled_fors = Vec::with_capacity(inputs.len());
+        let mut payloads = Vec::with_capacity(inputs.len());
+        let mut entity_types: Vec<Option<String>> = Vec::with_capacity(inputs.len());
+        let mut entity_ids: Vec<Option<Uuid>> = Vec::with_capacity(inputs.len());
+        // entity_name is a TEXT[] per row in the DB; we serialise as JSON
+        // arrays for the `unnest` of `jsonb[]` then convert back inside SQL.
+        let mut entity_names_json: Vec<Option<serde_json::Value>> =
+            Vec::with_capacity(inputs.len());
+
+        for input in inputs {
+            let TaskInput {
+                task_metadata,
+                payload,
+            } = input;
+            let (entity_type, entity_id, entity_name) = match task_metadata.entity {
+                TaskEntity::System => (None, None, None),
+                TaskEntity::Resource {
+                    entity_type,
+                    entity_id,
+                    entity_name,
+                } => (
+                    Some(entity_type),
+                    Some(entity_id),
+                    Some(serde_json::Value::Array(
+                        entity_name
+                            .into_iter()
+                            .map(serde_json::Value::String)
+                            .collect(),
+                    )),
+                ),
+            };
+
+            task_ids.push(Uuid::now_v7());
+            parent_task_ids.push(task_metadata.parent_task_id.map(Uuid::from));
+            scheduled_fors.push(task_metadata.scheduled_for);
+            payloads.push(payload);
+            entity_types.push(entity_type);
+            entity_ids.push(entity_id);
+            entity_names_json.push(entity_name);
+        }
+
+        let rows = sqlx::query(ENQUEUE_TASKS_SQL)
+            .bind(&task_ids)
+            .bind(queue_name.as_str())
+            .bind(&parent_task_ids)
+            .bind(&scheduled_fors)
+            .bind(&payloads)
+            .bind(&entity_types)
+            .bind(&entity_ids)
+            .bind(&entity_names_json)
+            .bind(TaskIntermediateStatus::Scheduled)
+            .fetch_all(&mut **tx)
+            .await?;
+
+        let mut inserted = Vec::with_capacity(rows.len());
+        for row in rows {
+            let id: Uuid = row.try_get("task_id")?;
+            inserted.push(TaskId::from(id));
+        }
+        Ok(inserted)
+    }
+
+    async fn check_and_heartbeat_task(
+        &self,
+        id: TaskAttemptId,
+        progress: f32,
+        execution_details: Option<serde_json::Value>,
+        tx: &mut Transaction<'_, Postgres>,
+    ) -> TaskResult<TaskCheckState> {
+        let TaskAttemptId { task_id, attempt } = id;
+        let row = sqlx::query(HEARTBEAT_SQL)
+            .bind(*task_id)
+            .bind(progress)
+            .bind(execution_details)
+            .bind(attempt)
+            .fetch_optional(&mut **tx)
+            .await?;
+
+        let Some(row) = row else {
+            return Ok(TaskCheckState::NotActive);
+        };
+        let status: TaskIntermediateStatus = row.try_get("status")?;
+        Ok(match status {
+            TaskIntermediateStatus::ShouldStop | TaskIntermediateStatus::Scheduled => {
+                TaskCheckState::Stop
+            }
+            TaskIntermediateStatus::Running => TaskCheckState::Continue,
+        })
+    }
+
+    async fn record_task_success(
+        &self,
+        id: TaskAttemptId,
+        details: Option<&str>,
+        tx: &mut Transaction<'_, Postgres>,
+    ) -> TaskResult<()> {
+        let TaskAttemptId { task_id, attempt } = id;
+        let row = sqlx::query(RECORD_SUCCESS_SQL)
+            .bind(*task_id)
+            .bind(details)
+            .bind(attempt)
+            .fetch_one(&mut **tx)
+            .await?;
+
+        let task_log_exists: bool = row.try_get("task_log_exists")?;
+        let log_inserted: bool = row.try_get("log_inserted")?;
+
+        if !task_log_exists {
+            return Err(TaskError::TaskNotFound { id });
+        }
+        if !log_inserted {
+            return Err(TaskError::AttemptAlreadyRecorded {
+                id,
+                outcome: "success",
+            });
+        }
+        Ok(())
+    }
+
+    async fn record_task_failure(
+        &self,
+        id: TaskAttemptId,
+        details: &str,
+        max_retries: i32,
+        tx: &mut Transaction<'_, Postgres>,
+    ) -> TaskResult<()> {
+        let TaskAttemptId { task_id, attempt } = id;
+        let row = if attempt >= max_retries {
+            sqlx::query(RECORD_TERMINAL_FAILURE_SQL)
+                .bind(*task_id)
+                .bind(attempt)
+                .bind(details)
+                .fetch_one(&mut **tx)
+                .await?
+        } else {
+            sqlx::query(RECORD_RETRY_FAILURE_SQL)
+                .bind(*task_id)
+                .bind(details)
+                .bind(attempt)
+                .fetch_one(&mut **tx)
+                .await?
+        };
+
+        let task_log_exists: bool = row.try_get("task_log_exists")?;
+        let log_inserted: bool = row.try_get("log_inserted")?;
+
+        if !task_log_exists {
+            return Err(TaskError::TaskNotFound { id });
+        }
+        if !log_inserted {
+            return Err(TaskError::AttemptAlreadyRecorded {
+                id,
+                outcome: "failure",
+            });
+        }
+        Ok(())
+    }
+
+    fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
+fn duration_to_pg_interval(d: Duration) -> TaskResult<PgInterval> {
+    let microseconds = d.num_microseconds().ok_or_else(|| {
+        TaskError::internal("duration overflowed when converting to microseconds")
+    })?;
+    Ok(PgInterval {
+        months: 0,
+        days: 0,
+        microseconds,
+    })
+}
+
+fn row_to_task(row: &sqlx::postgres::PgRow) -> TaskResult<Task> {
+    let task_id: Uuid = row.try_get("task_id")?;
+    let queue_name: String = row.try_get("queue_name")?;
+    let status: TaskIntermediateStatus = row.try_get("status")?;
+    let parent_task_id: Option<Uuid> = row.try_get("parent_task_id")?;
+    let scheduled_for: chrono::DateTime<chrono::Utc> = row.try_get("scheduled_for")?;
+    let picked_up_at: Option<chrono::DateTime<chrono::Utc>> = row.try_get("picked_up_at")?;
+    let attempt: i32 = row.try_get("attempt")?;
+    let task_data: serde_json::Value = row.try_get("task_data")?;
+    let entity_type: Option<String> = row.try_get("entity_type")?;
+    let entity_id: Option<Uuid> = row.try_get("entity_id")?;
+    let entity_name: Option<Vec<String>> = row.try_get("entity_name")?;
+    let config: Option<serde_json::Value> = row.try_get("config")?;
+
+    let entity = match (entity_type, entity_id, entity_name) {
+        (Some(entity_type), Some(entity_id), Some(entity_name)) => TaskEntity::Resource {
+            entity_type,
+            entity_id,
+            entity_name,
+        },
+        (None, None, None) => TaskEntity::System,
+        _ => {
+            return Err(TaskError::internal(
+                "task row has partial entity fields (entity_type / entity_id / entity_name out of sync)",
+            ));
+        }
+    };
+
+    Ok(Task {
+        task_metadata: TaskMetadata {
+            parent_task_id: parent_task_id.map(TaskId::from),
+            scheduled_for,
+            entity,
+        },
+        queue_name: TaskQueueName::from(queue_name),
+        id: TaskAttemptId {
+            task_id: TaskId::from(task_id),
+            attempt,
+        },
+        status,
+        picked_up_at,
+        config,
+        data: task_data,
+    })
+}
+
+// -------------------------------------------------------------- SQL ---------
+
+/// FOR UPDATE SKIP LOCKED picker that also reclaims stale `running` tasks
+/// whose last heartbeat is older than the configured timeout.
+const PICK_TASK_SQL: &str = r#"
+WITH picked_task AS (
+    SELECT t.*, tc.config
+    FROM task t
+    LEFT JOIN task_config tc ON tc.queue_name = t.queue_name
+    WHERE t.queue_name = $1
+        AND t.scheduled_for <= now()
+        AND (
+            t.status = 'scheduled'
+            OR (t.status != 'scheduled'
+                AND (now() - t.last_heartbeat_at) > COALESCE(tc.max_time_since_last_heartbeat, $2))
+        )
+    FOR UPDATE OF t SKIP LOCKED
+    LIMIT 1
+),
+inserted AS (
+    INSERT INTO task_log(
+        task_id, queue_name, task_data, status, entity_id, entity_type,
+        entity_name, message, attempt, started_at, duration, progress,
+        execution_details, attempt_scheduled_for, last_heartbeat_at,
+        parent_task_id, task_created_at
+    )
+    SELECT
+        task_id, queue_name, task_data, 'failed', entity_id, entity_type,
+        entity_name, 'Attempt timed out.', attempt, picked_up_at,
+        now() - picked_up_at, progress, execution_details, scheduled_for,
+        last_heartbeat_at, parent_task_id, created_at
+    FROM picked_task
+    WHERE status != 'scheduled'
+    ON CONFLICT (task_id, attempt) DO NOTHING
+)
+UPDATE task
+SET status = 'running',
+    progress = 0.0,
+    execution_details = NULL,
+    picked_up_at = now(),
+    last_heartbeat_at = now(),
+    attempt = task.attempt + 1
+FROM picked_task p
+WHERE task.task_id = p.task_id AND task.attempt = p.attempt
+RETURNING
+    task.task_id,
+    task.queue_name,
+    task.status,
+    task.parent_task_id,
+    task.scheduled_for,
+    task.picked_up_at,
+    task.attempt,
+    task.task_data,
+    task.entity_type,
+    task.entity_id,
+    task.entity_name,
+    (SELECT config FROM picked_task) AS config
+"#;
+
+/// Bulk INSERT using `unnest` arrays for the variable-length columns.
+///
+/// `$8` is `jsonb[]` of either `NULL` (system task) or a JSON array of strings
+/// (the resource entity name). We project it back to `text[]` inside SQL.
+const ENQUEUE_TASKS_SQL: &str = r#"
+INSERT INTO task(
+    task_id, queue_name, status, parent_task_id, scheduled_for, task_data,
+    entity_type, entity_id, entity_name
+)
+SELECT
+    t.task_id,
+    $2,
+    $9,
+    t.parent_task_id,
+    COALESCE(t.scheduled_for, now()),
+    t.payload,
+    t.entity_type,
+    t.entity_id,
+    CASE
+        WHEN t.entity_name IS NULL THEN NULL
+        ELSE ARRAY(SELECT jsonb_array_elements_text(t.entity_name))
+    END
+FROM unnest(
+    $1::uuid[],
+    $3::uuid[],
+    $4::timestamptz[],
+    $5::jsonb[],
+    $6::text[],
+    $7::uuid[],
+    $8::jsonb[]
+) AS t(task_id, parent_task_id, scheduled_for, payload, entity_type, entity_id, entity_name)
+ON CONFLICT (entity_type, entity_id, queue_name) DO NOTHING
+RETURNING task_id
+"#;
+
+/// Update `last_heartbeat_at`, `progress`, `execution_details`. Returning the
+/// current status lets the worker react to external stop signals.
+const HEARTBEAT_SQL: &str = r#"
+WITH heartbeat AS (
+    UPDATE task
+    SET last_heartbeat_at = now(),
+        progress = $2,
+        execution_details = $3
+    WHERE task_id = $1 AND attempt = $4
+    RETURNING status
+)
+SELECT status FROM heartbeat
+"#;
+
+/// Move the task to `task_log` as `success` and delete from the active table.
+/// Reports both whether the original row existed (to surface "not found") and
+/// whether the log row was actually inserted (to detect already-recorded
+/// attempts).
+const RECORD_SUCCESS_SQL: &str = r#"
+WITH moved AS (
+    DELETE FROM task WHERE task_id = $1 AND attempt = $3 RETURNING *
+),
+existing_log AS (
+    SELECT 1 FROM task_log WHERE task_id = $1 AND attempt = $3
+),
+log_insert AS (
+    INSERT INTO task_log(
+        task_id, queue_name, task_data, status, entity_id, entity_type,
+        entity_name, message, attempt, started_at, duration, progress,
+        execution_details, attempt_scheduled_for, last_heartbeat_at,
+        parent_task_id, task_created_at
+    )
+    SELECT
+        task_id, queue_name, task_data, 'success', entity_id, entity_type,
+        entity_name, $2, attempt, picked_up_at, now() - picked_up_at, 1.0,
+        execution_details, scheduled_for, last_heartbeat_at, parent_task_id,
+        created_at
+    FROM moved
+    ON CONFLICT (task_id, attempt) DO NOTHING
+    RETURNING task_id
+)
+SELECT
+    (EXISTS(SELECT 1 FROM existing_log) OR EXISTS(SELECT 1 FROM moved)) AS task_log_exists,
+    EXISTS(SELECT 1 FROM log_insert) AS log_inserted
+"#;
+
+/// Final failure: archive into `task_log` and delete from `task`.
+const RECORD_TERMINAL_FAILURE_SQL: &str = r#"
+WITH moved AS (
+    DELETE FROM task WHERE task_id = $1 AND attempt = $2 RETURNING *
+),
+existing_log AS (
+    SELECT 1 FROM task_log WHERE task_id = $1 AND attempt = $2
+),
+log_insert AS (
+    INSERT INTO task_log(
+        task_id, queue_name, task_data, status, entity_id, entity_type,
+        entity_name, message, attempt, started_at, duration, progress,
+        execution_details, attempt_scheduled_for, last_heartbeat_at,
+        parent_task_id, task_created_at
+    )
+    SELECT
+        task_id, queue_name, task_data, 'failed', entity_id, entity_type,
+        entity_name, $3, attempt, picked_up_at, now() - picked_up_at,
+        progress, execution_details, scheduled_for, last_heartbeat_at,
+        parent_task_id, created_at
+    FROM moved
+    ON CONFLICT (task_id, attempt) DO NOTHING
+    RETURNING task_id
+)
+SELECT
+    (EXISTS(SELECT 1 FROM existing_log) OR EXISTS(SELECT 1 FROM moved)) AS task_log_exists,
+    EXISTS(SELECT 1 FROM log_insert) AS log_inserted
+"#;
+
+/// Retryable failure: archive the attempt to `task_log` and reset the task
+/// back to `scheduled` so it can be picked up again.
+const RECORD_RETRY_FAILURE_SQL: &str = r#"
+WITH locked AS (
+    SELECT * FROM task WHERE task_id = $1 AND attempt = $3 FOR UPDATE
+),
+existing_log AS (
+    SELECT 1 FROM task_log WHERE task_id = $1 AND attempt = $3
+),
+log_insert AS (
+    INSERT INTO task_log(
+        task_id, queue_name, task_data, status, entity_id, entity_type,
+        entity_name, message, attempt, started_at, duration, progress,
+        execution_details, attempt_scheduled_for, last_heartbeat_at,
+        parent_task_id, task_created_at
+    )
+    SELECT
+        task_id, queue_name, task_data, 'failed', entity_id, entity_type,
+        entity_name, $2, attempt, picked_up_at, now() - picked_up_at,
+        progress, execution_details, scheduled_for, last_heartbeat_at,
+        parent_task_id, created_at
+    FROM locked
+    ON CONFLICT (task_id, attempt) DO NOTHING
+    RETURNING task_id
+),
+task_update AS (
+    UPDATE task t
+    SET status = 'scheduled',
+        progress = 0.0,
+        picked_up_at = NULL,
+        execution_details = NULL,
+        last_heartbeat_at = NULL
+    FROM locked
+    WHERE t.task_id = locked.task_id AND t.attempt = locked.attempt
+    RETURNING t.task_id
+)
+SELECT
+    (EXISTS(SELECT 1 FROM existing_log) OR EXISTS(SELECT 1 FROM log_insert)) AS task_log_exists,
+    EXISTS(SELECT 1 FROM log_insert) AS log_inserted
+"#;
+
+#[cfg(all(test, feature = "integration-pg"))]
+mod tests {
+    use std::time::Duration as StdDuration;
+
+    use chrono::Duration;
+    use serde_json::json;
+    use sqlx::PgPool;
+    use unitycatalog_tasks::{
+        ScheduleTaskMetadata, TaskEntity, TaskInput, TaskQueueName, TaskStore,
+    };
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::GraphStore;
+
+    fn store(pool: PgPool) -> GraphStore {
+        GraphStore::new(pool, None)
+    }
+
+    fn queue() -> TaskQueueName {
+        TaskQueueName::from("test-queue")
+    }
+
+    fn make_input(entity_uuid: Uuid) -> TaskInput {
+        TaskInput {
+            task_metadata: ScheduleTaskMetadata {
+                parent_task_id: None,
+                scheduled_for: None,
+                entity: TaskEntity::Resource {
+                    entity_type: "table".into(),
+                    entity_id: entity_uuid,
+                    entity_name: vec!["cat".into(), "schema".into(), "tbl".into()],
+                },
+            },
+            payload: json!({"foo": "bar"}),
+        }
+    }
+
+    #[sqlx::test]
+    async fn enqueue_dedup(pool: PgPool) {
+        let store = store(pool);
+        let entity = Uuid::new_v4();
+
+        let mut tx = store.pool().begin().await.unwrap();
+        let ids1 = store
+            .enqueue_tasks(&queue(), vec![make_input(entity)], &mut tx)
+            .await
+            .unwrap();
+        let ids2 = store
+            .enqueue_tasks(&queue(), vec![make_input(entity)], &mut tx)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        assert_eq!(ids1.len(), 1);
+        assert_eq!(ids2.len(), 0, "duplicate (entity, queue) should be skipped");
+    }
+
+    #[sqlx::test]
+    async fn pick_skip_locked_picks_one(pool: PgPool) {
+        let store = store(pool);
+
+        let mut tx = store.pool().begin().await.unwrap();
+        let _ = store
+            .enqueue_tasks(&queue(), vec![make_input(Uuid::new_v4())], &mut tx)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let picked = store
+            .pick_new_task(&queue(), Duration::seconds(300))
+            .await
+            .unwrap()
+            .expect("a task should be picked");
+
+        assert_eq!(picked.attempt(), 1, "picking increments attempt to 1");
+        assert_eq!(picked.queue_name.as_str(), "test-queue");
+    }
+
+    #[sqlx::test]
+    async fn pick_reclaims_stale_running(pool: PgPool) {
+        let store = store(pool);
+
+        let mut tx = store.pool().begin().await.unwrap();
+        let _ = store
+            .enqueue_tasks(&queue(), vec![make_input(Uuid::new_v4())], &mut tx)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        // First pick marks the task as running.
+        let first = store
+            .pick_new_task(&queue(), Duration::milliseconds(100))
+            .await
+            .unwrap()
+            .expect("task picked initially");
+
+        // Wait past the heartbeat timeout so the next pick reclaims it.
+        tokio::time::sleep(StdDuration::from_millis(300)).await;
+
+        let second = store
+            .pick_new_task(&queue(), Duration::milliseconds(100))
+            .await
+            .unwrap()
+            .expect("stale task should be re-picked");
+
+        assert_eq!(first.task_id(), second.task_id());
+        assert_eq!(second.attempt(), 2, "second pickup increments attempt");
+    }
+
+    #[sqlx::test]
+    async fn record_success_moves_to_log(pool: PgPool) {
+        let store = store(pool);
+        let mut tx = store.pool().begin().await.unwrap();
+        let _ = store
+            .enqueue_tasks(&queue(), vec![make_input(Uuid::new_v4())], &mut tx)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let picked = store
+            .pick_new_task(&queue(), Duration::seconds(300))
+            .await
+            .unwrap()
+            .unwrap();
+
+        let mut tx = store.pool().begin().await.unwrap();
+        store
+            .record_task_success(picked.id, Some("ok"), &mut tx)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let next = store
+            .pick_new_task(&queue(), Duration::seconds(300))
+            .await
+            .unwrap();
+        assert!(next.is_none(), "no further tasks after success");
+    }
+
+    #[sqlx::test]
+    async fn record_failure_retries_then_archives(pool: PgPool) {
+        let store = store(pool);
+        let mut tx = store.pool().begin().await.unwrap();
+        let _ = store
+            .enqueue_tasks(&queue(), vec![make_input(Uuid::new_v4())], &mut tx)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        // Pick + retryable failure.
+        let picked = store
+            .pick_new_task(&queue(), Duration::seconds(300))
+            .await
+            .unwrap()
+            .unwrap();
+        let mut tx = store.pool().begin().await.unwrap();
+        store
+            .record_task_failure(picked.id, "transient", 3, &mut tx)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        // Task should still be schedulable.
+        let retried = store
+            .pick_new_task(&queue(), Duration::seconds(300))
+            .await
+            .unwrap()
+            .expect("task should be back on the queue after retryable failure");
+        assert_eq!(retried.task_id(), picked.task_id());
+        assert_eq!(retried.attempt(), 2);
+
+        // Terminal failure (attempt >= max_retries).
+        let mut tx = store.pool().begin().await.unwrap();
+        store
+            .record_task_failure(retried.id, "terminal", 1, &mut tx)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let next = store
+            .pick_new_task(&queue(), Duration::seconds(300))
+            .await
+            .unwrap();
+        assert!(
+            next.is_none(),
+            "task should be archived after terminal failure"
+        );
+    }
+
+    #[sqlx::test]
+    async fn heartbeat_reports_state(pool: PgPool) {
+        let store = store(pool);
+
+        let mut tx = store.pool().begin().await.unwrap();
+        let _ = store
+            .enqueue_tasks(&queue(), vec![make_input(Uuid::new_v4())], &mut tx)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let picked = store
+            .pick_new_task(&queue(), Duration::seconds(300))
+            .await
+            .unwrap()
+            .unwrap();
+
+        let mut tx = store.pool().begin().await.unwrap();
+        let state = store
+            .check_and_heartbeat_task(picked.id, 0.5, None, &mut tx)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        assert_eq!(state, TaskCheckState::Continue);
+    }
+}

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "unitycatalog-tasks"
+description = "Postgres-backed background task queue framework for unitycatalog-rs."
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+version.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+chrono = { workspace = true }
+fastrand = "2.3"
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true, features = ["postgres", "chrono", "uuid", "json"] }
+thiserror = { workspace = true }
+tokio = { version = "1", features = ["rt", "time", "macros", "sync"] }
+tokio-util = { version = "0.7", default-features = false }
+tracing = { workspace = true }
+uuid = { workspace = true, features = ["v7"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+serde_json = { workspace = true }

--- a/crates/tasks/README.md
+++ b/crates/tasks/README.md
@@ -1,0 +1,93 @@
+# unitycatalog-tasks
+
+A Postgres-backed background task queue framework for the
+[`unitycatalog-rs`](https://github.com/unitycatalog-incubator/unitycatalog-rs)
+server. Workers run in-process alongside the HTTP server; tasks are persisted
+in Postgres and picked up via `FOR UPDATE SKIP LOCKED`. Designed to host
+catalog maintenance jobs (deferred deletes, log cleanup, credential rotation,
+table snapshot maintenance) — **not** user-defined data pipelines.
+
+## Acknowledgements
+
+The architecture, table schema, and trait shapes in this crate are **ported
+directly from
+[lakekeeper/lakekeeper](https://github.com/lakekeeper/lakekeeper)'s
+[`crates/lakekeeper/src/service/tasks/`](https://github.com/lakekeeper/lakekeeper/blob/main/crates/lakekeeper/src/service/tasks/)
+module** (Apache-2.0). Specifically, we ported from upstream commit
+[`05cce57`](https://github.com/lakekeeper/lakekeeper/commit/05cce5797d3321ce30c59e034f19a3861c39cd88).
+
+Huge thanks to the lakekeeper maintainers — in particular the registry/runner
+split and `SpecializedTask` design from
+[issue #1310](https://github.com/lakekeeper/lakekeeper/issues/1310). Each ported
+source file carries a top-of-file comment pointing back at the corresponding
+upstream file.
+
+## Why a separate crate instead of depending on `lakekeeper` directly
+
+We considered consuming the upstream queue as a dependency and decided against
+it. Three blockers:
+
+1. **Not on crates.io.** None of lakekeeper's workspace crates
+   (`lakekeeper`, `lakekeeper-bin`, `iceberg-ext`, `authz-openfga`,
+   `lakekeeper-io`) are published. Releases ship as Docker images and binaries.
+2. **Task queue is not a standalone crate.** It lives inside the monolithic
+   `lakekeeper` crate at `crates/lakekeeper/src/service/tasks/` and is not
+   feature-isolated.
+3. **Heavy transitive dependencies.** Even with `default-features = false`,
+   pulling in `lakekeeper` brings `iceberg` (their fork), `iceberg-ext`,
+   `lakekeeper-io`, AWS / Azure / GCS SDKs, `cloudevents-sdk`,
+   `axum-prometheus`, `figment`, `limes`, `moka`, `vaultrs`, `quick-xml`, and
+   ~60+ other crates. The queue module is also tightly coupled to internal
+   lakekeeper types (`CatalogStore`, `RequestMetadata`, `iceberg::TableIdent`,
+   the global `CONFIG`).
+
+Maintaining a small, focused copy here lets us depend on roughly ten crates
+(`sqlx`, `serde`, `chrono`, `uuid`, `tokio`, `tokio-util`, `tracing`,
+`async-trait`, `thiserror`, `fastrand`, `futures`) and to evolve the API for
+Unity Catalog semantics.
+
+## API compatibility goal
+
+The public type and trait names mirror lakekeeper's surface so that if either
+project later extracts `service/tasks/` into a standalone `lakekeeper-tasks`
+crate, the swap is mechanical:
+
+| `unitycatalog-tasks`                  | lakekeeper equivalent                |
+| ------------------------------------- | ------------------------------------ |
+| `TaskQueueRegistry`                   | `TaskQueueRegistry`                  |
+| `TaskQueuesRunner`                    | `TaskQueuesRunner`                   |
+| `TaskQueueWorkerFn`                   | `TaskQueueWorkerFn`                  |
+| `SpecializedTask<Q, D, E>`            | `SpecializedTask<Q, D, E>`           |
+| `TaskConfig` / `TaskData` / ...       | `TaskConfig` / `TaskData` / ...      |
+| `TaskStore` trait                     | `CatalogTaskOps` trait               |
+| `TaskCheckState`, `TaskAttemptId`, …  | identical names                      |
+
+## Scope
+
+This crate is *infrastructure only*. It provides:
+
+- Type-safe per-queue task definitions (`TaskConfig`, `TaskData`,
+  `TaskExecutionDetails`, `SpecializedTask<Q, D, E>`).
+- A `TaskQueueRegistry` for registering queues and their worker functions.
+- A `TaskQueuesRunner` that spawns and supervises the worker tasks (auto-restart
+  on crash, cooperative shutdown via `CancellationToken`).
+- A `TaskStore` trait describing the storage primitives (`pick_new_task`,
+  `enqueue_tasks`, `check_and_heartbeat_task`, `record_task_success`,
+  `record_task_failure`).
+
+It does **not** ship any specific worker implementations, a management HTTP
+API, or an in-memory backend. Those are intentionally left to follow-up work
+once we have concrete catalog jobs to run.
+
+## What this crate is not
+
+`unitycatalog-tasks` is for **system-initiated, transactionally-enqueued
+maintenance work** — the catalog managing its own state. It is not a
+substitute for a data-pipeline orchestrator like
+[rivers](https://github.com/ion-elgreco/rivers), Dagster, Airflow, or Kestra.
+Those tools belong on the *consumer* side of Unity Catalog: they read from and
+write to UC via its REST API.
+
+## License
+
+Apache-2.0 — matches upstream lakekeeper and the rest of this repository.

--- a/crates/tasks/src/error.rs
+++ b/crates/tasks/src/error.rs
@@ -1,0 +1,54 @@
+// Design ported from lakekeeper/lakekeeper, Apache-2.0.
+// Upstream commit: https://github.com/lakekeeper/lakekeeper/tree/05cce5797d3321ce30c59e034f19a3861c39cd88
+//
+// Errors are reshaped to a thiserror-based enum to avoid pulling in
+// `iceberg-ext`/`IcebergErrorResponse` from the upstream codebase.
+
+use crate::types::{TaskAttemptId, TaskQueueName};
+
+/// Result alias for fallible task-store and runtime operations.
+pub type Result<T, E = TaskError> = std::result::Result<T, E>;
+
+/// Errors that the task framework can surface.
+///
+/// Storage backends should map their native errors into one of the variants
+/// below so workers and registry callers can handle them uniformly.
+#[derive(Debug, thiserror::Error)]
+pub enum TaskError {
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+
+    #[error("failed to serialize {kind} for task queue `{queue}`: {source}")]
+    Serialization {
+        kind: &'static str,
+        queue: TaskQueueName,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("failed to deserialize {kind} for task queue `{queue}`: {source}")]
+    Deserialization {
+        kind: &'static str,
+        queue: TaskQueueName,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("task attempt {id} not found in active tasks")]
+    TaskNotFound { id: TaskAttemptId },
+
+    #[error("task attempt {id} has already been recorded as {outcome}")]
+    AttemptAlreadyRecorded {
+        id: TaskAttemptId,
+        outcome: &'static str,
+    },
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl TaskError {
+    pub fn internal(msg: impl Into<String>) -> Self {
+        Self::Internal(msg.into())
+    }
+}

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -1,0 +1,27 @@
+//! Postgres-backed background task queue framework.
+//!
+//! See the crate-level `README.md` for design notes, scope, and attribution.
+//! The architecture is ported from
+//! [lakekeeper/lakekeeper](https://github.com/lakekeeper/lakekeeper)'s
+//! `service/tasks/` module (Apache-2.0).
+
+pub mod error;
+mod registry;
+mod runner;
+mod specialized;
+mod store;
+mod types;
+
+pub use error::{Result, TaskError};
+pub use registry::{
+    QueueApiConfig, QueueRegistration, RegisteredTaskQueues, TaskQueueRegistry, ValidatorFn,
+};
+pub use runner::{TaskQueueWorkerFn, TaskQueuesRunner};
+pub use specialized::SpecializedTask;
+pub use store::TaskStore;
+pub use tokio_util::sync::CancellationToken;
+pub use types::{
+    DEFAULT_MAX_RETRIES, ScheduleTaskMetadata, Status, Task, TaskAttemptId, TaskCheckState,
+    TaskConfig, TaskData, TaskEntity, TaskExecutionDetails, TaskId, TaskInput,
+    TaskIntermediateStatus, TaskMetadata, TaskOutcome, TaskQueueName,
+};

--- a/crates/tasks/src/registry.rs
+++ b/crates/tasks/src/registry.rs
@@ -1,0 +1,371 @@
+// Design ported from lakekeeper/lakekeeper, Apache-2.0.
+// Upstream source: https://github.com/lakekeeper/lakekeeper/blob/05cce5797d3321ce30c59e034f19a3861c39cd88/crates/lakekeeper/src/service/tasks/task_registry.rs
+//
+// Adapted for unitycatalog-rs:
+//   * Dropped `QueueScope`, OpenAPI / utoipa integration, and the
+//     warehouse/project distinctions — none of those concepts exist in UC.
+//   * `RegisteredTaskQueues` still exposes a shared, interior-mutable view of
+//     the API config so it can be embedded in axum app state for a future
+//     management API. For now it only carries the validator function so
+//     downstream code can validate user-supplied queue config payloads.
+
+use std::{collections::HashMap, sync::Arc};
+
+use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
+
+use crate::runner::{QueueWorkerConfig, TaskQueueWorkerFn, TaskQueuesRunner};
+use crate::types::{TaskConfig, TaskQueueName};
+
+/// Validates a `serde_json::Value` against a queue's config schema.
+pub type ValidatorFn =
+    Arc<dyn Fn(serde_json::Value) -> serde_json::Result<()> + Send + Sync + 'static>;
+
+#[derive(Clone)]
+struct RegisteredQueue {
+    api_config: QueueApiConfig,
+    schema_validator_fn: ValidatorFn,
+}
+
+impl std::fmt::Debug for RegisteredQueue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegisteredQueue")
+            .field("api_config", &self.api_config)
+            .field("schema_validator_fn", &"Fn(...)")
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+struct RegisteredTaskQueueWorker {
+    worker_fn: TaskQueueWorkerFn,
+    num_workers: usize,
+}
+
+impl std::fmt::Debug for RegisteredTaskQueueWorker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegisteredTaskQueueWorker")
+            .field("worker_fn", &"Fn(...)")
+            .field("num_workers", &self.num_workers)
+            .finish()
+    }
+}
+
+/// Per-queue API metadata. Kept intentionally minimal here; a future
+/// management API can attach more (e.g. OpenAPI schemas) without affecting the
+/// runtime path.
+#[derive(Clone, Debug)]
+pub struct QueueApiConfig {
+    pub queue_name: &'static TaskQueueName,
+}
+
+/// Description of a queue to register with the [`TaskQueueRegistry`].
+#[derive(Clone)]
+pub struct QueueRegistration {
+    /// Static name of the queue.
+    pub queue_name: &'static TaskQueueName,
+    /// Worker loop. Receives a cancellation token and is expected to honour it.
+    pub worker_fn: TaskQueueWorkerFn,
+    /// Number of worker tasks to spawn locally for this queue.
+    pub num_workers: usize,
+}
+
+impl std::fmt::Debug for QueueRegistration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QueueRegistration")
+            .field("queue_name", &self.queue_name)
+            .field("worker_fn", &"Fn(...)")
+            .field("num_workers", &self.num_workers)
+            .finish()
+    }
+}
+
+/// Container for registered queues that can be cloned into application state.
+///
+/// The interior state is shared with the parent [`TaskQueueRegistry`], so
+/// registrations made after this view was constructed are visible to it.
+#[derive(Clone, Default, Debug)]
+pub struct RegisteredTaskQueues {
+    queues: Arc<RwLock<HashMap<&'static TaskQueueName, RegisteredQueue>>>,
+}
+
+impl RegisteredTaskQueues {
+    /// Returns the API config for every registered queue, sorted by name.
+    pub async fn api_config(&self) -> Vec<QueueApiConfig> {
+        let mut configs: Vec<_> = self
+            .queues
+            .read()
+            .await
+            .values()
+            .map(|q| q.api_config.clone())
+            .collect();
+        configs.sort_by_key(|c| c.queue_name);
+        configs
+    }
+
+    /// Returns the validator function for a given queue, or `None` if no queue
+    /// with that name is registered.
+    pub async fn validate_config_fn(&self, queue: &TaskQueueName) -> Option<ValidatorFn> {
+        self.queues
+            .read()
+            .await
+            .get(queue)
+            .map(|q| Arc::clone(&q.schema_validator_fn))
+    }
+
+    /// Convenience helper to list queue names in deterministic order.
+    pub async fn queue_names(&self) -> Vec<&'static TaskQueueName> {
+        let mut v: Vec<_> = self.queues.read().await.keys().copied().collect();
+        v.sort_unstable();
+        v
+    }
+}
+
+/// Registry for task queues and their worker pools.
+#[derive(Debug, Clone)]
+pub struct TaskQueueRegistry {
+    registered_queues: Arc<RwLock<HashMap<&'static TaskQueueName, RegisteredQueue>>>,
+    task_workers: Arc<RwLock<HashMap<&'static TaskQueueName, RegisteredTaskQueueWorker>>>,
+}
+
+impl Default for TaskQueueRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TaskQueueRegistry {
+    pub fn new() -> Self {
+        Self {
+            registered_queues: Arc::new(RwLock::new(HashMap::new())),
+            task_workers: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Register a queue with its worker function and configuration type.
+    ///
+    /// Registering a queue with the same name twice logs a warning and
+    /// overwrites the previous registration.
+    pub async fn register_queue<T: TaskConfig>(&self, task_queue: QueueRegistration) -> &Self {
+        let QueueRegistration {
+            queue_name,
+            worker_fn,
+            num_workers,
+        } = task_queue;
+
+        let schema_validator_fn: ValidatorFn =
+            Arc::new(|v| serde_json::from_value::<T>(v).map(|_| ()));
+        let api_config = QueueApiConfig { queue_name };
+
+        if self
+            .registered_queues
+            .write()
+            .await
+            .insert(
+                queue_name,
+                RegisteredQueue {
+                    api_config,
+                    schema_validator_fn,
+                },
+            )
+            .is_some()
+        {
+            tracing::warn!("Overwriting registration for queue `{queue_name}`");
+        }
+
+        self.task_workers.write().await.insert(
+            queue_name,
+            RegisteredTaskQueueWorker {
+                worker_fn,
+                num_workers,
+            },
+        );
+        self
+    }
+
+    /// Create a [`RegisteredTaskQueues`] view sharing state with this
+    /// registry.
+    pub fn registered_task_queues(&self) -> RegisteredTaskQueues {
+        RegisteredTaskQueues {
+            queues: self.registered_queues.clone(),
+        }
+    }
+
+    /// Number of registered queues.
+    pub async fn len(&self) -> usize {
+        self.registered_queues.read().await.len()
+    }
+
+    pub async fn is_empty(&self) -> bool {
+        self.registered_queues.read().await.is_empty()
+    }
+
+    /// Build a [`TaskQueuesRunner`] snapshot.
+    ///
+    /// Workers registered after `task_queues_runner` returns are **not**
+    /// reflected in that runner — call this once all queues are registered.
+    pub async fn task_queues_runner(
+        &self,
+        cancellation_token: CancellationToken,
+    ) -> TaskQueuesRunner {
+        let mut registered_task_queues = HashMap::new();
+
+        let queues = self.registered_queues.read().await;
+        let workers = self.task_workers.read().await;
+
+        for name in queues.keys() {
+            if let Some(worker) = workers.get(name) {
+                registered_task_queues.insert(
+                    *name,
+                    QueueWorkerConfig {
+                        worker_fn: Arc::clone(&worker.worker_fn),
+                        num_workers: worker.num_workers,
+                    },
+                );
+            }
+        }
+
+        TaskQueuesRunner {
+            registered_queues: Arc::new(registered_task_queues),
+            cancellation_token,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::LazyLock;
+
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct FirstConfig {
+        test_field: String,
+    }
+
+    static FIRST_QUEUE_NAME: LazyLock<TaskQueueName> = LazyLock::new(|| "test-queue".into());
+
+    impl TaskConfig for FirstConfig {
+        fn queue_name() -> &'static TaskQueueName {
+            &FIRST_QUEUE_NAME
+        }
+
+        fn max_time_since_last_heartbeat() -> chrono::Duration {
+            chrono::Duration::seconds(300)
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct SecondConfig {
+        other_field: i32,
+    }
+
+    static SECOND_QUEUE_NAME: LazyLock<TaskQueueName> =
+        LazyLock::new(|| "second-test-queue".into());
+
+    impl TaskConfig for SecondConfig {
+        fn queue_name() -> &'static TaskQueueName {
+            &SECOND_QUEUE_NAME
+        }
+
+        fn max_time_since_last_heartbeat() -> chrono::Duration {
+            chrono::Duration::seconds(300)
+        }
+    }
+
+    fn noop_worker() -> TaskQueueWorkerFn {
+        Arc::new(|_token| Box::pin(async {}))
+    }
+
+    #[tokio::test]
+    async fn registry_starts_empty() {
+        let registry = TaskQueueRegistry::new();
+        assert_eq!(registry.len().await, 0);
+        assert!(registry.is_empty().await);
+        assert!(
+            registry
+                .registered_task_queues()
+                .api_config()
+                .await
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn registry_register_lookup() {
+        let registry = TaskQueueRegistry::new();
+        let view = registry.registered_task_queues();
+
+        registry
+            .register_queue::<FirstConfig>(QueueRegistration {
+                queue_name: &FIRST_QUEUE_NAME,
+                worker_fn: noop_worker(),
+                num_workers: 1,
+            })
+            .await;
+
+        assert_eq!(registry.len().await, 1);
+
+        let api_config = view.api_config().await;
+        assert_eq!(api_config.len(), 1);
+        assert_eq!(api_config[0].queue_name, &*FIRST_QUEUE_NAME);
+
+        assert!(view.validate_config_fn(&FIRST_QUEUE_NAME).await.is_some());
+        assert!(
+            view.validate_config_fn(&TaskQueueName::from("does-not-exist"))
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn registered_task_queues_share_state() {
+        let registry = TaskQueueRegistry::new();
+        let initial = registry.registered_task_queues();
+
+        registry
+            .register_queue::<FirstConfig>(QueueRegistration {
+                queue_name: &FIRST_QUEUE_NAME,
+                worker_fn: noop_worker(),
+                num_workers: 1,
+            })
+            .await;
+
+        let later = registry.registered_task_queues();
+        registry
+            .register_queue::<SecondConfig>(QueueRegistration {
+                queue_name: &SECOND_QUEUE_NAME,
+                worker_fn: noop_worker(),
+                num_workers: 2,
+            })
+            .await;
+
+        let initial_names = initial.queue_names().await;
+        let later_names = later.queue_names().await;
+        assert_eq!(initial_names.len(), 2);
+        assert_eq!(initial_names, later_names);
+    }
+
+    #[tokio::test]
+    async fn validator_accepts_well_formed_payload() {
+        let registry = TaskQueueRegistry::new();
+        registry
+            .register_queue::<FirstConfig>(QueueRegistration {
+                queue_name: &FIRST_QUEUE_NAME,
+                worker_fn: noop_worker(),
+                num_workers: 1,
+            })
+            .await;
+
+        let view = registry.registered_task_queues();
+        let validator = view
+            .validate_config_fn(&FIRST_QUEUE_NAME)
+            .await
+            .expect("validator registered");
+
+        assert!(validator(serde_json::json!({ "test_field": "hello" })).is_ok());
+        assert!(validator(serde_json::json!({ "wrong": 1 })).is_err());
+    }
+}

--- a/crates/tasks/src/runner.rs
+++ b/crates/tasks/src/runner.rs
@@ -1,0 +1,157 @@
+// Design ported from lakekeeper/lakekeeper, Apache-2.0.
+// Upstream source: https://github.com/lakekeeper/lakekeeper/blob/05cce5797d3321ce30c59e034f19a3861c39cd88/crates/lakekeeper/src/service/tasks/task_queues_runner.rs
+
+use std::{collections::HashMap, sync::Arc};
+
+use futures::future::BoxFuture;
+use tokio_util::sync::CancellationToken;
+
+use crate::types::TaskQueueName;
+
+/// Infinitely running task worker loop. Workers receive a cancellation token
+/// and are expected to terminate cooperatively when it's triggered.
+pub type TaskQueueWorkerFn =
+    Arc<dyn Fn(CancellationToken) -> BoxFuture<'static, ()> + Send + Sync + 'static>;
+
+#[derive(Clone)]
+pub(crate) struct QueueWorkerConfig {
+    pub worker_fn: TaskQueueWorkerFn,
+    pub num_workers: usize,
+}
+
+impl std::fmt::Debug for QueueWorkerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QueueWorkerConfig")
+            .field("worker_fn", &"Fn(...)")
+            .field("num_workers", &self.num_workers)
+            .finish()
+    }
+}
+
+/// Spawns and supervises all registered task-queue workers.
+///
+/// Worker functions are spawned on the current tokio runtime. If a worker
+/// finishes unexpectedly (including panics) before cancellation is requested,
+/// it is restarted from the same `TaskQueueWorkerFn`. Once the cancellation
+/// token is triggered the supervisor stops restarting workers and waits for
+/// the survivors to drain.
+#[derive(Debug, Clone)]
+pub struct TaskQueuesRunner {
+    pub(crate) registered_queues: Arc<HashMap<&'static TaskQueueName, QueueWorkerConfig>>,
+    pub(crate) cancellation_token: CancellationToken,
+}
+
+struct WorkerInfo {
+    queue_name: &'static TaskQueueName,
+    worker_id: usize,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl TaskQueuesRunner {
+    /// Run all registered queue workers until every worker has terminated.
+    ///
+    /// When `restart_workers` is true, workers that finish before cancellation
+    /// is requested are automatically respawned.
+    pub async fn run_queue_workers(self, restart_workers: bool) {
+        let mut workers = Vec::new();
+        let registered_queues = Arc::clone(&self.registered_queues);
+
+        for (queue_name, queue) in registered_queues.iter() {
+            tracing::info!(
+                "Starting {} workers for task queue `{queue_name}`.",
+                queue.num_workers,
+            );
+            for worker_id in 0..queue.num_workers {
+                let task_fn = Arc::clone(&queue.worker_fn);
+                let cancellation_token_clone = self.cancellation_token.clone();
+                tracing::debug!(
+                    "Starting `{queue_name}` worker {} ({}/{})",
+                    worker_id,
+                    worker_id + 1,
+                    queue.num_workers
+                );
+                workers.push(WorkerInfo {
+                    queue_name,
+                    worker_id,
+                    handle: tokio::task::spawn(task_fn(cancellation_token_clone)),
+                });
+            }
+        }
+
+        loop {
+            if workers.is_empty() {
+                return;
+            }
+
+            let handles: Vec<_> = workers.iter_mut().map(|w| &mut w.handle).collect();
+            let (result, index, _) = futures::future::select_all(handles).await;
+            let worker = workers.swap_remove(index);
+
+            let log_msg_suffix = if restart_workers {
+                "Restarting worker"
+            } else {
+                "Restarting worker disabled"
+            };
+
+            match result {
+                Ok(()) if !self.cancellation_token.is_cancelled() => tracing::warn!(
+                    "Task queue `{}` worker {} finished. {log_msg_suffix}",
+                    worker.queue_name,
+                    worker.worker_id,
+                ),
+                Ok(()) => tracing::info!(
+                    "Task queue `{}` worker {} finished gracefully after cancellation.",
+                    worker.queue_name,
+                    worker.worker_id,
+                ),
+                Err(e) => {
+                    if e.is_panic() {
+                        tracing::error!(
+                            ?e,
+                            "Task queue `{}` worker {} panicked. {log_msg_suffix}",
+                            worker.queue_name,
+                            worker.worker_id,
+                        );
+                    } else if e.is_cancelled() {
+                        tracing::warn!(
+                            ?e,
+                            "Task queue `{}` worker {} was cancelled.",
+                            worker.queue_name,
+                            worker.worker_id,
+                        );
+                    } else {
+                        tracing::error!(
+                            ?e,
+                            "Task queue `{}` worker {} failed to join. {log_msg_suffix}",
+                            worker.queue_name,
+                            worker.worker_id,
+                        );
+                    }
+                }
+            }
+
+            if restart_workers && !self.cancellation_token.is_cancelled() {
+                if let Some(queue) = registered_queues.get(worker.queue_name) {
+                    let task_fn = Arc::clone(&queue.worker_fn);
+                    let cancellation_token_clone = self.cancellation_token.clone();
+                    tracing::debug!(
+                        "Restarting task queue `{}` worker {}",
+                        worker.queue_name,
+                        worker.worker_id,
+                    );
+                    workers.push(WorkerInfo {
+                        queue_name: worker.queue_name,
+                        worker_id: worker.worker_id,
+                        handle: tokio::task::spawn(task_fn(cancellation_token_clone)),
+                    });
+                }
+            } else if self.cancellation_token.is_cancelled() {
+                tracing::info!(
+                    "Cancellation requested, not restarting task queue `{}` worker {}",
+                    worker.queue_name,
+                    worker.worker_id,
+                );
+            }
+        }
+    }
+}

--- a/crates/tasks/src/specialized.rs
+++ b/crates/tasks/src/specialized.rs
@@ -1,0 +1,377 @@
+// Design ported from lakekeeper/lakekeeper, Apache-2.0.
+// Upstream source: https://github.com/lakekeeper/lakekeeper/blob/05cce5797d3321ce30c59e034f19a3861c39cd88/crates/lakekeeper/src/service/tasks/mod.rs
+//
+// Adapted for unitycatalog-rs:
+//   * Drops the `C: CatalogStore` generic parameter; works against a
+//     `&dyn TaskStore` directly.
+//   * Auto-commits its own transactions for the convenience methods
+//     (`heartbeat`, `record_success`, `record_failure`) since this crate is
+//     not coupled to a wider transaction-manager abstraction.
+
+use std::{marker::PhantomData, time::Duration};
+
+use serde::de::DeserializeOwned;
+use sqlx::{Postgres, Transaction};
+use tokio_util::sync::CancellationToken;
+
+use crate::error::{Result, TaskError};
+use crate::store::TaskStore;
+use crate::types::{
+    ScheduleTaskMetadata, Status, Task, TaskAttemptId, TaskCheckState, TaskConfig, TaskData,
+    TaskExecutionDetails, TaskId, TaskInput, TaskIntermediateStatus, TaskMetadata, TaskQueueName,
+};
+
+/// Type-safe wrapper around an active `Task` for a specific queue type.
+///
+/// Workers register against a concrete `SpecializedTask<Q, D, E>` and use its
+/// helpers to schedule, poll, heartbeat, and finalise their work. The wrapper
+/// owns the typed payload `D` and tracks `E` (execution details) through a
+/// `PhantomData` so heartbeats can publish strongly-typed progress info.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpecializedTask<Q: TaskConfig, D: TaskData, E: TaskExecutionDetails> {
+    pub task_metadata: TaskMetadata,
+    pub id: TaskAttemptId,
+    pub status: TaskIntermediateStatus,
+    pub picked_up_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub config: Option<Q>,
+    pub data: D,
+    execution_details: PhantomData<E>,
+}
+
+impl<Q: TaskConfig, D: TaskData, E: TaskExecutionDetails> AsRef<TaskAttemptId>
+    for SpecializedTask<Q, D, E>
+{
+    fn as_ref(&self) -> &TaskAttemptId {
+        &self.id
+    }
+}
+
+impl<Q: TaskConfig, D: TaskData, E: TaskExecutionDetails> SpecializedTask<Q, D, E> {
+    /// Static queue name for this specialisation.
+    pub fn queue_name() -> &'static TaskQueueName {
+        Q::queue_name()
+    }
+
+    pub fn task_id(&self) -> TaskId {
+        self.id.task_id
+    }
+
+    pub fn attempt(&self) -> i32 {
+        self.id.attempt
+    }
+
+    pub fn id(&self) -> TaskAttemptId {
+        self.id
+    }
+
+    /// Schedule a single task on this queue in the caller's transaction.
+    ///
+    /// Returns `Some(task_id)` if the task was enqueued, or `None` if an
+    /// active task already exists for the same `(entity, queue)` tuple.
+    pub async fn schedule_task(
+        store: &dyn TaskStore,
+        task_metadata: ScheduleTaskMetadata,
+        payload: D,
+        tx: &mut Transaction<'_, Postgres>,
+    ) -> Result<Option<TaskId>> {
+        let payload = serde_json::to_value(&payload).map_err(|e| TaskError::Serialization {
+            kind: "payload",
+            queue: Self::queue_name().clone(),
+            source: e,
+        })?;
+
+        let ids = store
+            .enqueue_tasks(
+                Self::queue_name(),
+                vec![TaskInput {
+                    task_metadata,
+                    payload,
+                }],
+                tx,
+            )
+            .await?;
+
+        Ok(ids.into_iter().next())
+    }
+
+    /// Schedule multiple tasks in a single transaction.
+    ///
+    /// CAUTION: the returned `Vec` may be shorter than `tasks` — inputs whose
+    /// `(entity, queue)` tuple was already active are silently skipped.
+    pub async fn schedule_tasks(
+        store: &dyn TaskStore,
+        tasks: impl IntoIterator<Item = (ScheduleTaskMetadata, D)>,
+        tx: &mut Transaction<'_, Postgres>,
+    ) -> Result<Vec<TaskId>> {
+        let inputs = tasks
+            .into_iter()
+            .map(|(task_metadata, payload)| {
+                Ok(TaskInput {
+                    task_metadata,
+                    payload: serde_json::to_value(&payload).map_err(|e| {
+                        TaskError::Serialization {
+                            kind: "payload",
+                            queue: Self::queue_name().clone(),
+                            source: e,
+                        }
+                    })?,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        store.enqueue_tasks(Self::queue_name(), inputs, tx).await
+    }
+
+    /// Atomically pick the next ready task from this queue.
+    ///
+    /// On JSON deserialisation failures the task is recorded as failed (so it
+    /// won't be picked up again on the next iteration) and `Ok(None)` is
+    /// returned to the worker.
+    pub async fn pick_new_task(store: &dyn TaskStore) -> Result<Option<Self>> {
+        let Some(task) = store
+            .pick_new_task(Self::queue_name(), Q::max_time_since_last_heartbeat())
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let data: D = match decode(&task, &task.data, "task data") {
+            Ok(v) => v,
+            Err(err) => {
+                Self::report_deserialization_failure(store, task.id, &err.to_string()).await;
+                return Ok(None);
+            }
+        };
+
+        let config: Option<Q> = match task
+            .config
+            .as_ref()
+            .map(|cfg| decode(&task, cfg, "queue configuration"))
+            .transpose()
+        {
+            Ok(v) => v,
+            Err(err) => {
+                Self::report_deserialization_failure(store, task.id, &err.to_string()).await;
+                return Ok(None);
+            }
+        };
+
+        Ok(Some(Self {
+            task_metadata: task.task_metadata,
+            id: task.id,
+            status: task.status,
+            picked_up_at: task.picked_up_at,
+            config,
+            data,
+            execution_details: PhantomData,
+        }))
+    }
+
+    /// Long-poll the queue, returning the first available task. Resolves to
+    /// `None` if `cancellation_token` is triggered first.
+    pub async fn poll_for_new_task(
+        store: &dyn TaskStore,
+        poll_interval: Duration,
+        cancellation_token: CancellationToken,
+    ) -> Option<Self> {
+        loop {
+            tokio::select! {
+                () = cancellation_token.cancelled() => {
+                    tracing::info!(
+                        "Graceful shutdown requested for queue `{}`",
+                        Self::queue_name()
+                    );
+                    return None;
+                }
+                pick = Self::pick_new_task(store) => {
+                    match pick {
+                        Ok(Some(task)) => {
+                            tracing::debug!("Picked up `{}` task {}.", Self::queue_name(), task.id);
+                            return Some(task);
+                        }
+                        Ok(None) => {
+                            // No work — sleep with a bit of jitter to avoid
+                            // thundering herd across workers.
+                            let jitter = fastrand::u64(0..500);
+                            tokio::select! {
+                                () = cancellation_token.cancelled() => return None,
+                                () = tokio::time::sleep(poll_interval + Duration::from_millis(jitter)) => continue,
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to pick new task from queue `{}`. Retrying in 5s. Error: {e}",
+                                Self::queue_name(),
+                            );
+                            tokio::select! {
+                                () = cancellation_token.cancelled() => return None,
+                                () = tokio::time::sleep(Duration::from_secs(5)) => continue,
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Heartbeat the task inside an existing transaction.
+    pub async fn heartbeat_in_transaction(
+        &self,
+        store: &dyn TaskStore,
+        tx: &mut Transaction<'_, Postgres>,
+        progress: f32,
+        execution_details: Option<E>,
+    ) -> Result<TaskCheckState> {
+        let execution_details = execution_details
+            .map(|d| serde_json::to_value(d))
+            .transpose()
+            .map_err(|e| TaskError::Serialization {
+                kind: "execution details",
+                queue: Self::queue_name().clone(),
+                source: e,
+            })?;
+
+        store
+            .check_and_heartbeat_task(self.id, progress, execution_details, tx)
+            .await
+    }
+
+    /// Heartbeat the task by opening and committing a short-lived transaction.
+    pub async fn heartbeat(
+        &self,
+        store: &dyn TaskStore,
+        progress: f32,
+        execution_details: Option<E>,
+    ) -> Result<TaskCheckState> {
+        let mut tx = store.pool().begin().await?;
+        let state = self
+            .heartbeat_in_transaction(store, &mut tx, progress, execution_details)
+            .await?;
+        tx.commit().await?;
+        Ok(state)
+    }
+
+    /// Record successful completion, retrying transient DB errors up to five
+    /// times. Failures are logged but never propagated — by the time we get
+    /// here the work has already happened.
+    pub async fn record_success(&self, store: &dyn TaskStore, details: Option<&str>) {
+        let status = Status::Success(details);
+        Self::record_with_retry(store, self.id, status, details, None).await;
+    }
+
+    /// Record a final failure with the configured `max_retries` budget so the
+    /// store can decide whether to reschedule or archive.
+    pub async fn record_failure(&self, store: &dyn TaskStore, error: &str) {
+        let status = Status::Failure(error, Q::max_retries());
+        Self::record_with_retry(store, self.id, status, None, Some(error)).await;
+    }
+
+    /// Record success inside the caller's transaction (no retry wrapper).
+    pub async fn record_success_in_transaction(
+        &self,
+        store: &dyn TaskStore,
+        tx: &mut Transaction<'_, Postgres>,
+        details: Option<&str>,
+    ) -> Result<()> {
+        store.record_task_success(self.id, details, tx).await
+    }
+
+    async fn record_with_retry(
+        store: &dyn TaskStore,
+        id: TaskAttemptId,
+        status: Status<'_>,
+        original_success_details: Option<&str>,
+        original_error_details: Option<&str>,
+    ) {
+        for attempt in 1..=5 {
+            let result: Result<()> = async {
+                let mut tx = store.pool().begin().await?;
+                match status {
+                    Status::Success(details) => {
+                        store.record_task_success(id, details, &mut tx).await?;
+                    }
+                    Status::Failure(details, max_retries) => {
+                        store
+                            .record_task_failure(id, details, max_retries, &mut tx)
+                            .await?;
+                    }
+                }
+                tx.commit().await?;
+                Ok(())
+            }
+            .await;
+
+            match result {
+                Ok(()) => {
+                    tracing::debug!(
+                        "Recorded {status} for task {id} in queue `{}` on attempt {attempt}",
+                        Self::queue_name(),
+                    );
+                    return;
+                }
+                Err(e) if attempt < 5 => {
+                    tracing::warn!(
+                        "Failed to record {status} for task {id} in queue `{}` on attempt {attempt}/5: {e}",
+                        Self::queue_name(),
+                    );
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to record {status} for task {id} in queue `{}` after 5 attempts: {e}. \
+                         Original success details: {success:?}. Original error details: {error:?}",
+                        Self::queue_name(),
+                        success = original_success_details,
+                        error = original_error_details,
+                    );
+                }
+            }
+        }
+    }
+
+    async fn report_deserialization_failure(store: &dyn TaskStore, id: TaskAttemptId, error: &str) {
+        tracing::error!("{error}. TaskID: {id}");
+
+        let mut tx = match store.pool().begin().await {
+            Ok(tx) => tx,
+            Err(e) => {
+                tracing::error!(
+                    "Failed to start transaction recording deserialization failure for task {id} in queue `{}`: {e}. Original error: {error}",
+                    Self::queue_name(),
+                );
+                return;
+            }
+        };
+
+        let msg = format!("Failed to deserialize task data: {error}");
+        if let Err(e) = store
+            .record_task_failure(id, &msg, Q::max_retries(), &mut tx)
+            .await
+        {
+            tracing::error!(
+                "Failed to record deserialization failure for task {id} in queue `{}`: {e}. Original error: {error}",
+                Self::queue_name(),
+            );
+            return;
+        }
+
+        if let Err(e) = tx.commit().await {
+            tracing::error!(
+                "Failed to commit transaction recording deserialization failure for task {id} in queue `{}`: {e}. Original error: {error}",
+                Self::queue_name(),
+            );
+        }
+    }
+}
+
+fn decode<T: DeserializeOwned>(
+    task: &Task,
+    value: &serde_json::Value,
+    kind: &'static str,
+) -> Result<T> {
+    serde_json::from_value(value.clone()).map_err(|e| TaskError::Deserialization {
+        kind,
+        queue: task.queue_name.clone(),
+        source: e,
+    })
+}

--- a/crates/tasks/src/store.rs
+++ b/crates/tasks/src/store.rs
@@ -1,0 +1,91 @@
+// Design ported from lakekeeper/lakekeeper, Apache-2.0.
+// Upstream source: https://github.com/lakekeeper/lakekeeper/blob/05cce5797d3321ce30c59e034f19a3861c39cd88/crates/lakekeeper/src/service/catalog_store/tasks.rs
+//
+// Adapted for unitycatalog-rs:
+//   * Renamed from `CatalogTaskOps` to `TaskStore` since this crate doesn't
+//     model the wider catalog store.
+//   * Trait is Postgres-bound (`sqlx::Transaction<'_, sqlx::Postgres>`) to
+//     keep it dyn-safe without an associated `Transaction` type. The
+//     framework explicitly targets Postgres only — see crate README.
+//   * Methods returning lists of `Option<TaskId>` mirror lakekeeper's
+//     "deduped enqueue" semantics: positions corresponding to existing active
+//     tasks return `None`.
+
+use async_trait::async_trait;
+use chrono::Duration;
+use sqlx::{PgPool, Postgres, Transaction};
+
+use crate::error::Result;
+use crate::types::{Task, TaskAttemptId, TaskCheckState, TaskId, TaskInput, TaskQueueName};
+
+/// Storage primitives for the task queue framework.
+///
+/// Implementations of this trait drive the actual Postgres queue. All
+/// transactional methods accept a borrowed `&mut sqlx::Transaction`, allowing
+/// callers (typically `SpecializedTask`) to combine task enqueue/update with
+/// other business writes in a single transaction.
+#[async_trait]
+pub trait TaskStore: Send + Sync + 'static {
+    /// Atomically pick the next ready task for the given queue, marking it
+    /// `running`. Returns `None` if no task is currently ready.
+    ///
+    /// `default_max_time_since_last_heartbeat` is the fallback timeout used
+    /// to reclaim stale `running` tasks when there is no per-queue override
+    /// configured in `task_config`.
+    async fn pick_new_task(
+        &self,
+        queue_name: &TaskQueueName,
+        default_max_time_since_last_heartbeat: Duration,
+    ) -> Result<Option<Task>>;
+
+    /// Insert tasks into the queue inside the caller's transaction.
+    ///
+    /// Tasks are deduplicated on the
+    /// `(entity_type, entity_id, queue_name)` tuple: re-enqueueing while an
+    /// active task already exists is a no-op for that input. The returned
+    /// vector contains only the task IDs that were actually inserted, so it
+    /// may be shorter than `inputs`.
+    async fn enqueue_tasks(
+        &self,
+        queue_name: &TaskQueueName,
+        inputs: Vec<TaskInput>,
+        tx: &mut Transaction<'_, Postgres>,
+    ) -> Result<Vec<TaskId>>;
+
+    /// Update the task's heartbeat / progress and return whether the worker
+    /// should keep going, stop cleanly, or abort.
+    async fn check_and_heartbeat_task(
+        &self,
+        id: TaskAttemptId,
+        progress: f32,
+        execution_details: Option<serde_json::Value>,
+        tx: &mut Transaction<'_, Postgres>,
+    ) -> Result<TaskCheckState>;
+
+    /// Mark a task attempt as a final success, archiving it into `task_log`
+    /// and removing it from the active `task` table.
+    async fn record_task_success(
+        &self,
+        id: TaskAttemptId,
+        details: Option<&str>,
+        tx: &mut Transaction<'_, Postgres>,
+    ) -> Result<()>;
+
+    /// Record a failed attempt. If `attempt < max_retries`, the task is
+    /// returned to the `scheduled` state for another try; otherwise it is
+    /// archived to `task_log` as `failed`.
+    async fn record_task_failure(
+        &self,
+        id: TaskAttemptId,
+        details: &str,
+        max_retries: i32,
+        tx: &mut Transaction<'_, Postgres>,
+    ) -> Result<()>;
+
+    /// Borrow the underlying connection pool.
+    ///
+    /// Used by `SpecializedTask`'s convenience helpers (`heartbeat`,
+    /// `record_success`, `record_failure`) to open their own transactions
+    /// when callers don't want to thread one through.
+    fn pool(&self) -> &PgPool;
+}

--- a/crates/tasks/src/types.rs
+++ b/crates/tasks/src/types.rs
@@ -1,0 +1,311 @@
+// Design ported from lakekeeper/lakekeeper, Apache-2.0.
+// Upstream source: https://github.com/lakekeeper/lakekeeper/blob/05cce5797d3321ce30c59e034f19a3861c39cd88/crates/lakekeeper/src/service/tasks/mod.rs
+//
+// Adapted for unitycatalog-rs:
+//   * Dropped `WarehouseId` / `ProjectId` scoping — UC does not yet model them.
+//   * Replaced `WarehouseTaskEntityId` (table/view enum) with a generic
+//     `TaskEntity` carrying `entity_type` as a free-form string so the
+//     framework stays UC-agnostic.
+//   * Dropped utoipa / open-api derives.
+
+use std::{fmt::Debug, ops::Deref};
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use uuid::Uuid;
+
+/// Default maximum number of attempts a single task is allowed before being
+/// marked permanently failed. Mirrors lakekeeper's default.
+pub const DEFAULT_MAX_RETRIES: i32 = 5;
+
+/// A queue identifier. Two queues with the same `TaskQueueName` share the same
+/// configuration, history, and worker pool.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[serde(transparent)]
+pub struct TaskQueueName(String);
+
+impl TaskQueueName {
+    pub fn new(name: &str) -> Self {
+        Self(name.to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl Deref for TaskQueueName {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: AsRef<str>> From<T> for TaskQueueName {
+    fn from(name: T) -> Self {
+        Self(name.as_ref().to_string())
+    }
+}
+
+impl std::fmt::Display for TaskQueueName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Identifier for a logical task instance (independent of which attempt is
+/// currently executing).
+#[derive(Hash, Debug, Clone, PartialEq, Serialize, Deserialize, Copy, Eq)]
+#[serde(transparent)]
+pub struct TaskId(Uuid);
+
+impl TaskId {
+    pub fn new(id: Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn into_uuid(self) -> Uuid {
+        self.0
+    }
+}
+
+impl From<Uuid> for TaskId {
+    fn from(id: Uuid) -> Self {
+        Self(id)
+    }
+}
+
+impl From<TaskId> for Uuid {
+    fn from(id: TaskId) -> Self {
+        id.0
+    }
+}
+
+impl Deref for TaskId {
+    type Target = Uuid;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for TaskId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Identifies a specific attempt of a task. `attempt` increments each time the
+/// task is picked up by a worker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskAttemptId {
+    pub task_id: TaskId,
+    pub attempt: i32,
+}
+
+impl TaskAttemptId {
+    pub fn new(task_id: TaskId, attempt: i32) -> Self {
+        Self { task_id, attempt }
+    }
+}
+
+impl std::fmt::Display for TaskAttemptId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} (attempt {})", self.task_id, self.attempt)
+    }
+}
+
+impl AsRef<TaskAttemptId> for TaskAttemptId {
+    fn as_ref(&self) -> &TaskAttemptId {
+        self
+    }
+}
+
+/// The thing a task acts on.
+///
+/// Mirrors lakekeeper's `TaskEntity` but stays generic: `entity_type` is a
+/// free-form string instead of a closed enum so the framework does not need to
+/// know about specific UC resource kinds.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", tag = "kind")]
+pub enum TaskEntity {
+    /// A catalog-wide task with no associated resource (e.g. periodic
+    /// housekeeping).
+    System,
+    /// A task scoped to a specific UC resource. `entity_type` mirrors UC
+    /// resource kinds such as `"table"`, `"share"`, `"credential"`, etc.
+    Resource {
+        entity_type: String,
+        entity_id: Uuid,
+        entity_name: Vec<String>,
+    },
+}
+
+impl TaskEntity {
+    pub fn entity_type(&self) -> Option<&str> {
+        match self {
+            TaskEntity::System => None,
+            TaskEntity::Resource { entity_type, .. } => Some(entity_type.as_str()),
+        }
+    }
+
+    pub fn entity_id(&self) -> Option<Uuid> {
+        match self {
+            TaskEntity::System => None,
+            TaskEntity::Resource { entity_id, .. } => Some(*entity_id),
+        }
+    }
+
+    pub fn entity_name(&self) -> Option<&[String]> {
+        match self {
+            TaskEntity::System => None,
+            TaskEntity::Resource { entity_name, .. } => Some(entity_name.as_slice()),
+        }
+    }
+}
+
+/// Persistent metadata for a task instance (read from the DB on pickup).
+#[derive(Debug, Clone, PartialEq)]
+pub struct TaskMetadata {
+    pub parent_task_id: Option<TaskId>,
+    pub scheduled_for: DateTime<Utc>,
+    pub entity: TaskEntity,
+}
+
+/// Metadata supplied when scheduling a new task. `scheduled_for: None` defaults
+/// to "now" on insert.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScheduleTaskMetadata {
+    pub parent_task_id: Option<TaskId>,
+    pub scheduled_for: Option<DateTime<Utc>>,
+    pub entity: TaskEntity,
+}
+
+/// Raw input passed to `TaskStore::enqueue_tasks`. The payload has already been
+/// serialised to a `Value` by the caller (typically `SpecializedTask`).
+#[derive(Debug, Clone)]
+pub struct TaskInput {
+    pub task_metadata: ScheduleTaskMetadata,
+    pub payload: serde_json::Value,
+}
+
+/// In-flight task as returned by `TaskStore::pick_new_task`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Task {
+    pub task_metadata: TaskMetadata,
+    pub queue_name: TaskQueueName,
+    pub id: TaskAttemptId,
+    pub status: TaskIntermediateStatus,
+    pub picked_up_at: Option<DateTime<Utc>>,
+    pub config: Option<serde_json::Value>,
+    pub data: serde_json::Value,
+}
+
+impl Task {
+    pub fn task_id(&self) -> TaskId {
+        self.id.task_id
+    }
+
+    pub fn attempt(&self) -> i32 {
+        self.id.attempt
+    }
+
+    pub fn id(&self) -> TaskAttemptId {
+        self.id
+    }
+}
+
+impl AsRef<TaskAttemptId> for Task {
+    fn as_ref(&self) -> &TaskAttemptId {
+        &self.id
+    }
+}
+
+/// Status of an active (non-terminal) task.
+///
+/// Stored in the Postgres `task` table as a `task_intermediate_status` enum.
+#[derive(Debug, Copy, Clone, PartialEq, Hash, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "task_intermediate_status", rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
+pub enum TaskIntermediateStatus {
+    Scheduled,
+    Running,
+    ShouldStop,
+}
+
+/// Terminal task outcome, stored in `task_log.status`.
+#[derive(Debug, Copy, Clone, PartialEq, Hash, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "task_final_status", rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
+pub enum TaskOutcome {
+    Failed,
+    Cancelled,
+    Success,
+}
+
+/// Result of `check_and_heartbeat_task`: tells the worker whether to keep
+/// going, stop cleanly, or abort because the task is no longer active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[must_use]
+pub enum TaskCheckState {
+    /// External signal asked the worker to stop (e.g. via management API).
+    Stop,
+    /// Continue executing.
+    Continue,
+    /// The task is no longer active (e.g. cancelled, deleted, completed).
+    NotActive,
+}
+
+impl TaskCheckState {
+    pub fn should_terminate(&self) -> bool {
+        matches!(self, TaskCheckState::Stop | TaskCheckState::NotActive)
+    }
+
+    pub fn should_report_termination(&self) -> bool {
+        matches!(self, TaskCheckState::Stop)
+    }
+}
+
+/// Internal status passed to `record_task_*` for logging/formatting.
+#[derive(Debug, Clone)]
+pub enum Status<'a> {
+    Success(Option<&'a str>),
+    Failure(&'a str, i32),
+}
+
+impl std::fmt::Display for Status<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Status::Success(details) => write!(f, "success ({})", details.unwrap_or("")),
+            Status::Failure(details, _) => write!(f, "failure ({details})"),
+        }
+    }
+}
+
+// -- typed-task traits ------------------------------------------------------
+
+/// Per-queue static configuration. Mirrors lakekeeper's `TaskConfig`.
+pub trait TaskConfig: Serialize + DeserializeOwned + Clone + Send + Sync + 'static {
+    fn queue_name() -> &'static TaskQueueName;
+
+    fn max_time_since_last_heartbeat() -> Duration;
+
+    fn max_retries() -> i32 {
+        DEFAULT_MAX_RETRIES
+    }
+}
+
+/// Payload type for a queue. The framework only requires that it round-trips
+/// through JSON.
+pub trait TaskData: Clone + Serialize + DeserializeOwned + Send + Sync + 'static {}
+
+/// Optional progress / execution-detail payload published via heartbeats.
+pub trait TaskExecutionDetails:
+    Clone + Serialize + DeserializeOwned + Send + Sync + 'static
+{
+}


### PR DESCRIPTION
Introduce  (unitycatalog-tasks), a Postgres-backed background task queue framework for hosting catalog maintenance jobs (deferred deletes, log cleanup, credential rotation, etc.) — infrastructure only, no workers registered yet.

The architecture is ported from lakekeeper/lakekeeper's module (Apache-2.0) at commit 05cce57, with API surface kept close to upstream so an eventual extracted  crate could be swapped in mechanically. We carry our own copy because none of lakekeeper's crates are published, the task module isn't feature-isolated, and depending on the full  crate would drag in iceberg-rust, AWS/Azure/GCS SDKs, OpenFGA, vaultrs, and ~60 other transitive dependencies.

What's in this commit:

- : new crate
  - types, TaskStore trait, SpecializedTask wrapper, TaskQueueRegistry, TaskQueuesRunner, thiserror-based TaskError, README withttribution
- : Postgres-backed TaskStore implementation
  - migrations/06_tasks.{up,down}.sql with task / task_log / task_config
  - src/tasks.rs with SKIP LOCKED picker, bulk enqueue, heartbeat, success / retry / final-failure CTEs and sqlx::test integration tests

Adjustments vs upstream: dropped warehouse/project scoping, generic TaskEntity, no utoipa / OpenAPI / management endpoints / in-memory backend. Each ported source file carries an attribution comment pointing at the upstream file and commit SHA.

Co-authored-by: Isaac

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->