### PR TITLE
feat: run journey tests against UC OSS (Java) in CI (#35)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,3 +39,37 @@ jobs:
 
       - name: Run tests
         run: cargo test --lib --bins --tests -- --nocapture
+
+  integration_oss_java:
+    name: integration-oss-java
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: true
+          rustflags: ""
+
+      - name: Start Unity Catalog OSS (Java) server
+        run: docker compose -f dev/uc-oss.compose.yaml up -d --wait
+
+      - name: Run journey tests against UC OSS (Java)
+        env:
+          UC_INTEGRATION_PROFILE: oss_java
+          UC_INTEGRATION_URL: http://localhost:8080
+        run: cargo test -p unitycatalog-acceptance -- journey_tests_live --nocapture
+
+      - name: Dump server logs
+        if: always()
+        run: docker compose -f dev/uc-oss.compose.yaml logs
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f dev/uc-oss.compose.yaml down -v

--- a/crates/acceptance/JOURNEY_CATALOG.md
+++ b/crates/acceptance/JOURNEY_CATALOG.md
@@ -102,7 +102,7 @@ All Tier 1 journeys are compatible with **all implementations** (`Implementation
 
 | Variable | Values | Description |
 |---|---|---|
-| `UC_INTEGRATION_PROFILE` | `oss_rust`, `managed_databricks` | Activates the `journey_tests_live` test with the named profile |
+| `UC_INTEGRATION_PROFILE` | `oss_rust`, `oss_java`, `managed_databricks` | Activates the `journey_tests_live` test with the named profile |
 
 ---
 
@@ -141,6 +141,27 @@ UC_INTEGRATION_PROFILE=oss_rust \
 UC_INTEGRATION_PROFILE=oss_rust \
   UC_INTEGRATION_URL=http://localhost:8080 \
   UC_INTEGRATION_RECORD=true \
+  cargo test -p unitycatalog-acceptance -- journey_tests_live
+```
+
+### Run against the open-source Java Unity Catalog server
+
+This boots the Java OSS server in Docker, waits for its healthcheck, and runs every
+journey compatible with the `OssJava` implementation tag. This is the same flow the
+`integration-oss-java` CI job runs.
+
+```bash
+just integration-oss-java
+
+# Tear down when done:
+docker compose -f dev/uc-oss.compose.yaml down -v
+```
+
+To run it by hand against an already-running Java server:
+
+```bash
+UC_INTEGRATION_PROFILE=oss_java \
+  UC_INTEGRATION_URL=http://localhost:8080 \
   cargo test -p unitycatalog-acceptance -- journey_tests_live
 ```
 
@@ -204,9 +225,9 @@ different payloads (e.g. three `POST /schemas` with different names).
 | `enhanced_catalog` | ✅ | ✅ | ✅ | ✅ |
 | `catalog_hierarchy` | ✅ | ✅ | ✅ | ✅ |
 | `schema_lifecycle` | ✅ | ✅ | ✅ | ✅ |
-| `table_managed_lifecycle` | ✅ | ✅ | ✅ | ✅ |
-| `volume_managed_lifecycle` | ✅ | ✅ | ✅ | ✅ |
-| `lakehouse_hierarchy` | ✅ | ✅ | ✅ | ✅ |
+| `table_managed_lifecycle` | — | ✅ | —¹ | ✅ |
+| `volume_managed_lifecycle` | — | ✅ | —² | ✅ |
+| `lakehouse_hierarchy` | — | ✅ | —¹ | ✅ |
 | `credential_lifecycle` | — | — | — | ✅ |
 | `external_location_lifecycle` | — | — | — | ✅ |
 | `volume_external_lifecycle` | — | — | — | ✅ |
@@ -217,3 +238,11 @@ different payloads (e.g. three `POST /schemas` with different names).
 | `share_lifecycle` | — | ✅ | — | ✅ |
 | `recipient_lifecycle` | — | ✅ | — | ✅ |
 | `function_lifecycle` | — | ✅ | — | ✅ |
+
+¹ The Java OSS server (`v0.4.1`, local file storage) returns `500 [INTERNAL]
+  "stagingLocation is null"` when creating MANAGED tables, so these journeys are
+  not OssJava-compatible without configured cloud storage.
+
+² The Java OSS server cannot deserialize the `VOLUME_TYPE_MANAGED` enum value our
+  client sends (it expects `MANAGED`) and returns a 500. Tracked as a
+  client/server wire-format follow-up.

--- a/crates/acceptance/src/execution/mod.rs
+++ b/crates/acceptance/src/execution/mod.rs
@@ -229,6 +229,21 @@ impl ImplementationProfile {
         }
     }
 
+    /// Profile for the Java OSS Unity Catalog implementation
+    pub fn oss_java(server_url: impl Into<String>) -> Self {
+        Self {
+            name: "oss_java".to_string(),
+            server_url: server_url.into(),
+            auth_token: None,
+            storage_root: "file:///tmp/uc-test/".to_string(),
+            filter: JourneyFilter {
+                implementation: Some(ImplementationTag::OssJava),
+                skip_external_storage: true,
+                ..Default::default()
+            },
+        }
+    }
+
     /// Profile for the Databricks managed Unity Catalog (reference implementation)
     pub fn managed_databricks(
         server_url: impl Into<String>,
@@ -751,10 +766,40 @@ impl JourneyExecutionResult {
 // JourneyConfig
 // ---------------------------------------------------------------------------
 
+/// How a journey is executed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionMode {
+    /// Replay recorded HTTP interactions against a mockito mock server. Journeys
+    /// without a recordings directory are skipped. No live server needed.
+    Replay,
+    /// Execute against a live server without recording. Used to validate clients
+    /// against a real implementation (e.g. the Java OSS server in CI).
+    Live,
+    /// Execute against a live server and record the interactions as new fixtures.
+    Record,
+}
+
+impl ExecutionMode {
+    /// Resolve the mode from the `UC_INTEGRATION_RECORD` environment variable
+    /// (`true` = [`Record`](Self::Record), otherwise [`Replay`](Self::Replay)).
+    fn from_record_env() -> Self {
+        if std::env::var("UC_INTEGRATION_RECORD").unwrap_or_default() == "true" {
+            Self::Record
+        } else {
+            Self::Replay
+        }
+    }
+
+    /// True when the journey runs against a live server (Live or Record).
+    fn is_live(self) -> bool {
+        matches!(self, Self::Live | Self::Record)
+    }
+}
+
 /// Configuration for journey execution
 #[derive(Debug, Clone)]
 pub struct JourneyConfig {
-    pub recording_enabled: bool,
+    pub mode: ExecutionMode,
     pub output_dir: PathBuf,
     pub server_url: String,
     pub auth_token: Option<String>,
@@ -765,7 +810,7 @@ pub struct JourneyConfig {
 impl Default for JourneyConfig {
     fn default() -> Self {
         Self {
-            recording_enabled: std::env::var("UC_INTEGRATION_RECORD").unwrap_or_default() == "true",
+            mode: ExecutionMode::from_record_env(),
             output_dir: std::env::var("UC_INTEGRATION_DIR")
                 .unwrap_or_else(|_| "test_data/recordings".to_string())
                 .into(),
@@ -805,7 +850,7 @@ impl JourneyConfig {
         } else {
             CloudClient::new_unauthenticated()
         };
-        if self.recording_enabled {
+        if self.mode == ExecutionMode::Record {
             std::fs::create_dir_all(&out_dir)?;
             client.set_recording_dir(out_dir)?;
         }
@@ -813,9 +858,23 @@ impl JourneyConfig {
         Ok(UnityCatalogClient::new(client, base_url))
     }
 
-    /// Enable/disable recording (true = live mode with recording, false = replay mode)
+    /// Set the execution mode (replay, live, or record).
+    pub fn with_mode(mut self, mode: ExecutionMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Convenience: `true` selects [`ExecutionMode::Record`] (live + record new
+    /// fixtures), `false` selects [`ExecutionMode::Replay`].
+    ///
+    /// For live execution without recording, use [`with_mode`](Self::with_mode)
+    /// with [`ExecutionMode::Live`].
     pub fn with_recording(mut self, enabled: bool) -> Self {
-        self.recording_enabled = enabled;
+        self.mode = if enabled {
+            ExecutionMode::Record
+        } else {
+            ExecutionMode::Replay
+        };
         self
     }
 
@@ -834,16 +893,22 @@ impl JourneyConfig {
         &self,
         journey: &mut dyn UserJourney,
     ) -> AcceptanceResult<JourneyExecutionResult> {
-        if self.recording_enabled {
-            // Live mode with recording - save state after execution
-            let out_dir = std::fs::canonicalize(self.output_dir.clone())?;
-            let out_dir = out_dir.join(journey.name());
+        if self.mode.is_live() {
+            // Live execution against a real server. In Record mode we also point
+            // the client at a recording directory and persist state afterwards;
+            // in plain Live mode we just exercise the server.
+            let out_dir = if self.mode == ExecutionMode::Record {
+                std::fs::create_dir_all(&self.output_dir)?;
+                std::fs::canonicalize(self.output_dir.clone())?.join(journey.name())
+            } else {
+                self.output_dir.join(journey.name())
+            };
             let client = self.create_client(out_dir.clone())?;
             let executor = JourneyExecutor::new(client);
             let result = executor.execute_journey(journey).await?;
 
-            // Save journey state if journey was successful
-            if result.is_success() {
+            // Save journey state only when recording new fixtures.
+            if self.mode == ExecutionMode::Record && result.is_success() {
                 let state = journey.save_state()?;
                 JourneyExecutor::save_journey_state(&out_dir, &state)?;
             }
@@ -946,16 +1011,17 @@ mod tests {
     async fn test_execution_mode_configuration() {
         let config = JourneyConfig::default();
 
-        // Test default mode (replay if UC_INTEGRATION_RECORD is not set)
-        assert!(!config.recording_enabled);
-
-        // Test recording flag (live mode with recording)
+        // with_recording(true) selects Record (live + record fixtures).
         let recording_config = config.clone().with_recording(true);
-        assert!(recording_config.recording_enabled);
+        assert_eq!(recording_config.mode, ExecutionMode::Record);
 
-        // Test replay mode (recording disabled)
+        // with_recording(false) selects Replay.
         let replay_config = config.clone().with_recording(false);
-        assert!(!replay_config.recording_enabled);
+        assert_eq!(replay_config.mode, ExecutionMode::Replay);
+
+        // with_mode allows live execution without recording.
+        let live_config = config.with_mode(ExecutionMode::Live);
+        assert_eq!(live_config.mode, ExecutionMode::Live);
     }
 
     #[test]

--- a/crates/acceptance/src/journeys/cross_resource/lakehouse_hierarchy.rs
+++ b/crates/acceptance/src/journeys/cross_resource/lakehouse_hierarchy.rs
@@ -59,7 +59,12 @@ impl UserJourney for LakehouseHierarchyJourney {
                 ResourceTag::Tables,
                 ResourceTag::Volumes,
             ],
-            implementations: vec![ImplementationTag::All],
+            // Creates managed tables, which the Java OSS server cannot create
+            // without configured cloud storage (500 "stagingLocation is null").
+            implementations: vec![
+                ImplementationTag::OssRust,
+                ImplementationTag::ManagedDatabricks,
+            ],
             tier: JourneyTier::Tier4Advanced,
             requires_external_storage: false,
         }

--- a/crates/acceptance/src/journeys/tier1/table_managed_lifecycle.rs
+++ b/crates/acceptance/src/journeys/tier1/table_managed_lifecycle.rs
@@ -53,7 +53,13 @@ impl UserJourney for TableManagedLifecycleJourney {
                 ResourceTag::Schemas,
                 ResourceTag::Tables,
             ],
-            implementations: vec![ImplementationTag::All],
+            // The Java OSS server rejects managed-table creation with a 500
+            // ("stagingLocation is null") unless backed by configured cloud
+            // storage, so it is excluded here.
+            implementations: vec![
+                ImplementationTag::OssRust,
+                ImplementationTag::ManagedDatabricks,
+            ],
             tier: JourneyTier::Tier1Crud,
             requires_external_storage: false,
         }

--- a/crates/acceptance/src/journeys/tier2/volume_managed_lifecycle.rs
+++ b/crates/acceptance/src/journeys/tier2/volume_managed_lifecycle.rs
@@ -56,7 +56,13 @@ impl UserJourney for VolumeManagedLifecycleJourney {
                 ResourceTag::Schemas,
                 ResourceTag::Volumes,
             ],
-            implementations: vec![ImplementationTag::All],
+            // The Java OSS server cannot deserialize our `VOLUME_TYPE_MANAGED`
+            // enum value (it expects `MANAGED`), so volume creation 500s there.
+            // Tracked as a client/server wire-format follow-up.
+            implementations: vec![
+                ImplementationTag::OssRust,
+                ImplementationTag::ManagedDatabricks,
+            ],
             tier: JourneyTier::Tier2Governance,
             requires_external_storage: false,
         }

--- a/crates/acceptance/src/lib.rs
+++ b/crates/acceptance/src/lib.rs
@@ -9,7 +9,7 @@ pub mod reporting;
 
 // Re-export commonly used types for convenience
 pub use execution::{
-    ImplementationProfile, ImplementationTag, JourneyConfig, JourneyExecutionResult,
+    ExecutionMode, ImplementationProfile, ImplementationTag, JourneyConfig, JourneyExecutionResult,
     JourneyExecutor, JourneyFilter, JourneyMetadata, JourneyTier, ResourceTag, UserJourney,
 };
 pub use execution::{JourneyLogger, PerformanceMetrics, ProgressTracker, cleanup_step};

--- a/crates/acceptance/tests/journeys.rs
+++ b/crates/acceptance/tests/journeys.rs
@@ -1,5 +1,5 @@
 use unitycatalog_acceptance::journeys::{journeys_for_filter, journeys_for_profile};
-use unitycatalog_acceptance::{ImplementationProfile, JourneyConfig, JourneyFilter};
+use unitycatalog_acceptance::{ExecutionMode, ImplementationProfile, JourneyConfig, JourneyFilter};
 
 /// Default replay test — runs all journeys that have recordings.
 ///
@@ -41,6 +41,10 @@ async fn journey_tests() -> Result<(), Box<dyn std::error::Error>> {
 /// UC_INTEGRATION_PROFILE=oss_rust UC_INTEGRATION_URL=http://localhost:8080 \
 ///   cargo test -p unitycatalog-acceptance -- journey_tests_live
 ///
+/// # Run against the local Java OSS server (see `just integration-oss-java`)
+/// UC_INTEGRATION_PROFILE=oss_java UC_INTEGRATION_URL=http://localhost:8080 \
+///   cargo test -p unitycatalog-acceptance -- journey_tests_live
+///
 /// # Record against Databricks managed UC
 /// UC_INTEGRATION_PROFILE=managed_databricks \
 ///   UC_INTEGRATION_URL=https://my-workspace.azuredatabricks.net \
@@ -61,6 +65,10 @@ async fn journey_tests_live() -> Result<(), Box<dyn std::error::Error>> {
             std::env::var("UC_INTEGRATION_URL")
                 .unwrap_or_else(|_| "http://localhost:8080".to_string()),
         ),
+        "oss_java" => ImplementationProfile::oss_java(
+            std::env::var("UC_INTEGRATION_URL")
+                .unwrap_or_else(|_| "http://localhost:8080".to_string()),
+        ),
         "managed_databricks" => ImplementationProfile::managed_databricks(
             std::env::var("UC_INTEGRATION_URL")
                 .expect("UC_INTEGRATION_URL required for managed_databricks profile"),
@@ -72,13 +80,20 @@ async fn journey_tests_live() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let profile = ImplementationProfile::from_env(base_profile);
-    let recording_enabled = std::env::var("UC_INTEGRATION_RECORD").unwrap_or_default() == "true";
+
+    // Live by default — actually exercise the target server. Set
+    // `UC_INTEGRATION_RECORD=true` to additionally capture new fixtures.
+    let mode = if std::env::var("UC_INTEGRATION_RECORD").unwrap_or_default() == "true" {
+        ExecutionMode::Record
+    } else {
+        ExecutionMode::Live
+    };
 
     let cargo_dir = std::env::var("CARGO_MANIFEST_DIR")?;
     let path = std::path::Path::new(&cargo_dir).join("recordings");
 
     let config = JourneyConfig::for_profile(&profile)
-        .with_recording(recording_enabled)
+        .with_mode(mode)
         .with_output_dir(path);
 
     for journey in journeys_for_profile(&profile).iter_mut() {

--- a/dev/uc-oss.compose.yaml
+++ b/dev/uc-oss.compose.yaml
@@ -1,0 +1,38 @@
+# Minimal Compose fixture that boots the open-source Java Unity Catalog server
+# for acceptance/journey integration tests. Reused by `just integration-oss-java`
+# and the `integration-oss-java` CI job.
+#
+# The image is the same one used by the marimo playground (dev/ucp.compose.yaml).
+# See https://github.com/unitycatalog/unitycatalog for the upstream project.
+name: unitycatalog-oss
+
+services:
+  unitycatalog:
+    image: newfrontdocker/unitycatalog:v0.4.1
+    hostname: unitycatalog
+    container_name: unitycatalog-oss
+    ports:
+      - "8080:8080"
+    volumes:
+      # Tracked, minimal config — authorization disabled, managed tables enabled.
+      - type: bind
+        source: ./uc-oss/server.properties
+        target: /home/unitycatalog/etc/conf/server.properties
+        read_only: true
+      # Ephemeral data dir so every run starts from a clean catalog.
+      - type: volume
+        source: uc_oss_data
+        target: /home/unitycatalog/etc/data
+    healthcheck:
+      # The server is ready once it answers the catalogs list endpoint.
+      # The image ships wget (not curl).
+      test:
+        - CMD-SHELL
+        - "wget -q -O /dev/null http://localhost:8080/api/2.1/unity-catalog/catalogs || exit 1"
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 20s
+
+volumes:
+  uc_oss_data:

--- a/dev/uc-oss/server.properties
+++ b/dev/uc-oss/server.properties
@@ -1,0 +1,10 @@
+# Minimal Unity Catalog OSS (Java) server config for integration tests.
+# Authorization is disabled so journeys can run unauthenticated.
+server.env=test
+server.authorization=disable
+
+# Enable MANAGED tables (experimental) so managed-table journeys can run.
+server.managed-table.enabled=true
+
+# Local storage root for managed tables/volumes inside the container.
+storage-root.tables=/home/unitycatalog/etc/data/

--- a/justfile
+++ b/justfile
@@ -168,6 +168,17 @@ integration:
     UC_INTEGRATION_RECORD="false" \
     cargo run --bin unitycatalog-acceptance
 
+# run journey tests live against the open-source Java Unity Catalog server.
+# Boots the server via docker compose, waits for its healthcheck, then runs
+# every OssJava-compatible journey. Tear down with:
+#   docker compose -f dev/uc-oss.compose.yaml down -v
+[group('test')]
+integration-oss-java:
+    docker compose -f dev/uc-oss.compose.yaml up -d --wait
+    UC_INTEGRATION_PROFILE="oss_java" \
+    UC_INTEGRATION_URL="http://localhost:8080" \
+    cargo test -p unitycatalog-acceptance -- journey_tests_live --nocapture
+
 # run object-store integration tests against the docker `full` profile
 # (UC server + SeaweedFS + Postgres + Azurite). Marks the test crate's
 # `#[ignore]` tests as runnable.


### PR DESCRIPTION
## Summary

Extends acceptance coverage by running client journeys **live against the open-source Java Unity Catalog server**, alongside the existing record/replay journeys against Databricks-hosted UC.

- **Compose fixture** — `dev/uc-oss.compose.yaml` + `dev/uc-oss/server.properties`: a minimal, self-contained fixture booting `newfrontdocker/unitycatalog:v0.4.1` with a `wget` healthcheck and an ephemeral data volume.
- **`ExecutionMode` (Replay / Live / Record)** — the new **Live** mode runs journeys against a real server without requiring or writing recordings. `journey_tests_live` now defaults to Live so it actually exercises the target; previously it fell into Replay and silently *skipped* any journey without committed recordings.
- **`oss_java` profile** wired into `ImplementationProfile` and `journey_tests_live`.
- **`just integration-oss-java`** recipe and a hard-failing **`integration_oss_java`** CI job (boots the server, runs OssJava journeys, dumps logs, tears down).

## Incompatibilities found

Running live surfaced real gaps with the Java OSS server, so the managed-resource journeys are retagged off `OssJava` (with explanatory comments + `JOURNEY_CATALOG.md` footnotes):

- `table_managed_lifecycle` / `lakehouse_hierarchy` — managed-table creation `500`s (`stagingLocation is null`) without configured cloud storage.
- `volume_managed_lifecycle` — the client's `VOLUME_TYPE_MANAGED` enum value is rejected by Java (expects `MANAGED`). Tracked in #141.

The OssJava-compatible set (`enhanced_catalog`, `catalog_hierarchy`, `schema_lifecycle`) passes live.

## Test plan

- [x] `cargo test -p unitycatalog-acceptance` — 27 unit + 2 replay pass
- [x] `cargo clippy -p unitycatalog-acceptance` — no new warnings
- [x] Booted the fixture locally: healthcheck green, `compose up --wait` exits 0
- [x] Live run against Java: 3 compatible journeys pass, 0 skipped, incompatible journeys excluded
- [ ] `integration_oss_java` CI job green on this PR

Closes #35

Follow-up: #141 (client enum wire-format mismatch with UC OSS Java)

AI-assisted by Isaac