### PR TITLE
fix: correct authorization filtering and harden credential vending

### DIFF
--- a/crates/server/src/api/sharing/handler.rs
+++ b/crates/server/src/api/sharing/handler.rs
@@ -7,11 +7,11 @@ use unitycatalog_common::models::shares::v1::{
 };
 use unitycatalog_sharing_client::models::sharing::v1::{Share as SharingShare, *};
 
-use crate::Result;
 use crate::api::{RequestContext, SecuredAction, ShareHandler};
 use crate::policy::{Permission, Policy, process_resources};
 pub use crate::sharing::SharingHandler;
 use crate::store::ResourceStore;
+use crate::{Error, Result};
 
 #[async_trait::async_trait]
 pub trait SharingQueryHandler<Cx = RequestContext>: Send + Sync + 'static {
@@ -190,25 +190,35 @@ where
         })
     }
 
+    // The following three methods are served by `SharingQueryHandler`, not this
+    // trait — the sharing router binds them to that handler (see
+    // `rest/routers/sharing.rs`). They are unreachable in practice; return a
+    // graceful error rather than panicking should a caller invoke them directly.
     async fn get_table_version(
         &self,
         _request: GetTableVersionRequest,
         _context: Cx,
     ) -> Result<GetTableVersionResponse> {
-        unimplemented!("only method on SharingQueryHandler should be used")
+        Err(Error::NotImplemented(
+            "get_table_version is served by SharingQueryHandler",
+        ))
     }
     async fn get_table_metadata(
         &self,
         _request: GetTableMetadataRequest,
         _context: Cx,
     ) -> Result<QueryResponse> {
-        unimplemented!("only method on SharingQueryHandler should be used")
+        Err(Error::NotImplemented(
+            "get_table_metadata is served by SharingQueryHandler",
+        ))
     }
     async fn query_table(
         &self,
         _request: QueryTableRequest,
         _context: Cx,
     ) -> Result<QueryResponse> {
-        unimplemented!("only method on SharingQueryHandler should be used")
+        Err(Error::NotImplemented(
+            "query_table is served by SharingQueryHandler",
+        ))
     }
 }

--- a/crates/server/src/api/temporary_credentials.rs
+++ b/crates/server/src/api/temporary_credentials.rs
@@ -3,7 +3,7 @@ use unitycatalog_common::models::tables::v1::Table;
 use unitycatalog_common::models::temporary_credentials::v1::*;
 use unitycatalog_common::models::{ResourceIdent, ResourceRef};
 
-use super::{RequestContext, SecuredAction};
+use super::RequestContext;
 use crate::api::CredentialHandler;
 use crate::api::credentials::CredentialHandlerExt;
 pub use crate::codegen::temporary_credentials::TemporaryCredentialHandler;
@@ -13,6 +13,17 @@ use crate::services::location::StorageLocationUrl;
 use crate::services::object_store::find_external_location_for_url;
 use crate::store::ResourceStore;
 use crate::{Error, Result};
+
+/// The permission a vend operation requires from the policy.
+///
+/// Read-only vending requires [`Permission::Read`]; read-write vending requires
+/// [`Permission::Write`] so the policy can deny write access independently.
+fn required_permission(operation: VendOperation) -> Permission {
+    match operation {
+        VendOperation::Read => Permission::Read,
+        VendOperation::ReadWrite => Permission::Write,
+    }
+}
 
 /// Map the proto `operation` integer to a `VendOperation`.
 ///
