### PR TITLE
refactor: dedup error->IntoResponse mapping and finish AxumPath/AxumQuery removal (#128)

### DIFF
--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -57,3 +57,65 @@ impl Error {
         }
     }
 }
+
+#[cfg(feature = "axum")]
+impl Error {
+    /// Maps this error to an HTTP status and a static client-facing message.
+    ///
+    /// Shared by downstream `IntoResponse` impls (server, sharing-client) so the
+    /// status/message table for common variants lives in one place. Callers
+    /// remain responsible for composing the `error_code` and wrapping the result
+    /// in their own `ErrorResponse` body.
+    pub fn response_parts(&self) -> (http::StatusCode, &'static str) {
+        use http::StatusCode;
+
+        const INTERNAL: &str = "The request is not handled correctly due to a server error.";
+        const INVALID: &str = "Invalid argument provided in the request.";
+        const NOT_FOUND: &str = "The requested resource does not exist.";
+        const ALREADY_EXISTS: &str = "The resource already exists.";
+
+        match self {
+            Error::NotFound => (StatusCode::NOT_FOUND, NOT_FOUND),
+            Error::InvalidArgument(msg) => {
+                tracing::error!("Invalid argument: {msg}");
+                (StatusCode::BAD_REQUEST, INVALID)
+            }
+            Error::InvalidIdentifier(e) => {
+                tracing::error!("Invalid identifier: {e}");
+                (StatusCode::BAD_REQUEST, INVALID)
+            }
+            Error::InvalidTableLocation(loc) => {
+                tracing::error!("Invalid table location: {loc}");
+                (StatusCode::BAD_REQUEST, INVALID)
+            }
+            Error::InvalidUrl(e) => {
+                tracing::error!("Invalid URL: {e}");
+                (StatusCode::BAD_REQUEST, INVALID)
+            }
+            Error::SerDe(e) => {
+                tracing::error!("Serialization error: {e}");
+                (StatusCode::INTERNAL_SERVER_ERROR, INTERNAL)
+            }
+            Error::Generic(msg) => {
+                tracing::error!("Generic common error: {msg}");
+                (StatusCode::INTERNAL_SERVER_ERROR, INTERNAL)
+            }
+            Error::ResourceStore(e) => match e {
+                olai_store::Error::NotFound => (StatusCode::NOT_FOUND, NOT_FOUND),
+                olai_store::Error::AlreadyExists => (StatusCode::CONFLICT, ALREADY_EXISTS),
+                olai_store::Error::InvalidArgument(msg) => {
+                    tracing::error!("Invalid argument: {msg}");
+                    (StatusCode::BAD_REQUEST, INVALID)
+                }
+                olai_store::Error::InvalidIdentifier(e) => {
+                    tracing::error!("Invalid identifier: {e}");
+                    (StatusCode::BAD_REQUEST, INVALID)
+                }
+                _ => {
+                    tracing::error!("Resource store error: {e}");
+                    (StatusCode::INTERNAL_SERVER_ERROR, INTERNAL)
+                }
+            },
+        }
+    }
+}

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -133,57 +133,7 @@ impl IntoResponse for Error {
         let error_code = self.error_code().to_string();
         let (status, message) = match self {
             Error::Common { source } => {
-                let (status, message) = match &source {
-                    unitycatalog_common::Error::NotFound => (
-                        StatusCode::NOT_FOUND,
-                        "The requested resource does not exist.",
-                    ),
-                    unitycatalog_common::Error::InvalidArgument(msg) => {
-                        error!("Invalid argument: {}", msg);
-                        INVALID_ARGUMENT
-                    }
-                    unitycatalog_common::Error::InvalidIdentifier(e) => {
-                        error!("Invalid identifier: {}", e);
-                        INVALID_ARGUMENT
-                    }
-                    unitycatalog_common::Error::InvalidTableLocation(loc) => {
-                        error!("Invalid table location: {}", loc);
-                        INVALID_ARGUMENT
-                    }
-                    unitycatalog_common::Error::InvalidUrl(e) => {
-                        error!("Invalid URL: {}", e);
-                        INVALID_ARGUMENT
-                    }
-                    unitycatalog_common::Error::SerDe(e) => {
-                        error!("Serialization error: {}", e);
-                        INTERNAL_ERROR
-                    }
-                    unitycatalog_common::Error::Generic(msg) => {
-                        error!("Generic common error: {}", msg);
-                        INTERNAL_ERROR
-                    }
-                    unitycatalog_common::Error::ResourceStore(e) => match e {
-                        olai_store::Error::NotFound => (
-                            StatusCode::NOT_FOUND,
-                            "The requested resource does not exist.",
-                        ),
-                        olai_store::Error::AlreadyExists => {
-                            (StatusCode::CONFLICT, "The resource already exists.")
-                        }
-                        olai_store::Error::InvalidArgument(msg) => {
-                            error!("Invalid argument: {}", msg);
-                            INVALID_ARGUMENT
-                        }
-                        olai_store::Error::InvalidIdentifier(e) => {
-                            error!("Invalid identifier: {}", e);
-                            INVALID_ARGUMENT
-                        }
-                        _ => {
-                            error!("Resource store error: {}", e);
-                            INTERNAL_ERROR
-                        }
-                    },
-                };
+                let (status, message) = source.response_parts();
                 return (
                     status,
                     Json(ErrorResponse {
@@ -356,11 +306,7 @@ impl From<Error> for Status {
                 }
                 olai_store::Error::InvalidArgument(msg) => Status::invalid_argument(msg),
                 _ => Status::internal(format!("Resource store error: {source}")),
-            }, // Error::RequestError(error) => Status::internal(error.to_string()),
-               // #[cfg(feature = "axum")]
-               // Error::AxumPath(rejection) => Status::internal(format!("Axum path: {}", rejection)),
-               // #[cfg(feature = "axum")]
-               // Error::AxumQuery(rejection) => Status::internal(format!("Axum query: {}", rejection)),
+            },
         }
     }
 }

--- a/crates/sharing-client/Cargo.toml
+++ b/crates/sharing-client/Cargo.toml
@@ -30,4 +30,4 @@ url = { workspace = true }
 
 [features]
 default = []
-server = ["axum", "axum-extra"]
+server = ["axum", "axum-extra", "unitycatalog-common/axum"]

--- a/crates/sharing-client/src/codegen/sharing/server.rs
+++ b/crates/sharing-client/src/codegen/sharing/server.rs
@@ -4,7 +4,7 @@ use crate::models::sharing::v1::*;
 use axum::{RequestExt, RequestPartsExt};
 
 impl<S: Send + Sync> axum::extract::FromRequestParts<S> for ListSharesRequest {
-    type Rejection = crate::Error;
+    type Rejection = axum::response::Response;
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
         _state: &S,
@@ -21,7 +21,8 @@ impl<S: Send + Sync> axum::extract::FromRequestParts<S> for ListSharesRequest {
             page_token,
         }) = parts
             .extract::<axum_extra::extract::Query<QueryParams>>()
-            .await?;
+            .await
+            .map_err(axum::response::IntoResponse::into_response)?;
         Ok(ListSharesRequest {
             max_results,
             page_token,
@@ -30,23 +31,29 @@ impl<S: Send + Sync> axum::extract::FromRequestParts<S> for ListSharesRequest {
 }
 
 impl<S: Send + Sync> axum::extract::FromRequestParts<S> for GetShareRequest {
-    type Rejection = crate::Error;
+    type Rejection = axum::response::Response;
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
         _state: &S,
     ) -> Result<Self, Self::Rejection> {
-        let axum::extract::Path(name) = parts.extract::<axum::extract::Path<String>>().await?;
+        let axum::extract::Path(name) = parts
+            .extract::<axum::extract::Path<String>>()
+            .await
+            .map_err(axum::response::IntoResponse::into_response)?;
         Ok(GetShareRequest { name })
     }
 }
 
 impl<S: Send + Sync> axum::extract::FromRequestParts<S> for ListSchemasRequest {
-    type Rejection = crate::Error;
+    type Rejection = axum::response::Response;
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
         _state: &S,
     ) -> Result<Self, Self::Rejection> {
-        let axum::extract::Path(share) = parts.extract::<axum::extract::Path<String>>().await?;
+        let axum::extract::Path(share) = parts
+            .extract::<axum::extract::Path<String>>()
+            .await
+            .map_err(axum::response::IntoResponse::into_response)?;
         #[derive(serde::Deserialize)]
         struct QueryParams {
             #[serde(default)]
@@ -59,7 +66,8 @@ impl<S: Send + Sync> axum::extract::FromRequestParts<S> for ListSchemasRequest {
             page_token,
         }) = parts
             .extract::<axum_extra::extract::Query<QueryParams>>()
-            .await?;
+            .await
+            .map_err(axum::response::IntoResponse::into_response)?;
         Ok(ListSchemasRequest {
             share,
             max_results,
@@ -69,14 +77,15 @@ impl<S: Send + Sync> axum::extract::FromRequestParts<S> for ListSchemasRequest {
 }
 
 impl<S: Send + Sync> axum::extract::FromRequestParts<S> for ListTablesRequest {
-    type Rejection = crate::Error;
+    type Rejection = axum::response::Response;
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
         _state: &S,
     ) -> Result<Self, Self::Rejection> {
         let axum::extract::Path((share, name)) = parts
             .extract::<axum::extract::Path<(String, String)>>()
-            .await?;
+            .await
+            .map_err(axum::response::IntoResponse::into_response)?;
         #[derive(serde::Deserialize)]
         struct QueryParams {
             #[serde(default)]
@@ -89,7 +98,8 @@ impl<S: Send + Sync> axum::extract::FromRequestParts<S> for ListTablesRequest {
             page_token,
         }) = parts
             .extract::<axum_extra::extract::Query<QueryParams>>()
-            .await?;
+            .await
+            .map_err(axum::response::IntoResponse::into_response)?;
         Ok(ListTablesRequest {
             share,
             name,
@@ -100,12 +110,15 @@ impl<S: Send + Sync> axum::extract::FromRequestParts<S> for ListTablesRequest {
 }
 
 impl<S: Send + Sync> axum::extract::FromRequestParts<S> for ListAllTablesRequest {
-    type Rejection = crate::Error;
+    type Rejection = axum::response::Response;
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
         _state: &S,
     ) -> Result<Self, Self::Rejection> {
-        let axum::extract::Path(name) = parts.extract::<axum::extract::Path<String>>().await?;
+        let axum::extract::Path(name) = parts
+            .extract::<axum::extract::Path<String>>()
+            .await
+            .map_err(axum::response::IntoResponse::into_response)?;
         #[derive(serde::Deserialize)]
         struct QueryParams {
             #[serde(default)]
@@ -118,7 +131,8 @@ impl<S: Send + Sync> axum::extract::FromRequestParts<S> for ListAllTablesRequest
             page_token,
         }) = parts
             .extract::<axum_extra::extract::Query<QueryParams>>()
-            .await?;
+            .await
+            .map_err(axum::response::IntoResponse::into_response)?;
         Ok(ListAllTablesRequest {
             name,
             max_results,
@@ -128,14 +142,15 @@ impl<S: Send + Sync> axum::extract::FromRequestParts<S> for ListAllTablesRequest
 }
 
 impl<S: Send + Sync> axum::extract::FromRequestParts<S> for GetTableVersionRequest {
-    type Rejection = crate::Error;
+    type Rejection = axum::response::Response;
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
         _state: &S,
     ) -> Result<Self, Self::Rejection> {
         let axum::extract::Path((share, schema, name)) = parts
             .extract::<axum::extract::Path<(String, String, String)>>()
-            .await?;
+            .await
+            .map_err(axum::response::IntoResponse::into_response)?;
         #[derive(serde::Deserialize)]
         struct QueryParams {
             #[serde(default)]
@@ -143,7 +158,8 @@ impl<S: Send + Sync> axum::extract::FromRequestParts<S> for GetTableVersionReque
         }
         let axum_extra::extract::Query(QueryParams { starting_timestamp }) = parts
             .extract::<axum_extra::extract::Query<QueryParams>>()
-            .await?;
+            .await
+            .map_err(axum::response::IntoResponse::into_response)?;
         Ok(GetTableVersionRequest {
             share,
             schema,
@@ -154,14 +170,15 @@ impl<S: Send + Sync> axum::extract::FromRequestParts<S> for GetTableVersionReque
 }
 
 impl<S: Send + Sync> axum::extract::FromRequestParts<S> for GetTableMetadataRequest {
-    type Rejection = crate::Error;
+    type Rejection = axum::response::Response;
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
         _state: &S,
     ) -> Result<Self, Self::Rejection> {
         let axum::extract::Path((share, schema, name)) = parts
             .extract::<axum::extract::Path<(String, String, String)>>()
-            .await?;
+            .await
+            .map_err(axum::response::IntoResponse::into_response)?;
         Ok(GetTableMetadataRequest {
             share,
             schema,

--- a/crates/sharing-client/src/error.rs
+++ b/crates/sharing-client/src/error.rs
@@ -43,14 +43,6 @@ pub enum Error {
 
     #[error("Generic error: {0}")]
     Generic(String),
-
-    #[cfg(feature = "server")]
-    #[error("Axum path: {0}")]
-    AxumPath(#[from] axum::extract::rejection::PathRejection),
-
-    #[cfg(feature = "server")]
-    #[error("Axum query: {0}")]
-    AxumQuery(#[from] axum_extra::extract::QueryRejection),
 }
 
 impl Error {
@@ -74,21 +66,15 @@ impl Error {
     }
 }
 
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ErrorResponse {
-    pub error_code: String,
-    pub message: String,
-}
-
 #[cfg(feature = "server")]
 mod server {
     use axum::extract::Json;
     use axum::http::StatusCode;
     use axum::response::{IntoResponse, Response};
     use tracing::error;
+    use unitycatalog_common::ErrorResponse;
 
-    use super::{Error, ErrorResponse};
+    use super::Error;
 
     const INTERNAL_ERROR: (StatusCode, &str) = (
         StatusCode::INTERNAL_SERVER_ERROR,
@@ -105,32 +91,7 @@ mod server {
             let error_code = self.error_code().to_string();
             let (status, message) = match self {
                 Error::Common { source } => {
-                    let (status, message) = match &source {
-                        unitycatalog_common::Error::NotFound => (
-                            StatusCode::NOT_FOUND,
-                            "The requested resource does not exist.",
-                        ),
-                        unitycatalog_common::Error::InvalidArgument(msg) => {
-                            error!("Invalid argument: {}", msg);
-                            INVALID_ARGUMENT
-                        }
-                        unitycatalog_common::Error::InvalidIdentifier(e) => {
-                            error!("Invalid identifier: {}", e);
-                            INVALID_ARGUMENT
-                        }
-                        unitycatalog_common::Error::InvalidTableLocation(loc) => {
-                            error!("Invalid table location: {}", loc);
-                            INVALID_ARGUMENT
-                        }
-                        unitycatalog_common::Error::InvalidUrl(e) => {
-                            error!("Invalid URL: {}", e);
-                            INVALID_ARGUMENT
-                        }
-                        _ => {
-                            error!("Common error: {}", source);
-                            INTERNAL_ERROR
-                        }
-                    };
+                    let (status, message) = source.response_parts();
                     return (
                         status,
                         Json(ErrorResponse {
@@ -174,14 +135,6 @@ mod server {
                 Error::Generic(message) => {
                     error!("Generic error: {}", message);
                     INTERNAL_ERROR
-                }
-                Error::AxumPath(rejection) => {
-                    error!("Path extraction error: {}", rejection);
-                    (StatusCode::BAD_REQUEST, "Invalid path parameter.")
-                }
-                Error::AxumQuery(rejection) => {
-                    error!("Query extraction error: {}", rejection);
-                    (StatusCode::BAD_REQUEST, "Invalid query parameter.")
                 }
             };
 


### PR DESCRIPTION
## Summary

Dedups the duplicated error→`IntoResponse` mapping across `server` and
`sharing-client`, and finishes the AxumPath/AxumQuery removal that #71
completed for `common` but never applied to `sharing-client`.

- **common**: add `Error::response_parts()` (gated on the `axum` feature)
  mapping each variant to `(http::StatusCode, &'static str)`. A mapping fn —
  not a full `IntoResponse` impl — so callers keep owning their `error_code`
  and `ErrorResponse` wrapping, preserving the decoupling #71 established.
- **server / sharing-client**: replace the duplicated `Error::Common` arms with
  `source.response_parts()`.
- **sharing-client**: drop the local `ErrorResponse` copy in favor of
  `unitycatalog_common::ErrorResponse`; remove the `AxumPath`/`AxumQuery`
  variants and their response arms; enable `unitycatalog-common/axum` from the
  `server` feature so `response_parts` resolves.
- **sharing-client codegen**: migrate the 7 `FromRequestParts` extractors in
  `codegen/sharing/server.rs` to `type Rejection = axum::response::Response` +
  `.map_err(IntoResponse::into_response)?`, matching current trestle output and
  the already-migrated `FromRequest` impl in the same file. This file is an
  orphaned generated artifact (no `just generate` target regenerates it) — see
  follow-up #133.
- **server**: delete the dead commented-out gRPC AxumPath/AxumQuery arms.

## Behavior change

sharing-client now maps common `ResourceStore::NotFound` → 404 and
`AlreadyExists` → 409 (previously 500 via a catch-all), aligning with server.

## Test plan

- [x] `cargo check -p unitycatalog-common` (with and without `--features axum`)
- [x] `cargo clippy -p unitycatalog-common --features axum -- -D warnings`
- [x] `cargo check -p unitycatalog-server` (default + `--features grpc`)
- [x] `cargo check -p unitycatalog-sharing-client` (default + `--features server`)
- [x] `cargo check --workspace`
- [x] `cargo test --workspace` — all pass

(Pre-existing `large_enum_variant` clippy errors in generated model code and the
`--all-features` build failure both reproduce on `main` and are unrelated.)

Closes #128
Refs #133

AI-assisted by Isaac