### PR TITLE
fix: unblock node CI unit tests and spell-check

### DIFF
--- a/.github/workflows/node-ci.yaml
+++ b/.github/workflows/node-ci.yaml
@@ -35,7 +35,10 @@ jobs:
         working-directory: node/client
 
       - name: Build NAPI binding
-        run: npx napi build --platform --release
+        # Regenerate the TypeScript declarations (`--dts`) so a stale committed
+        # `native.d.ts` cannot silently break `tsc` when the Rust NAPI surface
+        # changes; the type definitions are always rebuilt from the binding.
+        run: npx napi build --platform --release --dts unitycatalog/native.d.ts
         working-directory: node/client
 
       - name: Compile TypeScript

--- a/crates/common/src/reference.rs
+++ b/crates/common/src/reference.rs
@@ -12,7 +12,7 @@
 //! |------------------------------------------------------------|--------------------------------|
 //! | `uc:///Volumes/<catalog>/<schema>/<volume>[/<path>]`       | `temporary-volume-credentials` |
 //! | `uc:///Tables/<catalog>/<schema>/<table>`                  | `temporary-table-credentials`  |
-//! | `s3://`, `s3a://`, `gs://`, `abfs(s)://`, `az(ure)://`, `r2://` raw cloud URL | `temporary-path-credentials` |
+//! | `s3://`, `s3a://`, `gs://`, `abfs://`, `abfss://`, `az://`, `azure://`, `r2://` raw cloud URL | `temporary-path-credentials` |
 //!
 //! For ecosystem compatibility, the parser also accepts the
 //! `vol+dbfs:/Volumes/<catalog>/<schema>/<volume>[/<path>]` form used by

--- a/node/client/__test__/index.test.ts
+++ b/node/client/__test__/index.test.ts
@@ -131,7 +131,7 @@ describe("UnityCatalogClient", () => {
     });
 
     it("returns a TableClient", () => {
-      const table = client.table("my-table");
+      const table = client.table("my-catalog", "my-schema", "my-table");
       expect(table).toBeInstanceOf(TableClient);
     });
   });
@@ -166,7 +166,7 @@ describe("UnityCatalogClient", () => {
     });
 
     it("TableClient has get, delete", () => {
-      const table = client.table("my-table");
+      const table = client.table("cat", "sch", "tbl");
       expect(table.get).toBeDefined();
       expect(table.delete).toBeDefined();
     });

--- a/node/client/unitycatalog/native.d.ts
+++ b/node/client/unitycatalog/native.d.ts
@@ -87,7 +87,7 @@ export declare class NapiUnityCatalogClient {
   recipient(name: string): NapiRecipientClient
   schema(catalogName: string, schemaName: string): NapiSchemaClient
   share(name: string): NapiShareClient
-  table(name: string): NapiTableClient
+  table(catalogName: string, schemaName: string, tableName: string): NapiTableClient
   volume(catalogName: string, schemaName: string, volumeName: string): NapiVolumeClient
 }
 


### PR DESCRIPTION
## Summary

Two unrelated pre-existing failures were red on `node-ci` / `pr` for every PR.
Both are fixed here; neither was caused by the failing PR that surfaced them.

**1. `node-unit-tests` failed at `tsc`** — the committed generated
`native.d.ts` was stale: `NapiUnityCatalogClient.table()` was declared with one
arg, but the Rust NAPI binding and the generated TS wrapper both use three
(`catalogName, schemaName, tableName`). The CI build ran `napi build` *without*
`--dts`, so it never regenerated the declarations and could not self-correct.

- regenerate `native.d.ts` so `table()` matches the 3-arg NAPI signature
- harden `node-ci.yaml` to build with `--dts unitycatalog/native.d.ts`, so the
  declarations are always rebuilt from the binding and a stale committed copy
  can no longer break `tsc`
- fix two stale `client.table("my-table")` calls in the unit test to the 3-arg
  form

**2. `spell-check` failed** on `az(ure)://` shorthand in `reference.rs` (typos
flagged `ure`). Reworded to explicit `az://`, `azure://` (and `abfs://`,
`abfss://`).

## Test plan

- [x] `npm run tsc` (node/client) — compiles
- [x] `npm run test` (node/client) — 31/31 unit tests pass
- [x] `npm run lint` (biome) — clean
- [x] `typos .` — clean
- [x] regenerated `native.d.ts` verified to match the Rust `table()` signature

## Not in scope — Node integration tests (#70)

`#70` (enable Node.js integration tests in CI) stays open. The infra works and a
job was drafted + validated locally, but the suite fails **20/38** against the
server for unrelated server-side reasons (`POST /credentials` → 400;
schema/table/volume/external-location create-mismatch + 404-on-get). Enabling
the job would keep CI red. Documented in #135.

Refs #70
Refs #135

AI-assisted by Isaac