### PR TITLE
feat: add datafusion-unitycatalog crate integrating UC with DataFusion

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -57,7 +57,7 @@ AI-assisted-by: Isaac
 
 **Types:** `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
 
-The `Co-authored-by: Isaac` trailer is required on every commit.
+The `AI-assisted-by: Isaac` trailer is required on every commit.
 
 ### Step 6 — Print message and provide command
 1. Print the full commit message in a code block so the user can review it

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ axum = { version = "0.8" }
 axum-extra = { version = "0.10", features = ["query"] }
 bytes = { version = "1.1" }
 chrono = { version = "0.4.41", features = ["serde"] }
+dashmap = { version = "6" }
+datafusion = { version = "53.1.0" }
 env_logger = "0.11"
 futures = "0.3.32"
 itertools = { version = "0.14.0" }
@@ -55,6 +57,7 @@ serde_json = { version = "1.0" }
 strum = { version = "0.27", features = ["derive"] }
 sqlx = { version = "0.8.3" }
 thiserror = { version = "2" }
+tokio = { version = "1.40" }
 tonic = { version = "0.12.3" }
 tower = { version = "0.5", features = ["limit", "filter", "util"] }
 tracing = { version = "0.1", features = ["log"] }

--- a/crates/datafusion/Cargo.toml
+++ b/crates/datafusion/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "datafusion-unitycatalog"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+bytes = { workspace = true }
+dashmap = { workspace = true }
+datafusion = { workspace = true }
+futures = { workspace = true }
+object_store = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+tracing = { workspace = true }
+url = { workspace = true }
+
+unitycatalog-common = { path = "../common" }
+unitycatalog-object-store = { path = "../object-store" }
+
+[dev-dependencies]
+deltalake-core = { version = "0.32.3", features = ["datafusion", "cloud"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/datafusion/src/catalog/mod.rs
+++ b/crates/datafusion/src/catalog/mod.rs
@@ -1,0 +1,4 @@
+//! Catalog providers that back DataFusion's catalog/schema/table resolution
+//! with a live Unity Catalog instance.
+
+pub mod unity;

--- a/crates/datafusion/src/catalog/unity/builder.rs
+++ b/crates/datafusion/src/catalog/unity/builder.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use datafusion::catalog::TableProvider;
+use unitycatalog_common::models::tables::v1::Table;
+use url::Url;
+
+/// Error returned while turning a Unity Catalog table into a [`TableProvider`].
+pub type TableProviderError = datafusion::error::DataFusionError;
+
+/// Builds a DataFusion [`TableProvider`] for a Unity Catalog table.
+///
+/// The resolver ([`super::UnityCatalogSchemaProvider`]) handles UC metadata
+/// lookup, credential vending, and per-table object store registration. It then
+/// delegates the actual provider construction to an implementation of this
+/// trait, because building a Delta provider requires log-store / engine wiring
+/// owned by the host session rather than this generic crate.
+///
+/// Implementations receive the fully resolved storage `location` (the table's
+/// `storage_location`) plus the full UC [`Table`] metadata. By the time this is
+/// called, the object store serving `location` has already been registered on
+/// the session's runtime, so reads at scan time succeed with vended credentials.
+#[async_trait::async_trait]
+pub trait TableProviderBuilder: Send + Sync + std::fmt::Debug {
+    /// Build a provider for a Delta table rooted at `location`.
+    async fn build_delta(
+        &self,
+        location: &Url,
+        table: &Table,
+    ) -> Result<Arc<dyn TableProvider>, TableProviderError>;
+}

--- a/crates/datafusion/src/catalog/unity/mod.rs
+++ b/crates/datafusion/src/catalog/unity/mod.rs
@@ -1,0 +1,29 @@
+//! Unity Catalog backed catalog/schema/table resolution for DataFusion.
+//!
+//! These providers implement the `datafusion-catalog` async resolution traits
+//! ([`AsyncCatalogProviderList`], [`AsyncCatalogProvider`],
+//! [`AsyncSchemaProvider`]). At plan time DataFusion calls `resolve(refs, cfg)`,
+//! which walks the query's table references, looks each one up in Unity Catalog
+//! exactly once, and returns a synchronous, query-scoped catalog snapshot used
+//! for the rest of planning and execution.
+//!
+//! Looking a table up does three things:
+//! 1. fetch the [`Table`] metadata (storage location, format, id) from UC,
+//! 2. vend credentials and register a per-table object store so the engine can
+//!    read the table's storage location at scan time (see [`crate::storage`]),
+//! 3. build a [`TableProvider`] for the table's data source format (Delta).
+//!
+//! Step 3 is delegated to a [`TableProviderBuilder`] supplied by the embedder,
+//! because constructing a Delta provider requires log-store / engine wiring
+//! that belongs to the host session rather than this generic crate.
+//!
+//! [`AsyncCatalogProviderList`]: datafusion::catalog::AsyncCatalogProviderList
+//! [`AsyncCatalogProvider`]: datafusion::catalog::AsyncCatalogProvider
+//! [`AsyncSchemaProvider`]: datafusion::catalog::AsyncSchemaProvider
+//! [`Table`]: unitycatalog_common::models::tables::v1::Table
+
+mod builder;
+mod provider;
+
+pub use builder::{TableProviderBuilder, TableProviderError};
+pub use provider::{UnityCatalogProvider, UnityCatalogProviderList, UnityCatalogSchemaProvider};

--- a/crates/datafusion/src/catalog/unity/provider.rs
+++ b/crates/datafusion/src/catalog/unity/provider.rs
@@ -1,0 +1,230 @@
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use datafusion::catalog::{
+    AsyncCatalogProvider, AsyncCatalogProviderList, AsyncSchemaProvider, TableProvider,
+};
+use datafusion::common::{DataFusionError, plan_datafusion_err};
+use datafusion::error::Result;
+use datafusion::execution::runtime_env::RuntimeEnv;
+use object_store::path::Path;
+use tracing::{debug, instrument};
+use unitycatalog_common::models::tables::v1::DataSourceFormat;
+use unitycatalog_object_store::{TableOperation, UnityObjectStoreFactory};
+use url::Url;
+
+use super::builder::TableProviderBuilder;
+use crate::storage::RoutingObjectStore;
+
+/// Shared state used while resolving Unity Catalog references for a query.
+///
+/// Holds the UC-backed object store factory (metadata + credential vending),
+/// the session runtime on which per-table object stores are registered, the
+/// per-bucket [`RoutingObjectStore`]s, and the embedder-supplied provider
+/// builder. Cloning is cheap (everything is `Arc`-shared).
+#[derive(Clone)]
+struct UnityContext {
+    factory: Arc<UnityObjectStoreFactory>,
+    runtime: Arc<RuntimeEnv>,
+    builder: Arc<dyn TableProviderBuilder>,
+    /// `scheme://host` -> routing store registered on `runtime` for that host.
+    routers: Arc<DashMap<String, RoutingObjectStore>>,
+}
+
+impl std::fmt::Debug for UnityContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UnityContext").finish_non_exhaustive()
+    }
+}
+
+impl UnityContext {
+    /// Ensure a [`RoutingObjectStore`] is registered for the bucket of `url`,
+    /// then route `url`'s prefix to `store` within it.
+    ///
+    /// The routing store sits behind DataFusion's coarse `scheme://host`
+    /// registry key and dispatches to the correct per-table store at scan time.
+    fn register_table_store(&self, url: &Url, store: Arc<dyn object_store::ObjectStore>) {
+        let host_key = bucket_key(url);
+        let router = self
+            .routers
+            .entry(host_key.clone())
+            .or_insert_with(|| {
+                let router = RoutingObjectStore::new();
+                // Register once per host; the registry keys on scheme://host so
+                // re-registering the same instance is harmless but unnecessary.
+                if let Ok(bucket_url) = Url::parse(&format!("{host_key}/")) {
+                    self.runtime
+                        .register_object_store(&bucket_url, Arc::new(router.clone()));
+                }
+                router
+            })
+            .clone();
+        router.register(Path::from_url_path(url.path()).unwrap_or_default(), store);
+    }
+}
+
+/// `scheme://host` portion of a cloud URL, matching how DataFusion's
+/// `ObjectStoreRegistry` keys stores.
+fn bucket_key(url: &Url) -> String {
+    format!(
+        "{}://{}",
+        url.scheme(),
+        &url[url::Position::BeforeHost..url::Position::AfterPort]
+    )
+}
+
+/// Catalog list backed by a live Unity Catalog instance.
+///
+/// Register with DataFusion via the async resolution flow: call
+/// [`AsyncCatalogProviderList::resolve`] with the query's table references to
+/// obtain a synchronous, query-scoped `CatalogProviderList`.
+#[derive(Debug, Clone)]
+pub struct UnityCatalogProviderList {
+    ctx: UnityContext,
+}
+
+impl UnityCatalogProviderList {
+    pub fn new(
+        factory: Arc<UnityObjectStoreFactory>,
+        runtime: Arc<RuntimeEnv>,
+        builder: Arc<dyn TableProviderBuilder>,
+    ) -> Self {
+        Self {
+            ctx: UnityContext {
+                factory,
+                runtime,
+                builder,
+                routers: Arc::new(DashMap::new()),
+            },
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncCatalogProviderList for UnityCatalogProviderList {
+    #[instrument(skip(self), level = "debug")]
+    async fn catalog(&self, name: &str) -> Result<Option<Arc<dyn AsyncCatalogProvider>>> {
+        // Only fabricate a provider for catalogs Unity Catalog actually knows;
+        // unknown names fall through to other registered catalogs.
+        let exists = self
+            .ctx
+            .factory
+            .unity_client()
+            .catalog(name)
+            .get()
+            .await
+            .is_ok();
+        if !exists {
+            return Ok(None);
+        }
+        Ok(Some(Arc::new(UnityCatalogProvider {
+            ctx: self.ctx.clone(),
+            catalog: name.to_string(),
+        })))
+    }
+}
+
+/// A single Unity Catalog catalog.
+#[derive(Debug)]
+pub struct UnityCatalogProvider {
+    ctx: UnityContext,
+    catalog: String,
+}
+
+#[async_trait::async_trait]
+impl AsyncCatalogProvider for UnityCatalogProvider {
+    #[instrument(skip(self), fields(catalog = %self.catalog), level = "debug")]
+    async fn schema(&self, name: &str) -> Result<Option<Arc<dyn AsyncSchemaProvider>>> {
+        let exists = self
+            .ctx
+            .factory
+            .unity_client()
+            .schema(&self.catalog, name)
+            .get()
+            .await
+            .is_ok();
+        if !exists {
+            return Ok(None);
+        }
+        Ok(Some(Arc::new(UnityCatalogSchemaProvider {
+            ctx: self.ctx.clone(),
+            catalog: self.catalog.clone(),
+            schema: name.to_string(),
+        })))
+    }
+}
+
+/// A single Unity Catalog schema. Resolves tables to DataFusion providers.
+#[derive(Debug)]
+pub struct UnityCatalogSchemaProvider {
+    ctx: UnityContext,
+    catalog: String,
+    schema: String,
+}
+
+#[async_trait::async_trait]
+impl AsyncSchemaProvider for UnityCatalogSchemaProvider {
+    #[instrument(
+        skip(self),
+        fields(catalog = %self.catalog, schema = %self.schema, table = name),
+        level = "info",
+    )]
+    async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>> {
+        let full_name = format!("{}.{}.{}", self.catalog, self.schema, name);
+
+        // 1. Fetch table metadata from Unity Catalog.
+        let table = match self
+            .ctx
+            .factory
+            .unity_client()
+            .table_from_full_name(&full_name)
+            .get()
+            .await
+        {
+            Ok(table) => table,
+            // A missing table is not an error here: another provider may serve
+            // it, or planning will surface a clear "table not found" later.
+            Err(e) => {
+                debug!("table '{full_name}' not found in Unity Catalog: {e}");
+                return Ok(None);
+            }
+        };
+
+        // 2. Only Delta is supported for now.
+        let format = DataSourceFormat::try_from(table.data_source_format)
+            .unwrap_or(DataSourceFormat::Unspecified);
+        if format != DataSourceFormat::Delta {
+            return Err(DataFusionError::NotImplemented(format!(
+                "Unity Catalog table '{full_name}' has unsupported data source format {format:?}; \
+                 only Delta is supported"
+            )));
+        }
+
+        let location = table
+            .storage_location
+            .as_deref()
+            .ok_or_else(|| plan_datafusion_err!("table '{full_name}' has no storage location"))?;
+        let location = Url::parse(location).map_err(|e| {
+            plan_datafusion_err!("invalid storage location '{location}' for '{full_name}': {e}")
+        })?;
+
+        // 3. Vend credentials and build the per-table object store, then route
+        //    it under the bucket's routing store so the engine can read it.
+        let uc_store = self
+            .ctx
+            .factory
+            .for_table(full_name.clone(), TableOperation::Read)
+            .await
+            .map_err(|e| {
+                plan_datafusion_err!("failed to vend credentials for '{full_name}': {e}")
+            })?;
+        // Register the bucket-rooted store; the routing store forwards the full
+        // request path unchanged, and the credential is scoped to `prefix()`.
+        self.ctx
+            .register_table_store(uc_store.url(), uc_store.root());
+
+        // 4. Delegate provider construction to the host session.
+        let provider = self.ctx.builder.build_delta(&location, &table).await?;
+        Ok(Some(provider))
+    }
+}

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod catalog;
+pub mod storage;

--- a/crates/datafusion/src/storage/mod.rs
+++ b/crates/datafusion/src/storage/mod.rs
@@ -1,0 +1,15 @@
+//! Object store wiring for Unity Catalog backed tables.
+//!
+//! Unity Catalog vends temporary credentials that are scoped to a *sub-path*
+//! of a bucket (the table's storage location), but DataFusion's
+//! [`ObjectStoreRegistry`] resolves stores by `scheme://host` only — the path
+//! is discarded. Two tables in the same bucket therefore collide on a single
+//! registry key. [`RoutingObjectStore`] sits behind that coarse key and
+//! dispatches each operation to the correct per-table store based on the full
+//! request path.
+//!
+//! [`ObjectStoreRegistry`]: datafusion::execution::object_store::ObjectStoreRegistry
+
+mod routing;
+
+pub use routing::RoutingObjectStore;

--- a/crates/datafusion/src/storage/routing.rs
+++ b/crates/datafusion/src/storage/routing.rs
@@ -1,0 +1,264 @@
+use std::fmt;
+use std::ops::Range;
+use std::sync::{Arc, RwLock};
+
+use bytes::Bytes;
+use futures::stream::{self, BoxStream, StreamExt};
+use object_store::path::Path;
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
+};
+
+/// An [`ObjectStore`] that dispatches operations to per-prefix backing stores.
+///
+/// DataFusion's `ObjectStoreRegistry` resolves stores by `scheme://host` only,
+/// so every table living in the same bucket maps to one registry entry. When
+/// those tables are backed by Unity Catalog credentials vended for distinct
+/// sub-paths, a single backing store cannot serve them. A `RoutingObjectStore`
+/// is registered under the bucket key and routes each request to the store
+/// registered for the longest matching path prefix.
+///
+/// Each backing store is expected to be rooted at the bucket (e.g. a
+/// `UCStore::root()`), so the full request path is forwarded unchanged.
+/// A registered route: a path `prefix` and the store that serves paths beneath
+/// it. `prefix` is matched on path-segment boundaries.
+type Route = (Path, Arc<dyn ObjectStore>);
+
+#[derive(Clone)]
+pub struct RoutingObjectStore {
+    /// Routes ordered so that lookups can pick the longest matching prefix.
+    routes: Arc<RwLock<Vec<Route>>>,
+}
+
+impl RoutingObjectStore {
+    pub fn new() -> Self {
+        Self {
+            routes: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    /// Register `store` to serve every path at or beneath `prefix`.
+    ///
+    /// Re-registering an existing prefix replaces the backing store (e.g. when
+    /// a table is resolved again in a later query). Routes are kept sorted by
+    /// descending prefix length so the first match is the most specific.
+    pub fn register(&self, prefix: Path, store: Arc<dyn ObjectStore>) {
+        let mut routes = self.routes.write().unwrap();
+        routes.retain(|(p, _)| p != &prefix);
+        routes.push((prefix, store));
+        // Longest (most segments) first.
+        routes.sort_by_key(|(p, _)| std::cmp::Reverse(p.parts_count()));
+    }
+
+    /// Resolve the backing store for `location`, returning the most specific
+    /// registered prefix match.
+    fn route(&self, location: &Path) -> Result<Arc<dyn ObjectStore>> {
+        let routes = self.routes.read().unwrap();
+        routes
+            .iter()
+            .find(|(prefix, _)| is_path_prefix(prefix, location))
+            .map(|(_, store)| store.clone())
+            .ok_or_else(|| object_store::Error::NotFound {
+                path: location.to_string(),
+                source: format!("no registered object store routes path '{location}'").into(),
+            })
+    }
+
+    /// Resolve the backing store for a list `prefix`. A `None` prefix (list
+    /// everything) has no meaningful route here, so it errors — callers always
+    /// scan within a known table location.
+    fn route_prefix(&self, prefix: Option<&Path>) -> Result<Arc<dyn ObjectStore>> {
+        match prefix {
+            Some(prefix) => self.route(prefix),
+            None => Err(not_implemented("list without a prefix")),
+        }
+    }
+}
+
+fn not_implemented(operation: &str) -> object_store::Error {
+    object_store::Error::NotImplemented {
+        operation: operation.to_string(),
+        implementer: "RoutingObjectStore".to_string(),
+    }
+}
+
+impl Default for RoutingObjectStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for RoutingObjectStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let routes = self.routes.read().unwrap();
+        f.debug_struct("RoutingObjectStore")
+            .field(
+                "prefixes",
+                &routes
+                    .iter()
+                    .map(|(p, _)| p.to_string())
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+
+impl fmt::Display for RoutingObjectStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RoutingObjectStore")
+    }
+}
+
+/// Returns true when `path` is equal to, or lives beneath, `prefix`, matching
+/// only on full path-segment boundaries so that `db/t1` does not match
+/// `db/t10`. An empty prefix matches everything.
+fn is_path_prefix(prefix: &Path, path: &Path) -> bool {
+    let mut prefix_parts = prefix.parts();
+    let mut path_parts = path.parts();
+    loop {
+        match (prefix_parts.next(), path_parts.next()) {
+            // Consumed the whole prefix: `path` is at or below it.
+            (None, _) => return true,
+            // Prefix still has segments but path ran out, or a segment differs.
+            (Some(_), None) => return false,
+            (Some(a), Some(b)) if a != b => return false,
+            (Some(_), Some(_)) => continue,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for RoutingObjectStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
+        self.route(location)?
+            .put_opts(location, payload, opts)
+            .await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        self.route(location)?
+            .put_multipart_opts(location, opts)
+            .await
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+        self.route(location)?.get_opts(location, options).await
+    }
+
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
+        self.route(location)?.get_ranges(location, ranges).await
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
+        match self.route_prefix(prefix) {
+            Ok(store) => store.list(prefix),
+            Err(e) => stream::once(async move { Err(e) }).boxed(),
+        }
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        self.route_prefix(prefix)?.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> Result<()> {
+        let store = self.route(from)?;
+        // Cross-store copies are not supported; both ends must route to the
+        // same backing store.
+        if !Arc::ptr_eq(&store, &self.route(to)?) {
+            return Err(not_implemented("copy across distinct routed stores"));
+        }
+        store.copy_opts(from, to, options).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, Result<Path>>,
+    ) -> BoxStream<'static, Result<Path>> {
+        let this = self.clone();
+        locations
+            .map(move |location| {
+                let this = this.clone();
+                async move {
+                    let location = location?;
+                    this.route(&location)?.delete(&location).await?;
+                    Ok(location)
+                }
+            })
+            .buffered(10)
+            .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::memory::InMemory;
+
+    fn store_with(path: &str, body: &str) -> Arc<dyn ObjectStore> {
+        let store = InMemory::new();
+        let path = Path::from(path);
+        let payload = PutPayload::from(body.to_string());
+        futures::executor::block_on(store.put(&path, payload)).unwrap();
+        Arc::new(store)
+    }
+
+    #[test]
+    fn is_path_prefix_matches_on_segment_boundaries() {
+        let prefix = Path::from("db/t1");
+        assert!(is_path_prefix(&prefix, &Path::from("db/t1")));
+        assert!(is_path_prefix(
+            &prefix,
+            &Path::from("db/t1/_delta_log/0.json")
+        ));
+        // must NOT match a sibling whose name shares a textual prefix
+        assert!(!is_path_prefix(&prefix, &Path::from("db/t10/part.parquet")));
+        assert!(!is_path_prefix(&prefix, &Path::from("db/t2/part.parquet")));
+        // empty prefix matches everything
+        assert!(is_path_prefix(
+            &Path::from(""),
+            &Path::from("anything/here")
+        ));
+    }
+
+    #[tokio::test]
+    async fn routes_to_longest_matching_prefix() {
+        let routing = RoutingObjectStore::new();
+        let t1 = store_with("db/t1/data", "one");
+        let t2 = store_with("db/t2/data", "two");
+        routing.register(Path::from("db/t1"), t1);
+        routing.register(Path::from("db/t2"), t2);
+
+        let got_one = routing.get(&Path::from("db/t1/data")).await.unwrap();
+        assert_eq!(&got_one.bytes().await.unwrap()[..], b"one");
+
+        let got_two = routing.get(&Path::from("db/t2/data")).await.unwrap();
+        assert_eq!(&got_two.bytes().await.unwrap()[..], b"two");
+    }
+
+    #[tokio::test]
+    async fn unmatched_path_is_not_found() {
+        let routing = RoutingObjectStore::new();
+        routing.register(Path::from("db/t1"), store_with("db/t1/data", "one"));
+        let err = routing.get(&Path::from("db/other/data")).await.unwrap_err();
+        assert!(matches!(err, object_store::Error::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn re_register_replaces_backing_store() {
+        let routing = RoutingObjectStore::new();
+        routing.register(Path::from("db/t1"), store_with("db/t1/data", "old"));
+        routing.register(Path::from("db/t1"), store_with("db/t1/data", "new"));
+        let got = routing.get(&Path::from("db/t1/data")).await.unwrap();
+        assert_eq!(&got.bytes().await.unwrap()[..], b"new");
+    }
+}

--- a/crates/datafusion/tests/unity_resolve.rs
+++ b/crates/datafusion/tests/unity_resolve.rs
@@ -1,0 +1,188 @@
+//! Integration test for the Unity Catalog DataFusion resolver.
+//!
+//! These tests hit a live Unity Catalog server and its backing object store, so
+//! they are `#[ignore]`d by default. Run them explicitly once the environment
+//! stack is up and seeded:
+//!
+//! ```text
+//! UC_ENDPOINT=http://localhost:8081/api/2.1/unity-catalog/ \
+//! UC_TEST_TABLE=unity.default.numbers \
+//! AWS_REGION=us-east-1 \
+//! cargo test -p datafusion-unitycatalog --test unity_resolve -- --ignored --nocapture
+//! ```
+//!
+//! Set `UC_TOKEN` for an authenticated server; omit it for a local
+//! unauthenticated OSS server. Set `UC_TEST_TABLE_2` to a second table in the
+//! *same bucket* to exercise the routing store's per-table credential
+//! disambiguation.
+
+use std::sync::Arc;
+
+use datafusion::catalog::{AsyncCatalogProviderList, TableProvider};
+use datafusion::common::TableReference;
+use datafusion::error::DataFusionError;
+use datafusion::prelude::SessionContext;
+use datafusion_unitycatalog::catalog::unity::{
+    TableProviderBuilder, TableProviderError, UnityCatalogProviderList,
+};
+use deltalake_core::DeltaTableConfig;
+use deltalake_core::delta_datafusion::DeltaScanNext;
+use deltalake_core::delta_datafusion::engine::DataFusionEngine;
+use deltalake_core::kernel::Snapshot;
+use deltalake_core::logstore::{StorageConfig, logstore_with};
+use object_store::path::Path;
+use unitycatalog_common::models::tables::v1::Table;
+use unitycatalog_object_store::UnityObjectStoreFactory;
+use url::Url;
+
+/// A [`TableProviderBuilder`] that builds a Delta provider directly from a
+/// [`SessionContext`], reading through whatever object store the resolver has
+/// registered on the runtime for the table's location. Mirrors hydrofoil's
+/// `LakehouseTableProviderBuilder` without the Flight SQL plumbing.
+struct TestProviderBuilder {
+    ctx: SessionContext,
+}
+
+impl std::fmt::Debug for TestProviderBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TestProviderBuilder")
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait::async_trait]
+impl TableProviderBuilder for TestProviderBuilder {
+    async fn build_delta(
+        &self,
+        location: &Url,
+        _table: &Table,
+    ) -> Result<Arc<dyn TableProvider>, TableProviderError> {
+        let task_ctx = self.ctx.task_ctx();
+        let root_store = self
+            .ctx
+            .runtime_env()
+            .object_store_registry
+            .get_store(location)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let log_store = logstore_with(root_store, location, StorageConfig::default())
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        let engine = DataFusionEngine::new_from_context(task_ctx);
+        let snapshot = Snapshot::try_new_with_engine(
+            engine,
+            location.clone(),
+            DeltaTableConfig::default(),
+            None,
+        )
+        .await
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        let provider = DeltaScanNext::builder()
+            .with_snapshot(Arc::new(snapshot))
+            .with_log_store(log_store)
+            .await?;
+        Ok(provider)
+    }
+}
+
+fn factory_from_env() -> Option<UnityObjectStoreFactoryFut> {
+    let uri = std::env::var("UC_ENDPOINT").ok()?;
+    Some(UnityObjectStoreFactoryFut { uri })
+}
+
+struct UnityObjectStoreFactoryFut {
+    uri: String,
+}
+
+impl UnityObjectStoreFactoryFut {
+    async fn build(self) -> UnityObjectStoreFactory {
+        let mut builder = UnityObjectStoreFactory::builder().with_uri(self.uri);
+        match std::env::var("UC_TOKEN") {
+            Ok(token) => builder = builder.with_token(token),
+            Err(_) => builder = builder.with_allow_unauthenticated(true),
+        }
+        if let Ok(region) = std::env::var("AWS_REGION") {
+            builder = builder.with_aws_region(region);
+        }
+        builder.build().await.expect("failed to build UC factory")
+    }
+}
+
+/// Resolve a UC table to a provider and scan it, asserting we get rows back.
+#[tokio::test]
+#[ignore = "requires a live Unity Catalog server (set UC_ENDPOINT)"]
+async fn resolve_and_scan_uc_table() {
+    let Some(factory_fut) = factory_from_env() else {
+        eprintln!("UC_ENDPOINT not set; skipping");
+        return;
+    };
+    let full_name = std::env::var("UC_TEST_TABLE").expect("set UC_TEST_TABLE=catalog.schema.table");
+
+    let factory = Arc::new(factory_fut.build().await);
+    let ctx = SessionContext::new();
+    let builder = Arc::new(TestProviderBuilder { ctx: ctx.clone() });
+    let resolver = UnityCatalogProviderList::new(factory, ctx.runtime_env(), builder);
+
+    // Drive resolution exactly as the session does at plan time.
+    let reference = TableReference::parse_str(&full_name);
+    let config = ctx.copied_config();
+    let resolved = resolver
+        .resolve(std::slice::from_ref(&reference), &config)
+        .await
+        .expect("resolution failed");
+
+    let catalog_name = reference.catalog().expect("table must be fully qualified");
+    let catalog = resolved
+        .catalog(catalog_name)
+        .unwrap_or_else(|| panic!("catalog '{catalog_name}' not resolved"));
+    let schema = catalog
+        .schema(reference.schema().unwrap())
+        .expect("schema not resolved");
+    let provider = schema
+        .table(reference.table())
+        .await
+        .expect("table lookup errored")
+        .expect("table not resolved");
+
+    // Register and scan via SQL to exercise the full read path.
+    ctx.register_table(reference.clone(), provider)
+        .expect("failed to register resolved provider");
+    let df = ctx
+        .sql(&format!("SELECT * FROM {full_name}"))
+        .await
+        .expect("planning failed");
+    let batches = df.collect().await.expect("scan failed");
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    println!("scanned {rows} rows from {full_name}");
+    assert!(rows > 0, "expected at least one row from {full_name}");
+}
+
+/// Smoke test the vended credential directly, before any DataFusion wiring, so
+/// AWS credential-validation failures against the custom UC image surface here
+/// rather than deep in a scan.
+#[tokio::test]
+#[ignore = "requires a live Unity Catalog server (set UC_ENDPOINT)"]
+async fn vend_and_list_uc_table() {
+    use futures::TryStreamExt;
+    use unitycatalog_object_store::TableOperation;
+
+    let Some(factory_fut) = factory_from_env() else {
+        eprintln!("UC_ENDPOINT not set; skipping");
+        return;
+    };
+    let full_name = std::env::var("UC_TEST_TABLE").expect("set UC_TEST_TABLE=catalog.schema.table");
+    let factory = factory_fut.build().await;
+
+    let store = factory
+        .for_table(full_name.clone(), TableOperation::Read)
+        .await
+        .expect("vending credentials failed");
+    let listing: Vec<_> = store
+        .as_dyn()
+        .list(Some(&Path::from("")))
+        .try_collect()
+        .await
+        .expect("listing the table location failed (check AWS credential validation)");
+    println!("listed {} objects under {full_name}", listing.len());
+    assert!(!listing.is_empty(), "expected objects under {full_name}");
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -36,15 +36,15 @@ url = { workspace = true }
 axum = { workspace = true, optional = true }
 axum-extra = { workspace = true, optional = true }
 tonic = { workspace = true, optional = true }
-datafusion = { version = "53.1.0" }
+datafusion = { workspace = true }
 futures-util = { version = "0.3.28" }
 http = { version = "1.2", optional = true }
 olai-store = { workspace = true }
-tokio = { version = "1.40", features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 tower = { workspace = true, features = ["make"], optional = true }
 
 # in-memory handler dependencies (in alphabetical order)
-dashmap = { version = "6", optional = true }
+dashmap = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true, features = ["v7"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Adds a new `datafusion-unitycatalog` crate providing an async DataFusion catalog/schema provider that resolves Unity Catalog tables to Delta table providers, plus a routing object store keyed on table credential vending.

- Scope the crate's dependencies to what the code actually uses; drop the copied-in deps that were never referenced (serde, sqlparser, ordered-float, delta_kernel, unitycatalog-client).
- Hoist shared deps (datafusion, dashmap, tokio) to workspace.dependencies; the server crate now inherits them too.
- Source deltalake-core 0.32.3 (features datafusion, cloud) as a dev-dependency for the ignored live integration test; it aligns with the workspace on datafusion 53 / arrow 58 / buoyant_kernel 0.22.
- Use table_from_full_name on the generated client to look up tables by their dot-joined name.

AI-assisted-by: Isaac