@@ -49,10 +60,17 @@ impl<
         request: GenerateTemporaryPathCredentialsRequest,
         context: RequestContext,
     ) -> Result<TemporaryCredential> {
-        self.check_required(&request, &context).await?;
         let operation = to_vend_operation(request.operation);
         let storage_url = StorageLocationUrl::parse(&request.url)?;
         let ext_loc = find_external_location_for_url(&storage_url, self).await?;
+        // Authorize against the concrete external location and the operation
+        // actually requested, rather than the unscoped `SecuredAction` default.
+        self.authorize_checked(
+            &(&ext_loc).into(),
+            &required_permission(operation),
+            &context,
+        )
+        .await?;
         let credential = self
             .get_credential_internal(GetCredentialRequest {
                 name: ext_loc.credential_name.clone(),
@@ -87,13 +105,15 @@ impl<
         request: GenerateTemporaryTableCredentialsRequest,
         context: RequestContext,
     ) -> Result<TemporaryCredential> {
-        self.check_required(&request, &context).await?;
         let operation = to_vend_operation(request.operation);
         let table_id = uuid::Uuid::parse_str(&request.table_id)
             .map_err(|_| Error::invalid_argument("table_id is not a valid UUID"))?;
-        let (resource, _) = self
-            .get(&ResourceIdent::Table(ResourceRef::Uuid(table_id)))
+        // Authorize against the concrete table and the operation actually
+        // requested, rather than the unscoped `SecuredAction` default.
+        let table_ident = ResourceIdent::Table(ResourceRef::Uuid(table_id));
+        self.authorize_checked(&table_ident, &required_permission(operation), &context)
             .await?;
+        let (resource, _) = self.get(&table_ident).await?;
         let table: Table = resource.try_into()?;
         let location = table
             .storage_location
@@ -108,33 +128,8 @@ impl<
         vend_credential(&credential, &location, operation).await
     }
 }
-
-impl SecuredAction for GenerateTemporaryPathCredentialsRequest {
-    fn resource(&self) -> ResourceIdent {
-        ResourceIdent::external_location(ResourceRef::Undefined)
-    }
-
-    fn permission(&self) -> &'static Permission {
-        &Permission::Read
-    }
-}
-
-impl SecuredAction for GenerateTemporaryTableCredentialsRequest {
-    fn resource(&self) -> ResourceIdent {
-        ResourceIdent::table(ResourceRef::Undefined)
-    }
-
-    fn permission(&self) -> &'static Permission {
-        &Permission::Read
-    }
-}
-
-impl SecuredAction for GenerateTemporaryVolumeCredentialsRequest {
-    fn resource(&self) -> ResourceIdent {
-        ResourceIdent::volume(ResourceRef::Undefined)
-    }
-
-    fn permission(&self) -> &'static Permission {
-        &Permission::Read
-    }
-}
+// NOTE: These request types intentionally do not implement `SecuredAction`.
+// Authorization is performed inside the handlers against the *concrete* resolved
+// resource (external location / table) and the *requested* operation
+// (read vs. read-write), which a static `SecuredAction` impl cannot express.
+// See `generate_temporary_path_credentials` / `generate_temporary_table_credentials`.

--- a/crates/server/src/handlers/upstream.rs
+++ b/crates/server/src/handlers/upstream.rs
@@ -249,12 +249,13 @@ impl<Cx: Send + Sync + 'static> TableHandler<Cx> for UpstreamTableHandler<Cx> {
             .iter()
             .map(|t| ResourceIdent::table(ResourceName::from_naive_str_split(&t.full_name)))
             .collect();
-        let mut decisions = self
+        let decisions = self
             .policy
             .authorize_many(&idents, &Permission::Read, &context)
             .await?;
-        resp.tables
-            .retain(|_| decisions.pop() == Some(Decision::Allow));
+        // `decisions[i]` corresponds to `resp.tables[i]`; pair in forward order.
+        let mut allow = decisions.into_iter().map(|d| d == Decision::Allow);
+        resp.tables.retain(|_| allow.next().unwrap_or(false));
         Ok(resp)
     }
 

--- a/crates/server/src/policy/mod.rs
+++ b/crates/server/src/policy/mod.rs
@@ -166,7 +166,82 @@ pub async fn filter_authorized<Cx: Send + Sync + 'static, R: ResourceExt + Send>
     resources: &mut Vec<R>,
 ) -> Result<()> {
     let res = resources.iter().map(|r| r.into()).collect::<Vec<_>>();
-    let mut decisions = policy.authorize_many(&res, permission, context).await?;
-    resources.retain(|_| decisions.pop() == Some(Decision::Allow));
+    let decisions = policy.authorize_many(&res, permission, context).await?;
+    // `decisions[i]` corresponds to `resources[i]`; pair them in forward order.
+    let mut allow = decisions.into_iter().map(|d| d == Decision::Allow);
+    resources.retain(|_| allow.next().unwrap_or(false));
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use unitycatalog_common::models::{ResourceName, ResourceRef, resource_name};
+
+    /// Minimal resource carrying a share name, for exercising [`filter_authorized`].
+    #[derive(Debug, Clone, PartialEq)]
+    struct TestShare(&'static str);
+
+    impl ResourceExt for TestShare {
+        fn resource_name(&self) -> ResourceName {
+            ResourceName::new([self.0])
+        }
+        fn resource_ref(&self) -> ResourceRef {
+            ResourceRef::Name(self.resource_name())
+        }
+        fn resource_ident(&self) -> ResourceIdent {
+            ResourceIdent::share(self.resource_name())
+        }
+    }
+
+    /// Policy that allows only resources whose ident matches one of `allow`,
+    /// and denies everything else — i.e. a non-uniform per-resource decision.
+    struct AllowListPolicy {
+        allow: Vec<ResourceIdent>,
+    }
+
+    #[async_trait::async_trait]
+    impl Policy<()> for AllowListPolicy {
+        async fn authorize(
+            &self,
+            resource: &ResourceIdent,
+            _permission: &Permission,
+            _context: &(),
+        ) -> Result<Decision> {
+            Ok(if self.allow.contains(resource) {
+                Decision::Allow
+            } else {
+                Decision::Deny
+            })
+        }
+    }
+
+    /// Regression test for the reversed decision mapping bug: a non-uniform
+    /// policy must filter the *correct* resources, in their original order.
+    /// Before the fix, decisions were consumed back-to-front via `pop()`, so
+    /// resource `i` was matched against decision `n-1-i`.
+    #[tokio::test]
+    async fn filter_authorized_pairs_decision_with_correct_resource() {
+        let policy = AllowListPolicy {
+            allow: vec![
+                ResourceIdent::share(resource_name!("a")),
+                ResourceIdent::share(resource_name!("c")),
+            ],
+        };
+
+        // Asymmetric layout so a reversed mapping yields a different result:
+        // allowed at indices 0 and 2, denied at 1 and 3.
+        let mut resources = vec![
+            TestShare("a"),
+            TestShare("b"),
+            TestShare("c"),
+            TestShare("d"),
+        ];
+
+        filter_authorized(&policy, &(), &Permission::Read, &mut resources)
+            .await
+            .unwrap();
+
+        assert_eq!(resources, vec![TestShare("a"), TestShare("c")]);
+    }
 }

--- a/crates/server/src/services/credential_vending.rs
+++ b/crates/server/src/services/credential_vending.rs
@@ -100,18 +100,36 @@ fn build_s3_session_policy(bucket: &str, prefix: &str, operation: VendOperation)
     };
     let bucket_arn = format!("arn:aws:s3:::{bucket}");
 
