### PR TITLE
refactor: move FromRequestParts impl out of api module (#137)

### DIFF
--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -12,22 +12,6 @@ pub use volumes::VolumeHandler;
 use crate::policy::{Permission, Principal};
 use unitycatalog_common::models::ResourceIdent;
 
-impl<S: Send + Sync> axum::extract::FromRequestParts<S> for RequestContext {
-    type Rejection = std::convert::Infallible;
-
-    async fn from_request_parts(
-        parts: &mut axum::http::request::Parts,
-        _state: &S,
-    ) -> Result<Self, Self::Rejection> {
-        let recipient = parts
-            .extensions
-            .get::<Principal>()
-            .cloned()
-            .unwrap_or_else(Principal::anonymous);
-        Ok(RequestContext { recipient })
-    }
-}
-
 // TODO: implement once AssociationLabel::CreatedBy and AssociationLabel::UpdatedBy variants are
 // added to unitycatalog_common (they are currently absent from the AssociationLabel enum in
 // crates/common/src/models/mod.rs). Once those variants exist, this function should be called

--- a/crates/server/src/rest/auth.rs
+++ b/crates/server/src/rest/auth.rs
@@ -8,7 +8,32 @@ use futures_util::{FutureExt, future::BoxFuture};
 use tower::{Layer, Service};
 use unitycatalog_common::Result;
 
+use crate::api::RequestContext;
 use crate::policy::Principal;
+
+/// Extract a [`RequestContext`] from the [`Principal`] that the
+/// [`AuthenticationMiddleware`] inserted into the request extensions.
+///
+/// This is the transport-side counterpart to that middleware: the middleware
+/// writes the `Principal`, this reads it back so handlers can receive a
+/// `RequestContext`. It lives here (rather than next to the `RequestContext`
+/// definition in `crate::api`) to keep the `api` module free of any axum
+/// coupling.
+impl<S: Send + Sync> axum::extract::FromRequestParts<S> for RequestContext {
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> std::result::Result<Self, Self::Rejection> {
+        let recipient = parts
+            .extensions
+            .get::<Principal>()
+            .cloned()
+            .unwrap_or_else(Principal::anonymous);
+        Ok(RequestContext { recipient })
+    }
+}
 
 /// Authenticator for authenticating requests to a sharing server.
 ///


### PR DESCRIPTION
## Summary

- Move the `axum::extract::FromRequestParts for RequestContext` impl out of the pure `api` module (`crates/server/src/api/mod.rs`) into the transport layer (`crates/server/src/rest/auth.rs`), next to the `AuthenticationMiddleware` that inserts the `Principal` it reads back.
- The `api` module is now fully axum-free. The `RequestContext` struct and `SecuredAction` stay put as domain types.
- No behavior change.

## Scope note

Investigation found the domain/transport boundary is already largely in place from #127: `api/*.rs`, `policy/`, `services/`, `memory.rs`, and `handlers/upstream.rs` are all axum-free, and handler traits are generic over the request context `Cx`. The stray `FromRequestParts` impl was the one remaining axum coupling in hand-written domain code — this PR removes it.

The other items in #137 are **intentionally deferred to the actual crate extraction**:
- A "transport-free internal error path" — domain modules already only touch `Result<T>` and never transitively *use* axum (the crate merely compiles it). Splitting the `Error` type or relocating its `IntoResponse`/`tonic::Status` impls is churn with no payoff until a crate is actually extracted.
- Relocating the generated `codegen/*/server.rs` axum glue — this is the bulk of real axum coupling and can't move without a cross-repo trestle template change.

Both belong to the `server-core` / transport split when the right shape is forced.

## Test plan

- [x] `cargo check -p unitycatalog-server` (default features) — clean
- [x] `cargo test -p unitycatalog-server` — 22 tests + 1 doctest pass, incl. `rest::auth::tests::test_authentication_middleware`
- [x] `cargo clippy -p unitycatalog-server` — no findings in touched files
- [x] grep guard: no `axum` references remain in `crates/server/src/api/`

Closes #137

AI-assisted by Isaac