-    let actions = match operation {
-        VendOperation::Read => {
-            r#"["s3:GetObject","s3:GetObjectVersion","s3:ListBucket","s3:GetBucketLocation"]"#
-        }
-        VendOperation::ReadWrite => {
-            r#"["s3:GetObject","s3:GetObjectVersion","s3:PutObject","s3:DeleteObject","s3:ListBucket","s3:GetBucketLocation"]"#
-        }
+    let actions: &[&str] = match operation {
+        VendOperation::Read => &[
+            "s3:GetObject",
+            "s3:GetObjectVersion",
+            "s3:ListBucket",
+            "s3:GetBucketLocation",
+        ],
+        VendOperation::ReadWrite => &[
+            "s3:GetObject",
+            "s3:GetObjectVersion",
+            "s3:PutObject",
+            "s3:DeleteObject",
+            "s3:ListBucket",
+            "s3:GetBucketLocation",
+        ],
     };
 
-    format!(
-        r#"{{"Version":"2012-10-17","Statement":[{{"Effect":"Allow","Action":{actions},"Resource":["{object_arn}","{bucket_arn}"]}}]}}"#
-    )
+    // Build via `serde_json` so `bucket`/`prefix` (which derive from
+    // caller-influenced input) are JSON-escaped. Hand-formatting this document
+    // would let a crafted prefix break out of the `Resource` array and broaden
+    // the session policy — defeating the downscoping this is meant to enforce.
+    serde_json::json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Action": actions,
+            "Resource": [object_arn, bucket_arn],
+        }],
+    })
+    .to_string()
 }
 
 /// Generate a temporary credential for the given `Credential` and storage `url`,
@@ -398,6 +416,38 @@ mod tests {
         assert!(
             policy.contains("arn:aws:s3:::my-bucket/*"),
             "missing wildcard ARN"
+        );
+    }
+
+    #[test]
+    fn test_s3_session_policy_escapes_injection_in_prefix() {
+        // A prefix containing JSON metacharacters must not break out of the
+        // document. The result must remain valid JSON with exactly one
+        // statement (no injected Allow/Action entries).
+        let malicious =
+            r#"x"],"Resource":["*"}],"Statement":[{"Effect":"Allow","Action":["*"],"Resource":["*"#;
+        let policy = build_s3_session_policy("my-bucket", malicious, VendOperation::Read);
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&policy).expect("session policy must be valid JSON");
+        let statements = parsed["Statement"]
+            .as_array()
+            .expect("Statement must be an array");
+        assert_eq!(
+            statements.len(),
+            1,
+            "injected prefix must not add statements"
+        );
+        // The whole malicious string is escaped inside the single Resource ARN.
+        let resources = statements[0]["Resource"]
+            .as_array()
+            .expect("Resource must be an array");
+        assert!(
+            resources[0]
+                .as_str()
+                .unwrap()
+                .contains(&format!("my-bucket/{malicious}/*")),
+            "prefix must be contained verbatim within the object ARN"
         );
     }
 

--- a/crates/server/src/services/object_store.rs
+++ b/crates/server/src/services/object_store.rs
@@ -68,17 +68,30 @@ pub(crate) async fn find_external_location_for_url(
             let Ok(ext_loc_url) = StorageLocationUrl::parse(&l.url) else {
                 return false;
             };
-            location
-                .raw()
-                .as_str()
-                .starts_with(ext_loc_url.raw().as_str())
-                || location
-                    .location()
-                    .as_str()
-                    .starts_with(ext_loc_url.location().as_str())
+            is_path_prefix(location.raw().as_str(), ext_loc_url.raw().as_str())
+                || is_path_prefix(
+                    location.location().as_str(),
+                    ext_loc_url.location().as_str(),
+                )
         })
         .max_by(|l, r| l.url.len().cmp(&r.url.len()))
         .ok_or(Error::NotFound)
+}
+
+/// Whether `prefix` is a path-segment prefix of `url`.
+///
+/// Unlike a raw `starts_with`, this respects path boundaries so that a location
+/// registered for `s3://bucket/data` does **not** match `s3://bucket/data-secret/x`
+/// (which `starts_with` alone would wrongly accept). A match requires either an
+/// exact equality or that the character immediately after `prefix` is a `/`.
+/// A trailing `/` on `prefix` is normalized away first.
+fn is_path_prefix(url: &str, prefix: &str) -> bool {
+    let prefix = prefix.strip_suffix('/').unwrap_or(prefix);
+    match url.strip_prefix(prefix) {
+        Some("") => true,
+        Some(rest) => rest.starts_with('/'),
+        None => false,
+    }
 }
 
 pub(crate) async fn get_object_store(
@@ -171,4 +184,26 @@ fn get_azure_store(
     }
 
     Ok(Arc::new(builder.build()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_path_prefix;
+
+    #[test]
+    fn path_prefix_matches_exact_and_subpaths() {
+        assert!(is_path_prefix("s3://bucket/data", "s3://bucket/data"));
+        assert!(is_path_prefix("s3://bucket/data/file", "s3://bucket/data"));
+        assert!(is_path_prefix("s3://bucket/data/x/y", "s3://bucket/data/"));
+    }
+
+    #[test]
+    fn path_prefix_rejects_sibling_prefix() {
+        // The classic over-match: `data` must not match `data-secret`.
+        assert!(!is_path_prefix(
+            "s3://bucket/data-secret/file",
+            "s3://bucket/data"
+        ));
+        assert!(!is_path_prefix("s3://bucket/database", "s3://bucket/data"));
+    }
 }


### PR DESCRIPTION
## Summary

Addresses security/correctness issues found during a repo health review.

- **Authorization filtering (critical):** `filter_authorized` paired each resource with the *wrong* decision — decisions were collected forward but consumed via `pop()` (back-to-front) inside `retain` (front-to-back), so resource `i` matched decision `n-1-i`. Masked today by the uniform `ConstantPolicy`, but any per-resource policy would filter the wrong rows. Fixed here and in the duplicated inline block in `upstream.rs`.
- **S3 session policy injection:** `build_s3_session_policy` interpolated caller-influenced `bucket`/`prefix` into the STS session-policy JSON via `format!`, letting a crafted prefix break out of the `Resource` array and broaden the downscoped policy. Now built with `serde_json` so values are escaped.
- **Credential-vending authorization granularity:** path/table vending authorized against an `Undefined` resource with a hardcoded `Read` permission. Now authorizes against the concrete external location / table and reflects the requested read-vs-write operation, so the policy layer can actually scope which resource and operation is granted.
- **Path-prefix over-matching:** `find_external_location_for_url` used raw `starts_with`, letting a location for `s3://bucket/data` over-match `s3://bucket/data-secret`. Added a path-boundary-aware prefix check.
- **Panic hardening:** replaced unreachable `unimplemented!()` panics in the `SharingHandler` table-query methods (served by `SharingQueryHandler`) with a graceful `NotImplemented` error.

## Test plan

- [x] `cargo test -p unitycatalog-server` — 22 passing, incl. new regression tests
- [x] New `filter_authorized` test verified to FAIL against the old `pop()` impl and pass after the fix
- [x] New S3 session-policy injection test
- [x] New `is_path_prefix` tests (exact / subpath / sibling-rejection)
- [x] `cargo clippy -p unitycatalog-server` and `cargo check --workspace` clean

## Follow-ups

- #127 — move store/secret traits out of `server` (postgres→server dependency inversion)
- #128 — dedup error→`IntoResponse` mapping; finish AxumPath/AxumQuery removal
- #129 — broader policy / sharing-client / object-store test coverage

This pull request and its description were written by Isaac.