### PR TITLE
feat: add the /delta/v1 Delta REST API (managed tables + commits)

### DIFF
--- a/crates/cli/src/server/hybrid.rs
+++ b/crates/cli/src/server/hybrid.rs
@@ -18,7 +18,7 @@ use unitycatalog_server::handlers::upstream::{
 use unitycatalog_server::policy::Policy;
 use unitycatalog_server::rest::{
     AuthenticationLayer, Authenticator, create_catalogs_router, create_commits_router,
-    create_credentials_router, create_entity_tag_assignments_router,
+    create_credentials_router, create_delta_router, create_entity_tag_assignments_router,
     create_external_locations_router, create_functions_router, create_providers_router,
     create_recipients_router, create_schemas_router, create_shares_router, create_sharing_router,
     create_staging_tables_router, create_tables_router, create_tag_policies_router,
@@ -55,6 +55,13 @@ where
         uri_prefix: "/api/v1/delta-sharing",
         api_definition: OpenApiSource::Inline(include_str!("../../../../openapi/sharing.yaml")),
         title: Some("Delta Sharing API"),
+    };
+    let delta_api_def = ApiDefinition {
+        // Distinct UI prefix so its swagger-ui asset routes don't collide with the
+        // main UC API's (see run.rs for the rationale).
+        uri_prefix: "/api/2.1/unity-catalog/delta",
+        api_definition: OpenApiSource::Inline(include_str!("../../../../openapi/delta.yaml")),
+        title: Some("UC Delta API"),
     };
 
     let catalogs = match routing.catalogs {
@@ -107,6 +114,7 @@ where
         .merge(create_providers_router(handler.clone()))
         .merge(create_shares_router(handler.clone()))
         .merge(create_commits_router(handler.clone()))
+        .merge(create_delta_router(handler.clone()))
         .merge(create_entity_tag_assignments_router(handler.clone()));
 
     let router = Router::new()
@@ -119,5 +127,11 @@ where
         );
     let server = router.layer(AuthenticationLayer::new(authenticator));
 
-    super::run::run(server, host, port, api_def, sharing_api_def).await
+    super::run::run(
+        server,
+        host,
+        port,
+        vec![api_def, sharing_api_def, delta_api_def],
+    )
+    .await
 }

--- a/crates/cli/src/server/run.rs
+++ b/crates/cli/src/server/run.rs
@@ -9,6 +9,7 @@ use unitycatalog_common::{Error, Result};
 use unitycatalog_server::api::catalogs::CatalogHandler;
 use unitycatalog_server::api::commits::DeltaCommitHandler;
 use unitycatalog_server::api::credentials::CredentialHandler;
+use unitycatalog_server::api::delta::DeltaApiHandler;
 use unitycatalog_server::api::entity_tag_assignments::EntityTagAssignmentHandler;
 use unitycatalog_server::api::external_locations::ExternalLocationHandler;
 use unitycatalog_server::api::functions::FunctionHandler;
@@ -23,7 +24,7 @@ use unitycatalog_server::api::tag_policies::TagPolicyHandler;
 use unitycatalog_server::api::volumes::VolumeHandler;
 use unitycatalog_server::rest::{
     AuthenticationLayer, Authenticator, create_catalogs_router, create_commits_router,
-    create_credentials_router, create_entity_tag_assignments_router,
+    create_credentials_router, create_delta_router, create_entity_tag_assignments_router,
     create_external_locations_router, create_functions_router, create_providers_router,
     create_recipients_router, create_schemas_router, create_shares_router, create_sharing_router,
     create_staging_tables_router, create_tables_router, create_tag_policies_router,
@@ -51,6 +52,7 @@ where
         + RecipientHandler<Cx>
         + ProviderHandler<Cx>
         + DeltaCommitHandler<Cx>
+        + DeltaApiHandler<Cx>
         + TagPolicyHandler<Cx>
         + EntityTagAssignmentHandler<Cx>
         + Clone,
@@ -67,6 +69,16 @@ where
         api_definition: OpenApiSource::Inline(include_str!("../../../../openapi/sharing.yaml")),
         title: Some("Delta Sharing API"),
     };
+    // The Delta REST API routes live at `/delta/v1/...` under the UC base path, but its
+    // Swagger UI + spec are hosted under a distinct prefix so the swagger-ui asset routes
+    // (`swagger-ui.css`, etc.) don't collide with the main UC API's, which is mounted at
+    // `/api/2.1/unity-catalog`. (The spec's own `servers` block still advertises the real
+    // base path to clients.)
+    let delta_api_def = ApiDefinition {
+        uri_prefix: "/api/2.1/unity-catalog/delta",
+        api_definition: OpenApiSource::Inline(include_str!("../../../../openapi/delta.yaml")),
+        title: Some("UC Delta API"),
+    };
 
     let api_routes = create_catalogs_router(handler.clone())
         .merge(create_schemas_router(handler.clone()))
@@ -80,6 +92,7 @@ where
         .merge(create_providers_router(handler.clone()))
         .merge(create_shares_router(handler.clone()))
         .merge(create_commits_router(handler.clone()))
+        .merge(create_delta_router(handler.clone()))
         .merge(create_entity_tag_assignments_router(handler.clone()));
 
     let router = Router::new()
@@ -92,19 +105,24 @@ where
         );
     let server = router.layer(AuthenticationLayer::new(authenticator));
 
-    run(server, host, port, api_def, sharing_api_def).await
+    run(
+        server,
+        host,
+        port,
+        vec![api_def, sharing_api_def, delta_api_def],
+    )
+    .await
 }
 
 pub(crate) async fn run<S: Into<String> + Clone>(
     router: axum::Router,
     host: impl AsRef<str>,
     port: u16,
-    api: ApiDefinition<S>,
-    sharing_api: ApiDefinition<S>,
+    apis: Vec<ApiDefinition<S>>,
 ) -> Result<()> {
-    let router = router
-        .merge(swagger_ui_dist::generate_routes(api))
-        .merge(swagger_ui_dist::generate_routes(sharing_api));
+    let router = apis.into_iter().fold(router, |router, api| {
+        router.merge(swagger_ui_dist::generate_routes(api))
+    });
     let router = router.layer(
         TraceLayer::new_for_http()
             .make_span_with(DefaultMakeSpan::new().include_headers(true))

--- a/crates/server/src/api/commits.rs
+++ b/crates/server/src/api/commits.rs
@@ -106,7 +106,19 @@ where
                 request.latest_backfilled_version,
             )
             .await
-            .map_err(Error::from)
+            .map_err(Error::from)?;
+
+        // Apply any metadata change carried by the commit to the stored table.
+        // The reference's `updateTableFromCommit` persists the commit's metadata
+        // (here: the configuration/property map) as the table's new desired state.
+        if let Some(metadata) = request.metadata
+            && !metadata.configuration.is_empty()
+        {
+            let mut updated = table;
+            updated.properties = metadata.configuration;
+            self.update(&table_ident, updated.into()).await?;
+        }
+        Ok(())
     }
 
     #[tracing::instrument(skip(self, context))]

--- a/crates/server/src/api/delta.rs
+++ b/crates/server/src/api/delta.rs
@@ -1,0 +1,239 @@
+//! Handler trait for the UC Delta REST API (`/delta/v1/...`).
+//!
+//! This is the hand-written counterpart to the generated resource handlers: the
+//! Delta API is a standalone REST protocol (mirrored from the Unity Catalog Java
+//! reference `DeltaApiService` / `openapi/delta.yaml`), so the trait, router, and
+//! models are all maintained by hand. See the Delta Sharing handler for the
+//! precedent.
+//!
+//! Phase 1 ships the trait + a stubbed default implementation surface; the router
+//! wires every operation. Behavior (contract validation, the `updateTable` action
+//! dispatcher, commit coordination) lands in Phase 2.
+
+use async_trait::async_trait;
+
+use crate::api::RequestContext;
+use crate::policy::Policy;
+use crate::rest::routers::delta::models::*;
+use crate::store::ResourceStore;
+use crate::{Error, Result};
+
+/// A fully-qualified table coordinate parsed from the request path.
+#[derive(Debug, Clone)]
+pub struct TablePath {
+    pub catalog: String,
+    pub schema: String,
+    pub table: String,
+}
+
+/// A schema coordinate (parent of staging-tables / tables creation).
+#[derive(Debug, Clone)]
+pub struct SchemaPath {
+    pub catalog: String,
+    pub schema: String,
+}
+
+/// Query parameters for `getConfig`.
+#[derive(Debug, Clone)]
+pub struct GetConfigQuery {
+    pub catalog: String,
+    /// Comma-separated list of highest protocol versions the client supports.
+    pub protocol_versions: String,
+}
+
+/// Handler for the Delta REST API. One method per `delta.yaml` operation.
+///
+/// Method names match the spec `operationId`s. Path/query parameters are passed
+/// as typed structs; request bodies use the hand-written model types.
+#[async_trait]
+pub trait DeltaApiHandler<Cx = RequestContext>: Send + Sync + 'static {
+    /// `GET /delta/v1/config`
+    async fn get_config(&self, query: GetConfigQuery, context: Cx) -> Result<DeltaCatalogConfig>;
+
+    /// `POST /delta/v1/catalogs/{catalog}/schemas/{schema}/staging-tables`
+    async fn create_staging_table(
+        &self,
+        path: SchemaPath,
+        request: DeltaCreateStagingTableRequest,
+        context: Cx,
+    ) -> Result<DeltaStagingTableResponse>;
+
+    /// `POST /delta/v1/catalogs/{catalog}/schemas/{schema}/tables`
+    async fn create_table(
+        &self,
+        path: SchemaPath,
+        request: DeltaCreateTableRequest,
+        context: Cx,
+    ) -> Result<DeltaLoadTableResponse>;
+
+    /// `GET /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}`
+    async fn load_table(&self, path: TablePath, context: Cx) -> Result<DeltaLoadTableResponse>;
+
+    /// `POST /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}`
+    async fn update_table(
+        &self,
+        path: TablePath,
+        request: DeltaUpdateTableRequest,
+        context: Cx,
+    ) -> Result<DeltaLoadTableResponse>;
+
+    /// `DELETE /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}`
+    async fn delete_table(&self, path: TablePath, context: Cx) -> Result<()>;
+
+    /// `HEAD /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}`
+    ///
+    /// Returns `Ok(())` if the table exists; the router maps a not-found error to 404.
+    async fn table_exists(&self, path: TablePath, context: Cx) -> Result<()>;
+
+    /// `POST /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/rename`
+    async fn rename_table(
+        &self,
+        path: TablePath,
+        request: DeltaRenameTableRequest,
+        context: Cx,
+    ) -> Result<()>;
+
+    /// `GET /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials`
+    async fn get_table_credentials(
+        &self,
+        path: TablePath,
+        operation: DeltaCredentialOperation,
+        context: Cx,
+    ) -> Result<DeltaCredentialsResponse>;
+
+    /// `POST /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/metrics`
+    async fn report_metrics(
+        &self,
+        path: TablePath,
+        request: DeltaReportMetricsRequest,
+        context: Cx,
+    ) -> Result<()>;
+
+    /// `GET /delta/v1/staging-tables/{table_id}/credentials`
+    async fn get_staging_table_credentials(
+        &self,
+        table_id: String,
+        context: Cx,
+    ) -> Result<DeltaCredentialsResponse>;
+
+    /// `GET /delta/v1/temporary-path-credentials`
+    async fn get_temporary_path_credentials(
+        &self,
+        location: String,
+        operation: DeltaCredentialOperation,
+        context: Cx,
+    ) -> Result<DeltaCredentialsResponse>;
+}
+
+/// Phase 1 stub implementation.
+///
+/// Every backend that is a [`ResourceStore`] + [`Policy`] gets a `DeltaApiHandler`
+/// that returns [`Error::NotImplemented`] for each operation. This lets the router
+/// mount and serve the Delta API surface (and its OpenAPI spec) while the actual
+/// behavior is ported in Phase 2. The real implementation will replace this blanket
+/// impl with one that carries the additional bounds it needs (commit coordinator,
+/// credential vending, `TableManager`).
+#[async_trait]
+impl<T> DeltaApiHandler<RequestContext> for T
+where
+    T: ResourceStore + Policy<RequestContext>,
+{
+    async fn get_config(
+        &self,
+        _query: GetConfigQuery,
+        _context: RequestContext,
+    ) -> Result<DeltaCatalogConfig> {
+        Err(Error::NotImplemented("Delta API: getConfig"))
+    }
+
+    async fn create_staging_table(
+        &self,
+        _path: SchemaPath,
+        _request: DeltaCreateStagingTableRequest,
+        _context: RequestContext,
+    ) -> Result<DeltaStagingTableResponse> {
+        Err(Error::NotImplemented("Delta API: createStagingTable"))
+    }
+
+    async fn create_table(
+        &self,
+        _path: SchemaPath,
+        _request: DeltaCreateTableRequest,
+        _context: RequestContext,
+    ) -> Result<DeltaLoadTableResponse> {
+        Err(Error::NotImplemented("Delta API: createTable"))
+    }
+
+    async fn load_table(
+        &self,
+        _path: TablePath,
+        _context: RequestContext,
+    ) -> Result<DeltaLoadTableResponse> {
+        Err(Error::NotImplemented("Delta API: loadTable"))
+    }
+
+    async fn update_table(
+        &self,
+        _path: TablePath,
+        _request: DeltaUpdateTableRequest,
+        _context: RequestContext,
+    ) -> Result<DeltaLoadTableResponse> {
+        Err(Error::NotImplemented("Delta API: updateTable"))
+    }
+
+    async fn delete_table(&self, _path: TablePath, _context: RequestContext) -> Result<()> {
+        Err(Error::NotImplemented("Delta API: deleteTable"))
+    }
+
+    async fn table_exists(&self, _path: TablePath, _context: RequestContext) -> Result<()> {
+        Err(Error::NotImplemented("Delta API: tableExists"))
+    }
+
+    async fn rename_table(
+        &self,
+        _path: TablePath,
+        _request: DeltaRenameTableRequest,
+        _context: RequestContext,
+    ) -> Result<()> {
+        Err(Error::NotImplemented("Delta API: renameTable"))
+    }
+
+    async fn get_table_credentials(
+        &self,
+        _path: TablePath,
+        _operation: DeltaCredentialOperation,
+        _context: RequestContext,
+    ) -> Result<DeltaCredentialsResponse> {
+        Err(Error::NotImplemented("Delta API: getTableCredentials"))
+    }
+
+    async fn report_metrics(
+        &self,
+        _path: TablePath,
+        _request: DeltaReportMetricsRequest,
+        _context: RequestContext,
+    ) -> Result<()> {
+        Err(Error::NotImplemented("Delta API: reportMetrics"))
+    }
+
+    async fn get_staging_table_credentials(
+        &self,
+        _table_id: String,
+        _context: RequestContext,
+    ) -> Result<DeltaCredentialsResponse> {
+        Err(Error::NotImplemented(
+            "Delta API: getStagingTableCredentials",
+        ))
+    }
+
+    async fn get_temporary_path_credentials(
+        &self,
+        _location: String,
+        _operation: DeltaCredentialOperation,
+        _context: RequestContext,
+    ) -> Result<DeltaCredentialsResponse> {
+        Err(Error::NotImplemented(
+            "Delta API: getTemporaryPathCredentials",
+        ))
+    }
+}

--- a/crates/server/src/api/delta.rs
+++ b/crates/server/src/api/delta.rs
@@ -10,11 +10,35 @@
 //! wires every operation. Behavior (contract validation, the `updateTable` action
 //! dispatcher, commit coordination) lands in Phase 2.
 
+use std::collections::BTreeMap;
+
 use async_trait::async_trait;
 
+use unitycatalog_common::models::staging_tables::v1::CreateStagingTableRequest;
+use unitycatalog_common::models::tables::v1::{
+    Column, CreateTableRequest, DataSourceFormat, DeleteTableRequest, GetTableRequest, Table,
+    TableType,
+};
+use unitycatalog_common::models::temporary_credentials::v1::{
+    GenerateTemporaryPathCredentialsRequest, GenerateTemporaryTableCredentialsRequest,
+    TemporaryCredential, generate_temporary_path_credentials_request::Operation as PathOp,
+    generate_temporary_table_credentials_request::Operation as TableOp,
+    temporary_credential::Credentials,
+};
+use unitycatalog_common::models::{ResourceIdent, ResourceRef};
+use unitycatalog_common::services::commit_coordinator::ProvidesCommitCoordinator;
+
 use crate::api::RequestContext;
-use crate::policy::Policy;
+use crate::api::credentials::CredentialHandlerExt;
+use crate::api::staging_tables::find_staging_table_by_location;
+use crate::api::tables::{TableHandler, TableManager};
+use crate::api::temporary_credentials::TemporaryCredentialHandler;
+use crate::codegen::staging_tables::StagingTableHandler;
+use crate::policy::{Permission, Policy, Principal};
 use crate::rest::routers::delta::models::*;
+use crate::services::location::StorageLocationUrl;
+use crate::services::managed_delta_contract as contract;
+use crate::services::object_store::validate_external_storage_location;
 use crate::store::ResourceStore;
 use crate::{Error, Result};
 
@@ -125,68 +149,295 @@ pub trait DeltaApiHandler<Cx = RequestContext>: Send + Sync + 'static {
     ) -> Result<DeltaCredentialsResponse>;
 }
 
-/// Phase 1 stub implementation.
+/// The static endpoint list `getConfig` advertises (the spec's `DeltaCatalogConfig.endpoints`).
+const ENDPOINTS: &[&str] = &[
+    "POST /v1/catalogs/{catalog}/schemas/{schema}/staging-tables",
+    "POST /v1/catalogs/{catalog}/schemas/{schema}/tables",
+    "GET /v1/catalogs/{catalog}/schemas/{schema}/tables",
+    "GET /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}",
+    "POST /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}",
+    "DELETE /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}",
+    "HEAD /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}",
+    "POST /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/rename",
+    "GET /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials",
+    "POST /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/metrics",
+    "GET /v1/staging-tables/{table_id}/credentials",
+    "GET /v1/temporary-path-credentials",
+];
+
+/// Real implementation of the Delta API.
 ///
-/// Every backend that is a [`ResourceStore`] + [`Policy`] gets a `DeltaApiHandler`
-/// that returns [`Error::NotImplemented`] for each operation. This lets the router
-/// mount and serve the Delta API surface (and its OpenAPI spec) while the actual
-/// behavior is ported in Phase 2. The real implementation will replace this blanket
-/// impl with one that carries the additional bounds it needs (commit coordinator,
-/// credential vending, `TableManager`).
+/// Delegates resource lifecycle, permission checks, and credential vending to the
+/// existing handler traits (`StagingTableHandler`, `TableHandler`,
+/// `TemporaryCredentialHandler`, `CredentialHandlerExt`) and the commit coordinator;
+/// the Delta-specific logic (the catalog-managed contract, the kebab-case wire
+/// mapping, the `updateTable` action dispatcher) lives here. `ServerHandler`
+/// satisfies all these bounds, so the CLI wiring is unaffected.
 #[async_trait]
 impl<T> DeltaApiHandler<RequestContext> for T
 where
-    T: ResourceStore + Policy<RequestContext>,
+    T: ResourceStore
+        + Policy<RequestContext>
+        + StagingTableHandler<RequestContext>
+        + TableHandler<RequestContext>
+        + TemporaryCredentialHandler<RequestContext>
+        + CredentialHandlerExt
+        + TableManager
+        + ProvidesCommitCoordinator,
 {
     async fn get_config(
         &self,
-        _query: GetConfigQuery,
+        query: GetConfigQuery,
         _context: RequestContext,
     ) -> Result<DeltaCatalogConfig> {
-        Err(Error::NotImplemented("Delta API: getConfig"))
+        // Confirm the catalog exists (mirrors the reference, which loads it).
+        if query.catalog.is_empty() {
+            return Err(Error::invalid_argument(
+                "catalog query parameter is required",
+            ));
+        }
+        let catalog_ident =
+            ResourceIdent::catalog(unitycatalog_common::models::ResourceName::new([query
+                .catalog
+                .as_str()]));
+        self.get(&catalog_ident).await?;
+        Ok(DeltaCatalogConfig {
+            endpoints: ENDPOINTS.iter().map(|s| s.to_string()).collect(),
+            protocol_version: "1.0".to_string(),
+        })
     }
 
     async fn create_staging_table(
         &self,
-        _path: SchemaPath,
-        _request: DeltaCreateStagingTableRequest,
-        _context: RequestContext,
+        path: SchemaPath,
+        request: DeltaCreateStagingTableRequest,
+        context: RequestContext,
     ) -> Result<DeltaStagingTableResponse> {
-        Err(Error::NotImplemented("Delta API: createStagingTable"))
+        // Reuse the existing staging flow (allocates uuid + managed location and
+        // enforces CREATE on the schema).
+        let staging = StagingTableHandler::create_staging_table(
+            self,
+            CreateStagingTableRequest {
+                name: request.name,
+                catalog_name: path.catalog,
+                schema_name: path.schema,
+            },
+            context.clone(),
+        )
+        .await?;
+
+        // Vend READ_WRITE credentials for the staging location so the client can
+        // write the initial commit.
+        let creds = self
+            .generate_temporary_path_credentials(
+                GenerateTemporaryPathCredentialsRequest {
+                    url: staging.staging_location.clone(),
+                    operation: PathOp::PathReadWrite as i32,
+                    dry_run: Some(false),
+                },
+                context,
+            )
+            .await?;
+
+        Ok(DeltaStagingTableResponse {
+            table_id: staging.id.clone(),
+            table_type: DeltaTableType::Managed,
+            location: staging.staging_location.clone(),
+            storage_credentials: vec![to_storage_credential(
+                &staging.staging_location,
+                &creds,
+                DeltaCredentialOperation::ReadWrite,
+            )],
+            required_protocol: DeltaProtocol {
+                min_reader_version: contract::REQUIRED_MIN_READER_VERSION,
+                min_writer_version: contract::REQUIRED_MIN_WRITER_VERSION,
+                reader_features: Some(
+                    contract::REQUIRED_READER_FEATURES
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect(),
+                ),
+                writer_features: Some(
+                    contract::REQUIRED_WRITER_FEATURES
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect(),
+                ),
+            },
+            suggested_protocol: Some(DeltaSuggestedProtocol {
+                reader_features: Some(
+                    contract::SUGGESTED_READER_FEATURES
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect(),
+                ),
+                writer_features: Some(
+                    contract::SUGGESTED_WRITER_FEATURES
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect(),
+                ),
+            }),
+            required_properties: contract::required_properties(&staging.id),
+            suggested_properties: Some(contract::suggested_properties()),
+        })
     }
 
     async fn create_table(
         &self,
-        _path: SchemaPath,
-        _request: DeltaCreateTableRequest,
-        _context: RequestContext,
+        path: SchemaPath,
+        request: DeltaCreateTableRequest,
+        context: RequestContext,
     ) -> Result<DeltaLoadTableResponse> {
-        Err(Error::NotImplemented("Delta API: createTable"))
+        // Required-field + shape checks (mirrors DeltaCreateTableMapper).
+        if request.name.is_empty() {
+            return Err(Error::invalid_argument("Table name is required."));
+        }
+        if request.location.is_empty() {
+            return Err(Error::invalid_argument("Table location is required."));
+        }
+
+        // Authorize CREATE on the target table. We persist via the store directly
+        // (below) rather than `TableHandler::create_table` — whose managed branch
+        // reads the snapshot — so the permission check is done explicitly here via
+        // the same `SecuredAction` the UC-REST createTable uses.
+        let create_action = CreateTableRequest {
+            name: request.name.clone(),
+            catalog_name: path.catalog.clone(),
+            schema_name: path.schema.clone(),
+            table_type: to_uc_table_type(request.table_type) as i32,
+            data_source_format: DataSourceFormat::Delta as i32,
+            ..Default::default()
+        };
+        self.check_required(&create_action, &context).await?;
+
+        // MANAGED-only: the full catalog-managed contract validates against the
+        // request's declared protocol/properties (the client wrote 0.json).
+        if request.table_type == DeltaTableType::Managed {
+            contract::validate(
+                &request.protocol,
+                request.domain_metadata.as_ref(),
+                &request.properties,
+            )?;
+        }
+
+        let columns =
+            contract::delta_columns_to_uc(&request.columns, request.partition_columns.as_deref())?;
+        let stored_properties = contract::build_stored_properties(&request);
+
+        // For MANAGED, finalize the staging reservation: enforce creator-match,
+        // tableId identity, mark committed, and adopt the staging uuid.
+        let table_id = if request.table_type == DeltaTableType::Managed {
+            let staging = find_staging_table_by_location(self, &request.location).await?;
+            match context.recipient() {
+                Principal::User(name) if staging.created_by.as_deref() == Some(name.as_str()) => {}
+                Principal::Anonymous if staging.created_by.is_none() => {}
+                _ => return Err(Error::NotAllowed),
+            }
+            if staging.stage_committed {
+                return Err(Error::invalid_argument(format!(
+                    "staging table at '{}' has already been committed",
+                    request.location
+                )));
+            }
+            contract::validate_table_id_property(&request.properties, &staging.id)?;
+
+            // Mark the staging reservation committed. Address it by the same
+            // identity the store keys it under — `StagingTable::resource_name()` is
+            // a bare `[name]`, so use that (a constructed three-part name or the
+            // logical id would not resolve).
+            let staging_ident =
+                ResourceIdent::staging_table(unitycatalog_common::models::ResourceName::new([
+                    staging.name.as_str(),
+                ]));
+            let committed = unitycatalog_common::models::staging_tables::v1::StagingTable {
+                stage_committed: true,
+                ..staging.clone()
+            };
+            self.update(&staging_ident, committed.into()).await?;
+            Some(staging.id)
+        } else {
+            // EXTERNAL: the location must live inside a registered external location.
+            let location = StorageLocationUrl::parse(&request.location)?;
+            validate_external_storage_location(self, &location).await?;
+            None
+        };
+
+        // Persist via the existing TableHandler so its CREATE authorization and
+        // store conventions apply. We pass the Delta-derived columns/properties.
+        let create_req = CreateTableRequest {
+            name: request.name,
+            catalog_name: path.catalog,
+            schema_name: path.schema,
+            table_type: to_uc_table_type(request.table_type) as i32,
+            data_source_format: DataSourceFormat::Delta as i32,
+            columns,
+            storage_location: Some(request.location),
+            comment: request.comment,
+            properties: stored_properties.into_iter().collect(),
+        };
+        // The TableHandler create_table reads the snapshot for the managed branch;
+        // for the Delta API we have already validated and want to trust the request,
+        // so we persist directly via the store instead of re-reading.
+        let table = build_table_for_create(&create_req, table_id);
+        let stored: Table = self.create(table.into()).await?.0.try_into()?;
+
+        build_load_table_response(self, stored).await
     }
 
     async fn load_table(
         &self,
-        _path: TablePath,
-        _context: RequestContext,
+        path: TablePath,
+        context: RequestContext,
     ) -> Result<DeltaLoadTableResponse> {
-        Err(Error::NotImplemented("Delta API: loadTable"))
+        let table = TableHandler::get_table(
+            self,
+            GetTableRequest {
+                full_name: format!("{}.{}.{}", path.catalog, path.schema, path.table),
+                include_delta_metadata: None,
+                include_browse: None,
+                include_manifest_capabilities: None,
+            },
+            context,
+        )
+        .await?;
+        build_load_table_response(self, table).await
     }
 
     async fn update_table(
         &self,
-        _path: TablePath,
-        _request: DeltaUpdateTableRequest,
-        _context: RequestContext,
+        path: TablePath,
+        request: DeltaUpdateTableRequest,
+        context: RequestContext,
     ) -> Result<DeltaLoadTableResponse> {
-        Err(Error::NotImplemented("Delta API: updateTable"))
+        update_table_impl(self, path, request, context).await
     }
 
-    async fn delete_table(&self, _path: TablePath, _context: RequestContext) -> Result<()> {
-        Err(Error::NotImplemented("Delta API: deleteTable"))
+    async fn delete_table(&self, path: TablePath, context: RequestContext) -> Result<()> {
+        TableHandler::delete_table(
+            self,
+            DeleteTableRequest {
+                full_name: format!("{}.{}.{}", path.catalog, path.schema, path.table),
+            },
+            context,
+        )
+        .await
     }
 
-    async fn table_exists(&self, _path: TablePath, _context: RequestContext) -> Result<()> {
-        Err(Error::NotImplemented("Delta API: tableExists"))
+    async fn table_exists(&self, path: TablePath, context: RequestContext) -> Result<()> {
+        // Map "does not exist" to NotFound (the router renders 404 / the HEAD 204).
+        TableHandler::get_table(
+            self,
+            GetTableRequest {
+                full_name: format!("{}.{}.{}", path.catalog, path.schema, path.table),
+                include_delta_metadata: None,
+                include_browse: None,
+                include_manifest_capabilities: None,
+            },
+            context,
+        )
+        .await
+        .map(|_| ())
     }
 
     async fn rename_table(
@@ -195,45 +446,997 @@ where
         _request: DeltaRenameTableRequest,
         _context: RequestContext,
     ) -> Result<()> {
+        // The UC table store has no rename op yet; surface as not-implemented until
+        // an UpdateTable/rename path exists (tracked as a follow-up).
         Err(Error::NotImplemented("Delta API: renameTable"))
     }
 
     async fn get_table_credentials(
         &self,
-        _path: TablePath,
-        _operation: DeltaCredentialOperation,
-        _context: RequestContext,
+        path: TablePath,
+        operation: DeltaCredentialOperation,
+        context: RequestContext,
     ) -> Result<DeltaCredentialsResponse> {
-        Err(Error::NotImplemented("Delta API: getTableCredentials"))
+        // Resolve the table uuid, then vend via the existing table-credential flow
+        // (which authorizes the operation and downscopes the credential).
+        let table = TableHandler::get_table(
+            self,
+            GetTableRequest {
+                full_name: format!("{}.{}.{}", path.catalog, path.schema, path.table),
+                include_delta_metadata: None,
+                include_browse: None,
+                include_manifest_capabilities: None,
+            },
+            context.clone(),
+        )
+        .await?;
+        let table_id = table
+            .table_id
+            .ok_or_else(|| Error::invalid_argument("table has no id"))?;
+        let creds = self
+            .generate_temporary_table_credentials(
+                GenerateTemporaryTableCredentialsRequest {
+                    table_id,
+                    operation: match operation {
+                        DeltaCredentialOperation::Read => TableOp::Read as i32,
+                        DeltaCredentialOperation::ReadWrite => TableOp::ReadWrite as i32,
+                    },
+                },
+                context,
+            )
+            .await?;
+        Ok(DeltaCredentialsResponse {
+            storage_credentials: vec![to_storage_credential(&creds.url, &creds, operation)],
+        })
     }
 
     async fn report_metrics(
         &self,
-        _path: TablePath,
-        _request: DeltaReportMetricsRequest,
-        _context: RequestContext,
+        path: TablePath,
+        request: DeltaReportMetricsRequest,
+        context: RequestContext,
     ) -> Result<()> {
-        Err(Error::NotImplemented("Delta API: reportMetrics"))
+        // Validate the table exists and that the body table-id matches the path.
+        let table = TableHandler::get_table(
+            self,
+            GetTableRequest {
+                full_name: format!("{}.{}.{}", path.catalog, path.schema, path.table),
+                include_delta_metadata: None,
+                include_browse: None,
+                include_manifest_capabilities: None,
+            },
+            context,
+        )
+        .await?;
+        if table.table_id.as_deref() != Some(request.table_id.as_str()) {
+            return Err(Error::invalid_argument(
+                "report table-id does not match the table identified by the path",
+            ));
+        }
+        if let Some(cv) = request
+            .report
+            .as_ref()
+            .and_then(|r| r.commit_report.as_ref())
+            .and_then(|c| c.file_size_histogram.as_ref())
+            .and_then(|h| h.commit_version)
+            && cv < 0
+        {
+            return Err(Error::invalid_argument(
+                "commit-version must be non-negative",
+            ));
+        }
+        // Accept-and-ack: we have no maintenance scheduler yet (follow-up issue).
+        Ok(())
     }
 
     async fn get_staging_table_credentials(
         &self,
-        _table_id: String,
-        _context: RequestContext,
+        table_id: String,
+        context: RequestContext,
     ) -> Result<DeltaCredentialsResponse> {
-        Err(Error::NotImplemented(
-            "Delta API: getStagingTableCredentials",
-        ))
+        // Resolve the staging reservation by uuid, then vend READ_WRITE creds for
+        // its location.
+        let uuid = uuid::Uuid::parse_str(&table_id)
+            .map_err(|_| Error::invalid_argument("table_id is not a valid UUID"))?;
+        let ident = ResourceIdent::StagingTable(ResourceRef::Uuid(uuid));
+        let staging: unitycatalog_common::models::staging_tables::v1::StagingTable =
+            self.get(&ident).await?.0.try_into()?;
+        let creds = self
+            .generate_temporary_path_credentials(
+                GenerateTemporaryPathCredentialsRequest {
+                    url: staging.staging_location.clone(),
+                    operation: PathOp::PathReadWrite as i32,
+                    dry_run: Some(false),
+                },
+                context,
+            )
+            .await?;
+        Ok(DeltaCredentialsResponse {
+            storage_credentials: vec![to_storage_credential(
+                &staging.staging_location,
+                &creds,
+                DeltaCredentialOperation::ReadWrite,
+            )],
+        })
     }
 
     async fn get_temporary_path_credentials(
         &self,
-        _location: String,
-        _operation: DeltaCredentialOperation,
-        _context: RequestContext,
+        location: String,
+        operation: DeltaCredentialOperation,
+        context: RequestContext,
     ) -> Result<DeltaCredentialsResponse> {
-        Err(Error::NotImplemented(
-            "Delta API: getTemporaryPathCredentials",
-        ))
+        let creds = self
+            .generate_temporary_path_credentials(
+                GenerateTemporaryPathCredentialsRequest {
+                    url: location.clone(),
+                    operation: match operation {
+                        DeltaCredentialOperation::Read => PathOp::PathRead as i32,
+                        DeltaCredentialOperation::ReadWrite => PathOp::PathReadWrite as i32,
+                    },
+                    dry_run: Some(false),
+                },
+                context,
+            )
+            .await?;
+        Ok(DeltaCredentialsResponse {
+            storage_credentials: vec![to_storage_credential(&creds.url, &creds, operation)],
+        })
+    }
+}
+
+// ===================================================================
+// Helpers
+// ===================================================================
+
+fn to_uc_table_type(t: DeltaTableType) -> TableType {
+    match t {
+        DeltaTableType::Managed => TableType::Managed,
+        DeltaTableType::External => TableType::External,
+    }
+}
+
+/// Assemble the persisted [`Table`] for a Delta createTable. For MANAGED the uuid is
+/// the staging reservation's; for EXTERNAL the store assigns one.
+fn build_table_for_create(req: &CreateTableRequest, table_id: Option<String>) -> Table {
+    Table {
+        name: req.name.clone(),
+        catalog_name: req.catalog_name.clone(),
+        schema_name: req.schema_name.clone(),
+        table_type: req.table_type,
+        data_source_format: req.data_source_format,
+        columns: req.columns.clone(),
+        storage_location: req.storage_location.clone(),
+        comment: req.comment.clone(),
+        properties: req.properties.clone(),
+        table_id,
+        ..Default::default()
+    }
+}
+
+/// Build a `DeltaLoadTableResponse` from a stored [`Table`], appending unbackfilled
+/// commits + `latest_table_version` for MANAGED+DELTA tables.
+async fn build_load_table_response<T>(handler: &T, table: Table) -> Result<DeltaLoadTableResponse>
+where
+    T: ProvidesCommitCoordinator,
+{
+    let metadata = build_table_metadata(&table);
+
+    let (commits, latest_table_version) = if table.table_type == TableType::Managed as i32
+        && table.data_source_format == DataSourceFormat::Delta as i32
+        && let Some(id) = table.table_id.as_deref()
+    {
+        let (commits, latest) = handler
+            .commit_coordinator()
+            .get_commits(id, 0, None)
+            .await
+            .map_err(|e| Error::generic(format!("commit coordinator: {e:?}")))?;
+        (
+            Some(commits.into_iter().map(to_delta_commit).collect()),
+            Some(latest),
+        )
+    } else {
+        (None, None)
+    };
+
+    Ok(DeltaLoadTableResponse {
+        metadata,
+        commits,
+        uniform: None,
+        latest_table_version,
+    })
+}
+
+fn build_table_metadata(table: &Table) -> DeltaTableMetadata {
+    let properties: BTreeMap<String, String> = table.properties.clone().into_iter().collect();
+    let etag = match table.updated_at {
+        Some(ts) => format!("etag-{ts}"),
+        None => format!("etag-{}", table.table_id.clone().unwrap_or_default()),
+    };
+    let partition_columns: Vec<String> = {
+        let mut p: Vec<(&i32, &Column)> = table
+            .columns
+            .iter()
+            .filter_map(|c| c.partition_index.as_ref().map(|idx| (idx, c)))
+            .collect();
+        p.sort_by_key(|(idx, _)| **idx);
+        p.into_iter().map(|(_, c)| c.name.clone()).collect()
+    };
+
+    DeltaTableMetadata {
+        etag,
+        table_type: if table.table_type == TableType::External as i32 {
+            DeltaTableType::External
+        } else {
+            DeltaTableType::Managed
+        },
+        table_uuid: table.table_id.clone().unwrap_or_default(),
+        location: table.storage_location.clone().unwrap_or_default(),
+        created_time: table.created_at.unwrap_or_default(),
+        updated_time: table.updated_at.or(table.created_at).unwrap_or_default(),
+        columns: contract::uc_columns_to_delta(&table.columns),
+        partition_columns: (!partition_columns.is_empty()).then_some(partition_columns),
+        properties: properties.clone(),
+        last_commit_version: properties
+            .get(contract::PROP_LAST_UPDATE_VERSION)
+            .and_then(|v| v.parse().ok()),
+        last_commit_timestamp_ms: properties
+            .get(contract::PROP_LAST_COMMIT_TIMESTAMP)
+            .and_then(|v| v.parse().ok()),
+    }
+}
+
+fn to_delta_commit(c: unitycatalog_common::models::delta_commits::v1::CommitInfo) -> DeltaCommit {
+    DeltaCommit {
+        version: c.version,
+        timestamp: c.timestamp,
+        file_name: c.file_name,
+        file_size: c.file_size,
+        file_modification_timestamp: c.file_modification_timestamp,
+    }
+}
+
+/// Map a vended [`TemporaryCredential`] onto the Delta API `DeltaStorageCredential`
+/// (mirrors the reference `DeltaCredentialsMapper`).
+fn to_storage_credential(
+    prefix: &str,
+    creds: &TemporaryCredential,
+    operation: DeltaCredentialOperation,
+) -> DeltaStorageCredential {
+    let mut config = DeltaStorageCredentialConfig::default();
+    match &creds.credentials {
+        Some(Credentials::AwsTempCredentials(aws)) => {
+            config.s3_access_key_id = Some(aws.access_key_id.clone());
+            config.s3_secret_access_key = Some(aws.secret_access_key.clone());
+            if !aws.session_token.is_empty() {
+                config.s3_session_token = Some(aws.session_token.clone());
+            }
+        }
+        Some(Credentials::AzureUserDelegationSas(az)) => {
+            config.azure_sas_token = Some(az.sas_token.clone());
+        }
+        Some(Credentials::GcpOauthToken(gcp)) => {
+            config.gcs_oauth_token = Some(gcp.oauth_token.clone());
+        }
+        // R2 reuses the S3-shaped fields; AAD is not surfaced in the Delta config.
+        Some(Credentials::R2TempCredentials(r2)) => {
+            config.s3_access_key_id = Some(r2.access_key_id.clone());
+            config.s3_secret_access_key = Some(r2.secret_access_key.clone());
+            if !r2.session_token.is_empty() {
+                config.s3_session_token = Some(r2.session_token.clone());
+            }
+        }
+        _ => {}
+    }
+    DeltaStorageCredential {
+        prefix: prefix.to_string(),
+        operation,
+        config,
+        expiration_time_ms: creds.expiration_time,
+    }
+}
+
+// ===================================================================
+// updateTable action dispatcher (DeltaUpdateTableMapper)
+// ===================================================================
+
+/// Apply an `updateTable` request: check requirements, apply the action list in the
+/// reference's canonical order, route commit/backfill through the coordinator, and
+/// return the refreshed table. Mirrors `DeltaUpdateTableMapper` +
+/// `DeltaCommitRepository.applyCommitAndBackfillInSession`.
+async fn update_table_impl<T>(
+    handler: &T,
+    path: TablePath,
+    request: DeltaUpdateTableRequest,
+    context: RequestContext,
+) -> Result<DeltaLoadTableResponse>
+where
+    T: ResourceStore
+        + Policy<RequestContext>
+        + TableHandler<RequestContext>
+        + ProvidesCommitCoordinator,
+{
+    // Resolve the table by name, then authorize WRITE.
+    let mut table = TableHandler::get_table(
+        handler,
+        GetTableRequest {
+            full_name: format!("{}.{}.{}", path.catalog, path.schema, path.table),
+            include_delta_metadata: None,
+            include_browse: None,
+            include_manifest_capabilities: None,
+        },
+        context.clone(),
+    )
+    .await?;
+    let table_uuid = table
+        .table_id
+        .clone()
+        .ok_or_else(|| Error::invalid_argument("table has no id"))?;
+    let uuid = uuid::Uuid::parse_str(&table_uuid)
+        .map_err(|_| Error::invalid_argument("table id is not a valid UUID"))?;
+    let table_ident = ResourceIdent::Table(ResourceRef::Uuid(uuid));
+    handler
+        .authorize_checked(&table_ident, &Permission::Write, &context)
+        .await?;
+
+    // --- Requirements (assert-table-uuid mandatory; assert-etag optional) ---
+    let has_uuid_assert = request
+        .requirements
+        .iter()
+        .any(|r| matches!(r, DeltaTableRequirement::AssertTableUuid { .. }));
+    if !has_uuid_assert {
+        return Err(Error::invalid_argument(
+            "assert-table-uuid requirement is required.",
+        ));
+    }
+    let current_etag = match table.updated_at {
+        Some(ts) => format!("etag-{ts}"),
+        None => format!("etag-{table_uuid}"),
+    };
+    for req in &request.requirements {
+        match req {
+            DeltaTableRequirement::AssertTableUuid { uuid } => {
+                if uuid != &table_uuid {
+                    return Err(Error::UpdateRequirementConflict(format!(
+                        "assert-table-uuid failed: expected {uuid} but table has {table_uuid}"
+                    )));
+                }
+            }
+            DeltaTableRequirement::AssertEtag { etag } => {
+                if etag != &current_etag {
+                    return Err(Error::UpdateRequirementConflict(
+                        "assert-etag failed: table has been modified".to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    // --- Overlap checks (set/remove on the same key) ---
+    let set_prop_keys: Vec<&String> = request
+        .updates
+        .iter()
+        .filter_map(|u| match u {
+            DeltaTableUpdate::SetProperties { updates } => Some(updates.keys()),
+            _ => None,
+        })
+        .flatten()
+        .collect();
+    if let Some(removals) = request.updates.iter().find_map(|u| match u {
+        DeltaTableUpdate::RemoveProperties { removals } => Some(removals),
+        _ => None,
+    }) {
+        for r in removals {
+            if set_prop_keys.contains(&r) {
+                return Err(Error::invalid_argument(format!(
+                    "set-properties and remove-properties overlap on key: {r}"
+                )));
+            }
+        }
+    }
+
+    let mut properties: BTreeMap<String, String> = table.properties.clone().into_iter().collect();
+    let is_managed = table.table_type == TableType::Managed as i32;
+    let mut metadata_changed = false;
+
+    // Apply in canonical order (not request order). We make multiple passes.
+    // 1. set-columns / set-partition-columns
+    apply_schema_and_partitions(&mut table, &request.updates)?;
+    if request.updates.iter().any(|u| {
+        matches!(
+            u,
+            DeltaTableUpdate::SetColumns { .. } | DeltaTableUpdate::SetPartitionColumns { .. }
+        )
+    }) {
+        metadata_changed = true;
+    }
+
+    // 2. set-protocol (re-derive delta.feature.* and re-validate for MANAGED)
+    if let Some(protocol) = request.updates.iter().find_map(|u| match u {
+        DeltaTableUpdate::SetProtocol { protocol } => Some(protocol),
+        _ => None,
+    }) {
+        // Drop existing feature props, then re-derive from the new protocol.
+        properties.retain(|k, _| !k.starts_with("delta.feature."));
+        contract::derive_from_protocol(&mut properties, protocol);
+        if is_managed {
+            contract::validate(protocol, None, &properties)?;
+        }
+        metadata_changed = true;
+    }
+
+    // 3. set-properties / 4. remove-properties
+    for update in &request.updates {
+        match update {
+            DeltaTableUpdate::SetProperties { updates } => {
+                properties.extend(updates.clone());
+                metadata_changed = true;
+            }
+            DeltaTableUpdate::RemoveProperties { removals } => {
+                for k in removals {
+                    properties.remove(k);
+                }
+                metadata_changed = true;
+            }
+            _ => {}
+        }
+    }
+
+    // 5. set-domain-metadata / 6. remove-domain-metadata
+    for update in &request.updates {
+        match update {
+            DeltaTableUpdate::SetDomainMetadata { updates } => {
+                contract::derive_from_domain_metadata(&mut properties, updates);
+                metadata_changed = true;
+            }
+            DeltaTableUpdate::RemoveDomainMetadata { domains } => {
+                for d in domains {
+                    match d.as_str() {
+                        "delta.clustering" => {
+                            properties.remove("delta.clusteringColumns");
+                        }
+                        "delta.rowTracking" => {
+                            properties.remove("delta.rowTracking.rowIdHighWaterMark");
+                        }
+                        other => {
+                            return Err(Error::invalid_argument(format!(
+                                "Unknown domain in remove-domain-metadata: {other}"
+                            )));
+                        }
+                    }
+                }
+                metadata_changed = true;
+            }
+            _ => {}
+        }
+    }
+
+    // 7. set-table-comment
+    if let Some(comment) = request.updates.iter().find_map(|u| match u {
+        DeltaTableUpdate::SetTableComment { comment } => Some(comment.clone()),
+        _ => None,
+    }) {
+        table.comment = Some(comment);
+        metadata_changed = true;
+    }
+
+    // 8. update-metadata-snapshot-version (EXTERNAL only)
+    if let Some((v, ts)) = request.updates.iter().find_map(|u| match u {
+        DeltaTableUpdate::UpdateMetadataSnapshotVersion {
+            last_commit_version,
+            last_commit_timestamp_ms,
+        } => Some((*last_commit_version, *last_commit_timestamp_ms)),
+        _ => None,
+    }) {
+        if is_managed {
+            return Err(Error::invalid_argument(
+                "update-metadata-snapshot-version is only valid for EXTERNAL tables",
+            ));
+        }
+        properties.insert(
+            contract::PROP_LAST_UPDATE_VERSION.to_string(),
+            v.to_string(),
+        );
+        properties.insert(
+            contract::PROP_LAST_COMMIT_TIMESTAMP.to_string(),
+            ts.to_string(),
+        );
+        metadata_changed = true;
+    }
+
+    // 9. add-commit + set-latest-backfilled-version → commit coordinator
+    let add_commit = request.updates.iter().find_map(|u| match u {
+        DeltaTableUpdate::AddCommit { commit, .. } => Some(commit.clone()),
+        _ => None,
+    });
+    let backfill = request.updates.iter().find_map(|u| match u {
+        DeltaTableUpdate::SetLatestBackfilledVersion {
+            latest_published_version,
+        } => Some(*latest_published_version),
+        _ => None,
+    });
+    if add_commit.is_some() || backfill.is_some() {
+        if !is_managed {
+            return Err(Error::invalid_argument(
+                "add-commit / set-latest-backfilled-version require a MANAGED table",
+            ));
+        }
+        let commit_info =
+            add_commit.map(
+                |c| unitycatalog_common::models::delta_commits::v1::CommitInfo {
+                    version: c.version,
+                    timestamp: c.timestamp,
+                    file_name: c.file_name,
+                    file_size: c.file_size,
+                    file_modification_timestamp: c.file_modification_timestamp,
+                },
+            );
+        handler
+            .commit_coordinator()
+            .commit(&table_uuid, commit_info, backfill)
+            .await?;
+    }
+
+    // Persist metadata changes (if any) before reloading.
+    if metadata_changed {
+        table.properties = properties.into_iter().collect();
+        handler.update(&table_ident, table.clone().into()).await?;
+    }
+
+    build_load_table_response(handler, table).await
+}
+
+/// Apply `set-columns` and `set-partition-columns` in a combined pass, mirroring the
+/// reference `applySchemaAndPartitionColumns`. Columns set replaces the schema;
+/// partition columns re-derive partition indices.
+fn apply_schema_and_partitions(table: &mut Table, updates: &[DeltaTableUpdate]) -> Result<()> {
+    let new_columns = updates.iter().find_map(|u| match u {
+        DeltaTableUpdate::SetColumns { columns } => Some(columns),
+        _ => None,
+    });
+    let new_partitions = updates.iter().find_map(|u| match u {
+        DeltaTableUpdate::SetPartitionColumns { partition_columns } => Some(partition_columns),
+        _ => None,
+    });
+    if new_columns.is_none() && new_partitions.is_none() {
+        return Ok(());
+    }
+
+    // Determine the schema to work from: the new one if set, else the existing.
+    let columns: Vec<Column> = match new_columns {
+        Some(struct_type) => {
+            // Preserve existing partitioning unless new partitions are supplied.
+            let existing_partitions: Vec<String> = {
+                let mut p: Vec<(&i32, &Column)> = table
+                    .columns
+                    .iter()
+                    .filter_map(|c| c.partition_index.as_ref().map(|idx| (idx, c)))
+                    .collect();
+                p.sort_by_key(|(idx, _)| **idx);
+                p.into_iter().map(|(_, c)| c.name.clone()).collect()
+            };
+            let partitions = new_partitions.cloned().unwrap_or(existing_partitions);
+            contract::delta_columns_to_uc(struct_type, Some(&partitions))?
+        }
+        None => {
+            // Only partitions changed: re-apply indices to the existing columns.
+            let partitions = new_partitions.expect("checked above");
+            let mut cols = table.columns.clone();
+            for col in &mut cols {
+                col.partition_index = partitions
+                    .iter()
+                    .position(|p| p.eq_ignore_ascii_case(&col.name))
+                    .map(|i| i as i32);
+            }
+            for p in partitions {
+                if !cols.iter().any(|c| c.name.eq_ignore_ascii_case(p)) {
+                    return Err(Error::invalid_argument(format!(
+                        "partition column '{p}' is not present in the table schema"
+                    )));
+                }
+            }
+            cols
+        }
+    };
+    table.columns = columns;
+    Ok(())
+}
+
+#[cfg(all(test, feature = "memory"))]
+mod tests {
+    use std::sync::Arc;
+
+    use unitycatalog_common::models::catalogs::v1::CreateCatalogRequest;
+    use unitycatalog_common::models::schemas::v1::CreateSchemaRequest;
+    use unitycatalog_common::services::encryption::{EnvelopeEncryptor, LocalKeyProvider};
+
+    use super::*;
+    use crate::api::{CatalogHandler, SchemaHandler};
+    use crate::memory::InMemoryResourceStore;
+    use crate::policy::ConstantPolicy;
+    use crate::services::ServerHandler;
+
+    fn handler() -> ServerHandler<RequestContext> {
+        let encryptor =
+            EnvelopeEncryptor::local(LocalKeyProvider::single("test", vec![0x42; 32]).unwrap());
+        let store = Arc::new(InMemoryResourceStore::new(encryptor));
+        let policy: Arc<dyn Policy<RequestContext>> = Arc::new(ConstantPolicy::default());
+        ServerHandler::try_new_tokio(policy, store.clone(), store).unwrap()
+    }
+
+    fn ctx() -> RequestContext {
+        RequestContext {
+            recipient: Principal::anonymous(),
+        }
+    }
+
+    async fn setup(h: &ServerHandler<RequestContext>) {
+        h.create_catalog(
+            CreateCatalogRequest {
+                name: "cat".into(),
+                storage_root: Some("s3://bucket/cat".into()),
+                ..Default::default()
+            },
+            ctx(),
+        )
+        .await
+        .unwrap();
+        h.create_schema(
+            CreateSchemaRequest {
+                name: "sch".into(),
+                catalog_name: "cat".into(),
+                ..Default::default()
+            },
+            ctx(),
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Create a staging reservation directly (avoids the credential-vending path of
+    /// the public createStagingTable) and return it.
+    async fn stage(
+        h: &ServerHandler<RequestContext>,
+        name: &str,
+    ) -> unitycatalog_common::models::staging_tables::v1::StagingTable {
+        StagingTableHandler::create_staging_table(
+            h,
+            CreateStagingTableRequest {
+                name: name.into(),
+                catalog_name: "cat".into(),
+                schema_name: "sch".into(),
+            },
+            ctx(),
+        )
+        .await
+        .unwrap()
+    }
+
+    fn compliant_protocol() -> DeltaProtocol {
+        DeltaProtocol {
+            min_reader_version: 3,
+            min_writer_version: 7,
+            reader_features: Some(
+                contract::REQUIRED_READER_FEATURES
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+            ),
+            writer_features: Some(
+                contract::REQUIRED_WRITER_FEATURES
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+            ),
+        }
+    }
+
+    fn compliant_properties(table_id: &str) -> BTreeMap<String, String> {
+        let mut p: BTreeMap<String, String> = contract::REQUIRED_FIXED_PROPERTIES
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        p.insert(contract::PROP_UC_TABLE_ID.to_string(), table_id.to_string());
+        p
+    }
+
+    fn create_req(name: &str, location: &str, table_id: &str) -> DeltaCreateTableRequest {
+        DeltaCreateTableRequest {
+            name: name.into(),
+            location: location.into(),
+            table_type: DeltaTableType::Managed,
+            comment: None,
+            columns: DeltaStructType {
+                type_tag: Default::default(),
+                fields: vec![DeltaStructField {
+                    name: "id".into(),
+                    data_type: DeltaDataType::Primitive("long".into()),
+                    nullable: false,
+                    metadata: Default::default(),
+                }],
+            },
+            partition_columns: None,
+            protocol: compliant_protocol(),
+            properties: compliant_properties(table_id),
+            domain_metadata: None,
+            last_commit_timestamp_ms: 1700,
+            uniform: None,
+        }
+    }
+
+    fn schema_path() -> SchemaPath {
+        SchemaPath {
+            catalog: "cat".into(),
+            schema: "sch".into(),
+        }
+    }
+
+    fn table_path(table: &str) -> TablePath {
+        TablePath {
+            catalog: "cat".into(),
+            schema: "sch".into(),
+            table: table.into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_config_returns_endpoints() {
+        let h = handler();
+        setup(&h).await;
+        let cfg = h
+            .get_config(
+                GetConfigQuery {
+                    catalog: "cat".into(),
+                    protocol_versions: "1.0".into(),
+                },
+                ctx(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(cfg.protocol_version, "1.0");
+        assert_eq!(cfg.endpoints.len(), 12);
+    }
+
+    #[tokio::test]
+    async fn create_managed_table_happy_path() {
+        let h = handler();
+        setup(&h).await;
+        let st = stage(&h, "t").await;
+
+        let resp = DeltaApiHandler::create_table(
+            &h,
+            schema_path(),
+            create_req("t", &st.staging_location, &st.id),
+            ctx(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.metadata.table_uuid, st.id);
+        assert_eq!(resp.metadata.table_type, DeltaTableType::Managed);
+        // Derived feature property present.
+        assert_eq!(
+            resp.metadata
+                .properties
+                .get("delta.feature.catalogManaged")
+                .map(String::as_str),
+            Some("supported")
+        );
+        // Newly created managed table has no commits yet.
+        assert_eq!(resp.latest_table_version, Some(0));
+
+        // The staging reservation is now committed.
+        let staged = find_staging_table_by_location(&h, &st.staging_location)
+            .await
+            .unwrap();
+        assert!(staged.stage_committed);
+    }
+
+    #[tokio::test]
+    async fn create_managed_table_id_mismatch_rejected() {
+        let h = handler();
+        setup(&h).await;
+        let st = stage(&h, "t").await;
+        // tableId property points at a different uuid than the staging reservation.
+        let req = create_req(
+            "t",
+            &st.staging_location,
+            "00000000-0000-0000-0000-000000000000",
+        );
+        let err = DeltaApiHandler::create_table(&h, schema_path(), req, ctx())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn create_managed_table_without_staging_rejected() {
+        let h = handler();
+        setup(&h).await;
+        let req = create_req("t", "s3://bucket/cat/__unitystorage/tables/nope", "id");
+        let err = DeltaApiHandler::create_table(&h, schema_path(), req, ctx())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::NotFound), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn create_managed_table_non_compliant_rejected() {
+        let h = handler();
+        setup(&h).await;
+        let st = stage(&h, "t").await;
+        let mut req = create_req("t", &st.staging_location, &st.id);
+        req.protocol.min_writer_version = 5; // below contract minimum
+        let err = DeltaApiHandler::create_table(&h, schema_path(), req, ctx())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn update_table_requires_assert_table_uuid() {
+        let h = handler();
+        setup(&h).await;
+        let st = stage(&h, "t").await;
+        DeltaApiHandler::create_table(
+            &h,
+            schema_path(),
+            create_req("t", &st.staging_location, &st.id),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+        let req = DeltaUpdateTableRequest {
+            requirements: vec![],
+            updates: vec![DeltaTableUpdate::SetProperties {
+                updates: BTreeMap::from([("k".into(), "v".into())]),
+            }],
+        };
+        let err = h
+            .update_table(table_path("t"), req, ctx())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn update_table_etag_mismatch_conflicts() {
+        let h = handler();
+        setup(&h).await;
+        let st = stage(&h, "t").await;
+        DeltaApiHandler::create_table(
+            &h,
+            schema_path(),
+            create_req("t", &st.staging_location, &st.id),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+        let req = DeltaUpdateTableRequest {
+            requirements: vec![
+                DeltaTableRequirement::AssertTableUuid {
+                    uuid: st.id.clone(),
+                },
+                DeltaTableRequirement::AssertEtag {
+                    etag: "etag-wrong".into(),
+                },
+            ],
+            updates: vec![DeltaTableUpdate::SetProperties {
+                updates: BTreeMap::from([("k".into(), "v".into())]),
+            }],
+        };
+        let err = h
+            .update_table(table_path("t"), req, ctx())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::UpdateRequirementConflict(_)),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_table_add_commit_visible_in_load() {
+        let h = handler();
+        setup(&h).await;
+        let st = stage(&h, "t").await;
+        DeltaApiHandler::create_table(
+            &h,
+            schema_path(),
+            create_req("t", &st.staging_location, &st.id),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+        let req = DeltaUpdateTableRequest {
+            requirements: vec![DeltaTableRequirement::AssertTableUuid {
+                uuid: st.id.clone(),
+            }],
+            updates: vec![DeltaTableUpdate::AddCommit {
+                commit: DeltaCommit {
+                    version: 1,
+                    timestamp: 1800,
+                    file_name: "00000000-0000-0000-0000-00000000002a.json".into(),
+                    file_size: 64,
+                    file_modification_timestamp: 1800,
+                },
+                uniform: None,
+            }],
+        };
+        h.update_table(table_path("t"), req, ctx()).await.unwrap();
+
+        let loaded = h.load_table(table_path("t"), ctx()).await.unwrap();
+        assert_eq!(loaded.latest_table_version, Some(1));
+        let commits = loaded.commits.unwrap();
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].version, 1);
+    }
+
+    #[tokio::test]
+    async fn update_table_set_remove_property_overlap_rejected() {
+        let h = handler();
+        setup(&h).await;
+        let st = stage(&h, "t").await;
+        DeltaApiHandler::create_table(
+            &h,
+            schema_path(),
+            create_req("t", &st.staging_location, &st.id),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+        let req = DeltaUpdateTableRequest {
+            requirements: vec![DeltaTableRequirement::AssertTableUuid {
+                uuid: st.id.clone(),
+            }],
+            updates: vec![
+                DeltaTableUpdate::SetProperties {
+                    updates: BTreeMap::from([("k".into(), "v".into())]),
+                },
+                DeltaTableUpdate::RemoveProperties {
+                    removals: vec!["k".into()],
+                },
+            ],
+        };
+        let err = h
+            .update_table(table_path("t"), req, ctx())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn report_metrics_table_id_mismatch_rejected() {
+        let h = handler();
+        setup(&h).await;
+        let st = stage(&h, "t").await;
+        DeltaApiHandler::create_table(
+            &h,
+            schema_path(),
+            create_req("t", &st.staging_location, &st.id),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+        let req = DeltaReportMetricsRequest {
+            table_id: "00000000-0000-0000-0000-000000000000".into(),
+            report: None,
+        };
+        let err = h
+            .report_metrics(table_path("t"), req, ctx())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "{err:?}");
+
+        // Matching id succeeds (accept-and-ack).
+        let ok = DeltaReportMetricsRequest {
+            table_id: st.id.clone(),
+            report: None,
+        };
+        h.report_metrics(table_path("t"), ok, ctx()).await.unwrap();
     }
 }

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -1,6 +1,7 @@
 pub use catalogs::CatalogHandler;
 pub use commits::DeltaCommitHandler;
 pub use credentials::CredentialHandler;
+pub use delta::DeltaApiHandler;
 pub use entity_tag_assignments::EntityTagAssignmentHandler;
 pub use external_locations::ExternalLocationHandler;
 pub use functions::FunctionHandler;
@@ -33,6 +34,7 @@ use unitycatalog_common::models::ResourceIdent;
 pub mod catalogs;
 pub mod commits;
 pub mod credentials;
+pub mod delta;
 pub mod entity_tag_assignments;
 pub mod external_locations;
 pub mod functions;

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -55,6 +55,9 @@ pub enum Error {
     #[error("Commit version conflict: {0}")]
     CommitVersionConflict(String),
 
+    #[error("Update requirement conflict: {0}")]
+    UpdateRequirementConflict(String),
+
     #[error("Resource exhausted: {0}")]
     ResourceExhausted(String),
 
@@ -101,6 +104,7 @@ impl Error {
             Error::NotFound => "RESOURCE_NOT_FOUND",
             Error::AlreadyExists => "RESOURCE_ALREADY_EXISTS",
             Error::CommitVersionConflict(_) => "COMMIT_VERSION_CONFLICT",
+            Error::UpdateRequirementConflict(_) => "UPDATE_REQUIREMENT_CONFLICT",
             Error::ResourceExhausted(_) => "RESOURCE_EXHAUSTED",
             Error::NotAllowed => "PERMISSION_DENIED",
             Error::Unauthenticated => "UNAUTHENTICATED",
@@ -191,6 +195,13 @@ impl IntoResponse for Error {
                 (
                     StatusCode::CONFLICT,
                     "The commit version was already accepted by another writer.",
+                )
+            }
+            Error::UpdateRequirementConflict(message) => {
+                error!("Update requirement conflict: {}", message);
+                (
+                    StatusCode::CONFLICT,
+                    "An update requirement (assert-table-uuid / assert-etag) was not met.",
                 )
             }
             Error::ResourceExhausted(message) => {
@@ -306,6 +317,7 @@ impl From<Error> for Status {
             // Error::InvalidPredicate(msg) => Status::invalid_argument(msg),
             Error::AlreadyExists => Status::already_exists("The resource already exists."),
             Error::CommitVersionConflict(message) => Status::aborted(message),
+            Error::UpdateRequirementConflict(message) => Status::aborted(message),
             Error::ResourceExhausted(message) => Status::resource_exhausted(message),
             Error::InvalidIdentifier(e) => Status::invalid_argument(e.to_string()),
             Error::InvalidArgument(message) => Status::invalid_argument(message),

--- a/crates/server/src/rest/routers/delta/mod.rs
+++ b/crates/server/src/rest/routers/delta/mod.rs
@@ -13,9 +13,12 @@ use axum::http::StatusCode;
 use axum::routing::{Router, get, post};
 use serde::Deserialize;
 
-use crate::Result;
 use crate::api::delta::{DeltaApiHandler, GetConfigQuery, SchemaPath, TablePath};
 use models::*;
+
+/// Handler result whose error half serializes as the Delta API envelope
+/// (`{ "error": { message, type, code } }`) via [`DeltaError`].
+type DeltaResult<T> = std::result::Result<T, DeltaError>;
 
 /// Create a [`Router`] for the Delta REST API. Routes match `openapi/delta.yaml`.
 pub fn get_router<T, Cx>(state: T) -> Router
@@ -89,7 +92,7 @@ async fn get_config<T, Cx>(
     State(handler): State<T>,
     context: Cx,
     Query(params): Query<GetConfigParams>,
-) -> Result<axum::Json<DeltaCatalogConfig>>
+) -> DeltaResult<axum::Json<DeltaCatalogConfig>>
 where
     T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
     Cx: axum::extract::FromRequestParts<T> + Send,
@@ -106,7 +109,7 @@ async fn create_staging_table<T, Cx>(
     context: Cx,
     Path((catalog, schema)): Path<(String, String)>,
     axum::Json(request): axum::Json<DeltaCreateStagingTableRequest>,
-) -> Result<axum::Json<DeltaStagingTableResponse>>
+) -> DeltaResult<axum::Json<DeltaStagingTableResponse>>
 where
     T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
     Cx: axum::extract::FromRequestParts<T> + Send,
@@ -122,7 +125,7 @@ async fn create_table<T, Cx>(
     context: Cx,
     Path((catalog, schema)): Path<(String, String)>,
     axum::Json(request): axum::Json<DeltaCreateTableRequest>,
-) -> Result<axum::Json<DeltaLoadTableResponse>>
+) -> DeltaResult<axum::Json<DeltaLoadTableResponse>>
 where
     T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
     Cx: axum::extract::FromRequestParts<T> + Send,
@@ -137,7 +140,7 @@ async fn load_table<T, Cx>(
     State(handler): State<T>,
     context: Cx,
     Path((catalog, schema, table)): Path<(String, String, String)>,
-) -> Result<axum::Json<DeltaLoadTableResponse>>
+) -> DeltaResult<axum::Json<DeltaLoadTableResponse>>
 where
     T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
     Cx: axum::extract::FromRequestParts<T> + Send,
@@ -155,7 +158,7 @@ async fn update_table<T, Cx>(
     context: Cx,
     Path((catalog, schema, table)): Path<(String, String, String)>,
     axum::Json(request): axum::Json<DeltaUpdateTableRequest>,
-) -> Result<axum::Json<DeltaLoadTableResponse>>
+) -> DeltaResult<axum::Json<DeltaLoadTableResponse>>
 where
     T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
     Cx: axum::extract::FromRequestParts<T> + Send,
@@ -174,7 +177,7 @@ async fn delete_table<T, Cx>(
     State(handler): State<T>,
     context: Cx,
     Path((catalog, schema, table)): Path<(String, String, String)>,
-) -> Result<StatusCode>
+) -> DeltaResult<StatusCode>
 where
     T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
     Cx: axum::extract::FromRequestParts<T> + Send,
@@ -192,7 +195,7 @@ async fn table_exists<T, Cx>(
     State(handler): State<T>,
     context: Cx,
     Path((catalog, schema, table)): Path<(String, String, String)>,
-) -> Result<StatusCode>
+) -> DeltaResult<StatusCode>
 where
     T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
     Cx: axum::extract::FromRequestParts<T> + Send,
@@ -211,7 +214,7 @@ async fn rename_table<T, Cx>(
     context: Cx,
     Path((catalog, schema, table)): Path<(String, String, String)>,
     axum::Json(request): axum::Json<DeltaRenameTableRequest>,
-) -> Result<StatusCode>
+) -> DeltaResult<StatusCode>
 where
     T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
     Cx: axum::extract::FromRequestParts<T> + Send,
@@ -230,7 +233,7 @@ async fn get_table_credentials<T, Cx>(
     context: Cx,
     Path((catalog, schema, table)): Path<(String, String, String)>,
     Query(params): Query<OperationParam>,
-) -> Result<axum::Json<DeltaCredentialsResponse>>
+) -> DeltaResult<axum::Json<DeltaCredentialsResponse>>
 where
     T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
     Cx: axum::extract::FromRequestParts<T> + Send,
@@ -252,7 +255,7 @@ async fn report_metrics<T, Cx>(
     context: Cx,
     Path((catalog, schema, table)): Path<(String, String, String)>,
     axum::Json(request): axum::Json<DeltaReportMetricsRequest>,
-) -> Result<StatusCode>
+) -> DeltaResult<StatusCode>
 where
     T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
     Cx: axum::extract::FromRequestParts<T> + Send,
@@ -270,7 +273,7 @@ async fn get_staging_table_credentials<T, Cx>(
     State(handler): State<T>,
     context: Cx,
     Path(table_id): Path<String>,
-) -> Result<axum::Json<DeltaCredentialsResponse>>
+) -> DeltaResult<axum::Json<DeltaCredentialsResponse>>
 where
     T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
     Cx: axum::extract::FromRequestParts<T> + Send,
@@ -286,7 +289,7 @@ async fn get_temporary_path_credentials<T, Cx>(
     State(handler): State<T>,
     context: Cx,
     Query(params): Query<PathCredentialParams>,
-) -> Result<axum::Json<DeltaCredentialsResponse>>
+) -> DeltaResult<axum::Json<DeltaCredentialsResponse>>
 where
     T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
     Cx: axum::extract::FromRequestParts<T> + Send,

--- a/crates/server/src/rest/routers/delta/mod.rs
+++ b/crates/server/src/rest/routers/delta/mod.rs
@@ -1,0 +1,299 @@
+//! Hand-written Axum router for the UC Delta REST API (`/delta/v1/...`).
+//!
+//! Mirrors the Delta Sharing router (`super::sharing`): a `get_router` that mounts
+//! every operation, plus per-operation handler functions that extract the request,
+//! call [`DeltaApiHandler`], and serialize the response. The models and trait are
+//! hand-maintained (see `models` and `crate::api::delta`) because the Delta API is
+//! a standalone REST protocol, not a generated resource API.
+
+pub mod models;
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::routing::{Router, get, post};
+use serde::Deserialize;
+
+use crate::Result;
+use crate::api::delta::{DeltaApiHandler, GetConfigQuery, SchemaPath, TablePath};
+use models::*;
+
+/// Create a [`Router`] for the Delta REST API. Routes match `openapi/delta.yaml`.
+pub fn get_router<T, Cx>(state: T) -> Router
+where
+    T: DeltaApiHandler<Cx> + Clone,
+    Cx: axum::extract::FromRequestParts<T> + Send + 'static,
+{
+    Router::new()
+        .route("/delta/v1/config", get(get_config::<T, Cx>))
+        .route(
+            "/delta/v1/catalogs/{catalog}/schemas/{schema}/staging-tables",
+            post(create_staging_table::<T, Cx>),
+        )
+        .route(
+            "/delta/v1/catalogs/{catalog}/schemas/{schema}/tables",
+            post(create_table::<T, Cx>),
+        )
+        .route(
+            "/delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}",
+            get(load_table::<T, Cx>)
+                .post(update_table::<T, Cx>)
+                .delete(delete_table::<T, Cx>)
+                .head(table_exists::<T, Cx>),
+        )
+        .route(
+            "/delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/rename",
+            post(rename_table::<T, Cx>),
+        )
+        .route(
+            "/delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials",
+            get(get_table_credentials::<T, Cx>),
+        )
+        .route(
+            "/delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/metrics",
+            post(report_metrics::<T, Cx>),
+        )
+        .route(
+            "/delta/v1/staging-tables/{table_id}/credentials",
+            get(get_staging_table_credentials::<T, Cx>),
+        )
+        .route(
+            "/delta/v1/temporary-path-credentials",
+            get(get_temporary_path_credentials::<T, Cx>),
+        )
+        .with_state(state)
+}
+
+// ----- Query parameter deserialization helpers -------------------------------
+
+#[derive(Debug, Deserialize)]
+struct GetConfigParams {
+    catalog: String,
+    #[serde(rename = "protocol-versions")]
+    protocol_versions: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OperationParam {
+    operation: DeltaCredentialOperation,
+}
+
+#[derive(Debug, Deserialize)]
+struct PathCredentialParams {
+    location: String,
+    operation: DeltaCredentialOperation,
+}
+
+// ----- Handlers --------------------------------------------------------------
+
+async fn get_config<T, Cx>(
+    State(handler): State<T>,
+    context: Cx,
+    Query(params): Query<GetConfigParams>,
+) -> Result<axum::Json<DeltaCatalogConfig>>
+where
+    T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
+    Cx: axum::extract::FromRequestParts<T> + Send,
+{
+    let query = GetConfigQuery {
+        catalog: params.catalog,
+        protocol_versions: params.protocol_versions,
+    };
+    Ok(axum::Json(handler.get_config(query, context).await?))
+}
+
+async fn create_staging_table<T, Cx>(
+    State(handler): State<T>,
+    context: Cx,
+    Path((catalog, schema)): Path<(String, String)>,
+    axum::Json(request): axum::Json<DeltaCreateStagingTableRequest>,
+) -> Result<axum::Json<DeltaStagingTableResponse>>
+where
+    T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
+    Cx: axum::extract::FromRequestParts<T> + Send,
+{
+    let path = SchemaPath { catalog, schema };
+    Ok(axum::Json(
+        handler.create_staging_table(path, request, context).await?,
+    ))
+}
+
+async fn create_table<T, Cx>(
+    State(handler): State<T>,
+    context: Cx,
+    Path((catalog, schema)): Path<(String, String)>,
+    axum::Json(request): axum::Json<DeltaCreateTableRequest>,
+) -> Result<axum::Json<DeltaLoadTableResponse>>
+where
+    T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
+    Cx: axum::extract::FromRequestParts<T> + Send,
+{
+    let path = SchemaPath { catalog, schema };
+    Ok(axum::Json(
+        handler.create_table(path, request, context).await?,
+    ))
+}
+
+async fn load_table<T, Cx>(
+    State(handler): State<T>,
+    context: Cx,
+    Path((catalog, schema, table)): Path<(String, String, String)>,
+) -> Result<axum::Json<DeltaLoadTableResponse>>
+where
+    T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
+    Cx: axum::extract::FromRequestParts<T> + Send,
+{
+    let path = TablePath {
+        catalog,
+        schema,
+        table,
+    };
+    Ok(axum::Json(handler.load_table(path, context).await?))
+}
+
+async fn update_table<T, Cx>(
+    State(handler): State<T>,
+    context: Cx,
+    Path((catalog, schema, table)): Path<(String, String, String)>,
+    axum::Json(request): axum::Json<DeltaUpdateTableRequest>,
+) -> Result<axum::Json<DeltaLoadTableResponse>>
+where
+    T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
+    Cx: axum::extract::FromRequestParts<T> + Send,
+{
+    let path = TablePath {
+        catalog,
+        schema,
+        table,
+    };
+    Ok(axum::Json(
+        handler.update_table(path, request, context).await?,
+    ))
+}
+
+async fn delete_table<T, Cx>(
+    State(handler): State<T>,
+    context: Cx,
+    Path((catalog, schema, table)): Path<(String, String, String)>,
+) -> Result<StatusCode>
+where
+    T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
+    Cx: axum::extract::FromRequestParts<T> + Send,
+{
+    let path = TablePath {
+        catalog,
+        schema,
+        table,
+    };
+    handler.delete_table(path, context).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn table_exists<T, Cx>(
+    State(handler): State<T>,
+    context: Cx,
+    Path((catalog, schema, table)): Path<(String, String, String)>,
+) -> Result<StatusCode>
+where
+    T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
+    Cx: axum::extract::FromRequestParts<T> + Send,
+{
+    let path = TablePath {
+        catalog,
+        schema,
+        table,
+    };
+    handler.table_exists(path, context).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn rename_table<T, Cx>(
+    State(handler): State<T>,
+    context: Cx,
+    Path((catalog, schema, table)): Path<(String, String, String)>,
+    axum::Json(request): axum::Json<DeltaRenameTableRequest>,
+) -> Result<StatusCode>
+where
+    T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
+    Cx: axum::extract::FromRequestParts<T> + Send,
+{
+    let path = TablePath {
+        catalog,
+        schema,
+        table,
+    };
+    handler.rename_table(path, request, context).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn get_table_credentials<T, Cx>(
+    State(handler): State<T>,
+    context: Cx,
+    Path((catalog, schema, table)): Path<(String, String, String)>,
+    Query(params): Query<OperationParam>,
+) -> Result<axum::Json<DeltaCredentialsResponse>>
+where
+    T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
+    Cx: axum::extract::FromRequestParts<T> + Send,
+{
+    let path = TablePath {
+        catalog,
+        schema,
+        table,
+    };
+    Ok(axum::Json(
+        handler
+            .get_table_credentials(path, params.operation, context)
+            .await?,
+    ))
+}
+
+async fn report_metrics<T, Cx>(
+    State(handler): State<T>,
+    context: Cx,
+    Path((catalog, schema, table)): Path<(String, String, String)>,
+    axum::Json(request): axum::Json<DeltaReportMetricsRequest>,
+) -> Result<StatusCode>
+where
+    T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
+    Cx: axum::extract::FromRequestParts<T> + Send,
+{
+    let path = TablePath {
+        catalog,
+        schema,
+        table,
+    };
+    handler.report_metrics(path, request, context).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn get_staging_table_credentials<T, Cx>(
+    State(handler): State<T>,
+    context: Cx,
+    Path(table_id): Path<String>,
+) -> Result<axum::Json<DeltaCredentialsResponse>>
+where
+    T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
+    Cx: axum::extract::FromRequestParts<T> + Send,
+{
+    Ok(axum::Json(
+        handler
+            .get_staging_table_credentials(table_id, context)
+            .await?,
+    ))
+}
+
+async fn get_temporary_path_credentials<T, Cx>(
+    State(handler): State<T>,
+    context: Cx,
+    Query(params): Query<PathCredentialParams>,
+) -> Result<axum::Json<DeltaCredentialsResponse>>
+where
+    T: DeltaApiHandler<Cx> + Clone + Send + Sync + 'static,
+    Cx: axum::extract::FromRequestParts<T> + Send,
+{
+    Ok(axum::Json(
+        handler
+            .get_temporary_path_credentials(params.location, params.operation, context)
+            .await?,
+    ))
+}

--- a/crates/server/src/rest/routers/delta/models.rs
+++ b/crates/server/src/rest/routers/delta/models.rs
@@ -1,0 +1,792 @@
+//! Hand-written serde models for the UC Delta REST API (`/delta/v1/...`).
+//!
+//! These mirror the component schemas in `openapi/delta.yaml` (vendored from the
+//! Unity Catalog Java reference, `api/delta.yaml`). The wire format is kebab-case
+//! JSON, so every struct uses `#[serde(rename_all = "kebab-case")]`; individual
+//! fields whose JSON key is not a straight kebab-case of the Rust identifier
+//! carry an explicit `#[serde(rename = "...")]`.
+//!
+//! This is a standalone REST protocol (not resource-CRUD), so — unlike the rest
+//! of the server — it is not generated from proto. See the plan and the Delta
+//! Sharing router for the precedent.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+// ===================================================================
+// Enums
+// ===================================================================
+
+/// The type of a Delta table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum DeltaTableType {
+    Managed,
+    External,
+}
+
+/// The permission level for a storage credential.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum DeltaCredentialOperation {
+    Read,
+    ReadWrite,
+}
+
+// ===================================================================
+// Shared credential types
+// ===================================================================
+
+/// Cloud provider-specific credential configuration. Only keys for the relevant
+/// cloud provider are populated; the others are omitted (`None`).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeltaStorageCredentialConfig {
+    #[serde(rename = "s3.access-key-id", skip_serializing_if = "Option::is_none")]
+    pub s3_access_key_id: Option<String>,
+    #[serde(
+        rename = "s3.secret-access-key",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub s3_secret_access_key: Option<String>,
+    #[serde(rename = "s3.session-token", skip_serializing_if = "Option::is_none")]
+    pub s3_session_token: Option<String>,
+    #[serde(rename = "azure.sas-token", skip_serializing_if = "Option::is_none")]
+    pub azure_sas_token: Option<String>,
+    #[serde(rename = "gcs.oauth-token", skip_serializing_if = "Option::is_none")]
+    pub gcs_oauth_token: Option<String>,
+}
+
+/// Temporary storage credential with prefix and config.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaStorageCredential {
+    /// Storage path prefix this credential applies to.
+    pub prefix: String,
+    pub operation: DeltaCredentialOperation,
+    pub config: DeltaStorageCredentialConfig,
+    /// Credential expiration time in epoch milliseconds.
+    pub expiration_time_ms: i64,
+}
+
+/// Response carrying temporary cloud storage credentials.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaCredentialsResponse {
+    pub storage_credentials: Vec<DeltaStorageCredential>,
+}
+
+// ===================================================================
+// Configuration
+// ===================================================================
+
+/// Catalog configuration and supported endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaCatalogConfig {
+    /// List of supported endpoints.
+    pub endpoints: Vec<String>,
+    /// The negotiated protocol version (e.g., "1.0").
+    pub protocol_version: String,
+}
+
+// ===================================================================
+// Delta data types (schema)
+// ===================================================================
+
+/// A Delta column data type.
+///
+/// On the wire, primitive types are bare JSON strings (e.g. `"long"`, `"string"`,
+/// `"decimal(10,2)"`) while complex types are JSON objects carrying a `type`
+/// discriminator (`"array"`, `"map"`, `"struct"`, `"decimal"`). serde's `untagged`
+/// representation drives the split: a JSON string matches [`DeltaDataType::Primitive`];
+/// a JSON object matches one of the object variants. Each object variant carries its
+/// own `type` constant so it both round-trips and self-identifies.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DeltaDataType {
+    /// Bare-string primitive type, e.g. `"long"`, `"string"`, `"decimal(10,2)"`.
+    Primitive(String),
+    Array(Box<DeltaArrayType>),
+    Map(Box<DeltaMapType>),
+    Struct(Box<DeltaStructType>),
+    /// Object form of decimal (`{"type":"decimal","precision":..,"scale":..}`).
+    /// The string form `"decimal(p,s)"` is carried by [`DeltaDataType::Primitive`].
+    Decimal(DeltaDecimalType),
+}
+
+/// The `type` discriminator constant for an array data type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ArrayTypeTag {
+    #[default]
+    Array,
+}
+
+/// The `type` discriminator constant for a map data type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MapTypeTag {
+    #[default]
+    Map,
+}
+
+/// The `type` discriminator constant for a decimal data type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DecimalTypeTag {
+    #[default]
+    Decimal,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaArrayType {
+    #[serde(rename = "type", default)]
+    pub type_tag: ArrayTypeTag,
+    pub element_type: DeltaDataType,
+    pub contains_null: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaMapType {
+    #[serde(rename = "type", default)]
+    pub type_tag: MapTypeTag,
+    pub key_type: DeltaDataType,
+    pub value_type: DeltaDataType,
+    pub value_contains_null: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeltaDecimalType {
+    #[serde(rename = "type", default)]
+    pub type_tag: DecimalTypeTag,
+    pub precision: i32,
+    pub scale: i32,
+}
+
+/// A field in a [`DeltaStructType`]: name, type, nullability, and metadata.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeltaStructField {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub data_type: DeltaDataType,
+    pub nullable: bool,
+    /// Arbitrary column metadata (e.g. `comment`, `delta.columnMapping.id`).
+    /// Values can be strings, numbers, booleans, or nested objects.
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+/// Struct type containing named fields. Carries the `type: "struct"`
+/// discriminator on the wire (it is the schema container for tables), so it is
+/// emitted/accepted explicitly even when used as a bare `columns` value.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeltaStructType {
+    #[serde(rename = "type", default = "struct_type_tag")]
+    pub type_tag: StructTypeTag,
+    pub fields: Vec<DeltaStructField>,
+}
+
+fn struct_type_tag() -> StructTypeTag {
+    StructTypeTag::Struct
+}
+
+/// The constant `"struct"` discriminator for [`DeltaStructType`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StructTypeTag {
+    #[default]
+    Struct,
+}
+
+// ===================================================================
+// Protocol
+// ===================================================================
+
+/// Delta table protocol specification.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaProtocol {
+    pub min_reader_version: i32,
+    pub min_writer_version: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reader_features: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub writer_features: Option<Vec<String>>,
+}
+
+/// Suggested protocol advertised in the staging response (no version fields,
+/// only feature hints).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaSuggestedProtocol {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reader_features: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub writer_features: Option<Vec<String>>,
+}
+
+// ===================================================================
+// Domain metadata
+// ===================================================================
+
+/// Configuration for Clustered Tables.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeltaClusteringDomainMetadata {
+    /// Clustering column paths. Each inner array is a path from root schema to a
+    /// column.
+    #[serde(rename = "clusteringColumns")]
+    pub clustering_columns: Vec<Vec<String>>,
+}
+
+/// Configuration for Row Tracking.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeltaRowTrackingDomainMetadata {
+    /// The highest fresh Row ID assigned so far.
+    #[serde(rename = "rowIdHighWaterMark")]
+    pub row_id_high_water_mark: i64,
+}
+
+/// Domain metadata entries keyed by domain name.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeltaDomainMetadataUpdates {
+    #[serde(rename = "delta.clustering", skip_serializing_if = "Option::is_none")]
+    pub delta_clustering: Option<DeltaClusteringDomainMetadata>,
+    #[serde(rename = "delta.rowTracking", skip_serializing_if = "Option::is_none")]
+    pub delta_row_tracking: Option<DeltaRowTrackingDomainMetadata>,
+}
+
+// ===================================================================
+// Uniform / Iceberg
+// ===================================================================
+
+/// Iceberg-specific conversion metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaIcebergMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_location: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub converted_delta_version: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub converted_delta_timestamp: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_converted_delta_version: Option<i64>,
+}
+
+/// UniForm conversion metadata. Present only for Uniform (Delta + Iceberg) tables.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeltaUniformMetadata {
+    pub iceberg: DeltaIcebergMetadata,
+}
+
+// ===================================================================
+// Commit
+// ===================================================================
+
+/// Delta commit information for CCv2.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaCommit {
+    pub version: i64,
+    /// In-commit timestamp, in epoch milliseconds.
+    pub timestamp: i64,
+    /// UUID-based commit file name.
+    pub file_name: String,
+    pub file_size: i64,
+    /// File modification timestamp, in epoch milliseconds.
+    pub file_modification_timestamp: i64,
+}
+
+// ===================================================================
+// Table lifecycle
+// ===================================================================
+
+/// Request to create a staging table.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeltaCreateStagingTableRequest {
+    pub name: String,
+}
+
+/// Response from creating a staging table. Advertises the UC catalog-managed
+/// contract (required / suggested protocol + properties) plus READ_WRITE
+/// credentials for writing the initial commit.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaStagingTableResponse {
+    pub table_id: String,
+    pub table_type: DeltaTableType,
+    pub location: String,
+    pub storage_credentials: Vec<DeltaStorageCredential>,
+    pub required_protocol: DeltaProtocol,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggested_protocol: Option<DeltaSuggestedProtocol>,
+    /// Properties that must be set; null values mean any valid value is allowed.
+    pub required_properties: BTreeMap<String, Option<String>>,
+    /// Properties that should be set whenever possible; null values mean the
+    /// client generates the value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggested_properties: Option<BTreeMap<String, Option<String>>>,
+}
+
+/// Request to create a Delta table (managed or external).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaCreateTableRequest {
+    pub name: String,
+    pub location: String,
+    pub table_type: DeltaTableType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    pub columns: DeltaStructType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partition_columns: Option<Vec<String>>,
+    pub protocol: DeltaProtocol,
+    pub properties: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain_metadata: Option<DeltaDomainMetadataUpdates>,
+    /// Timestamp of version 0 (the commit the client wrote before calling this
+    /// endpoint), in epoch milliseconds.
+    pub last_commit_timestamp_ms: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uniform: Option<DeltaUniformMetadata>,
+}
+
+/// Complete table metadata.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaTableMetadata {
+    /// Entity tag for optimistic concurrency control.
+    pub etag: String,
+    pub table_type: DeltaTableType,
+    pub table_uuid: String,
+    pub location: String,
+    pub created_time: i64,
+    pub updated_time: i64,
+    pub columns: DeltaStructType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partition_columns: Option<Vec<String>>,
+    pub properties: BTreeMap<String, String>,
+    /// The version of the last commit that changed table metadata
+    /// (`delta.lastUpdateVersion`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_commit_version: Option<i64>,
+    /// Timestamp of the last commit that changed table metadata, in epoch
+    /// milliseconds (`delta.lastCommitTimestamp`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_commit_timestamp_ms: Option<i64>,
+}
+
+/// Response from `loadTable` / `createTable` / `updateTable`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaLoadTableResponse {
+    pub metadata: DeltaTableMetadata,
+    /// All unbackfilled CCv2 commits.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commits: Option<Vec<DeltaCommit>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uniform: Option<DeltaUniformMetadata>,
+    /// The latest ratified table version tracked by the server, including
+    /// data-only commits.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_table_version: Option<i64>,
+}
+
+/// Request to rename a table within the same catalog and schema.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaRenameTableRequest {
+    pub new_name: String,
+}
+
+// ===================================================================
+// Update table (requirements + actions)
+// ===================================================================
+
+/// A pre-condition that must hold for the update to apply.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum DeltaTableRequirement {
+    /// `assert-table-uuid`: the table UUID must match `uuid`.
+    AssertTableUuid { uuid: String },
+    /// `assert-etag`: the table etag must match `etag`.
+    AssertEtag { etag: String },
+}
+
+/// A single update action. Tagged by the `action` discriminator, matching the
+/// `propertyName: action` + `const` mapping in `delta.yaml`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "kebab-case")]
+pub enum DeltaTableUpdate {
+    SetProperties {
+        updates: BTreeMap<String, String>,
+    },
+    RemoveProperties {
+        removals: Vec<String>,
+    },
+    SetColumns {
+        columns: DeltaStructType,
+    },
+    SetTableComment {
+        comment: String,
+    },
+    AddCommit {
+        commit: DeltaCommit,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        uniform: Option<DeltaUniformMetadata>,
+    },
+    SetLatestBackfilledVersion {
+        #[serde(rename = "latest-published-version")]
+        latest_published_version: i64,
+    },
+    SetProtocol {
+        protocol: DeltaProtocol,
+    },
+    SetDomainMetadata {
+        updates: DeltaDomainMetadataUpdates,
+    },
+    RemoveDomainMetadata {
+        domains: Vec<String>,
+    },
+    SetPartitionColumns {
+        #[serde(rename = "partition-columns")]
+        partition_columns: Vec<String>,
+    },
+    UpdateMetadataSnapshotVersion {
+        #[serde(rename = "last-commit-version")]
+        last_commit_version: i64,
+        #[serde(rename = "last-commit-timestamp-ms")]
+        last_commit_timestamp_ms: i64,
+    },
+}
+
+/// Request to update a table with requirements and updates.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeltaUpdateTableRequest {
+    pub requirements: Vec<DeltaTableRequirement>,
+    pub updates: Vec<DeltaTableUpdate>,
+}
+
+// ===================================================================
+// Metrics
+// ===================================================================
+
+/// Histogram tracking file counts and total bytes across size ranges.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaFileSizeHistogram {
+    pub sorted_bin_boundaries: Vec<i64>,
+    pub file_counts: Vec<i64>,
+    pub total_bytes: Vec<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit_version: Option<i64>,
+}
+
+/// Commit report metrics.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaCommitReport {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_files_added: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_bytes_added: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_files_removed: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_bytes_removed: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_rows_inserted: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_rows_removed: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_rows_updated: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_size_histogram: Option<DeltaFileSizeHistogram>,
+}
+
+/// The metrics being reported.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaReport {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit_report: Option<DeltaCommitReport>,
+}
+
+/// Request to report commit metrics (telemetry) for a table.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DeltaReportMetricsRequest {
+    /// Table UUID. Must match the table identified by the path.
+    pub table_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub report: Option<DeltaReport>,
+}
+
+#[cfg(test)]
+mod tests {
+    //! Round-trip tests over the example payloads in `openapi/delta.yaml`.
+    //!
+    //! Each test deserializes a spec example into our hand-written model and
+    //! re-serializes it, asserting the JSON survives a round-trip with the
+    //! kebab-case keys, enum casing, and tagged-union discriminators intact.
+    //! This is the Phase-1 parity gate: it pins our models to the vendored spec.
+
+    use super::*;
+    use serde_json::{Value, json};
+
+    /// Deserialize `json` into `T`, re-serialize, and assert structural equality
+    /// with the original JSON value (key order independent).
+    fn round_trip<T>(value: Value)
+    where
+        T: Serialize + for<'de> Deserialize<'de>,
+    {
+        let parsed: T = serde_json::from_value(value.clone())
+            .unwrap_or_else(|e| panic!("deserialize failed: {e}\njson: {value:#}"));
+        let reserialized = serde_json::to_value(&parsed).expect("serialize");
+        assert_eq!(
+            reserialized, value,
+            "round-trip mismatch\n  expected: {value:#}\n  got:      {reserialized:#}"
+        );
+    }
+
+    #[test]
+    fn staging_table_response() {
+        round_trip::<DeltaStagingTableResponse>(json!({
+            "table-id": "123e4567-e89b-12d3-a456-426614174000",
+            "table-type": "MANAGED",
+            "location": "s3://bucket/warehouse/catalog/schema/table",
+            "storage-credentials": [{
+                "prefix": "s3://bucket/warehouse/catalog/schema/table/",
+                "operation": "READ_WRITE",
+                "config": {
+                    "s3.access-key-id": "AK...example",
+                    "s3.secret-access-key": "ExampleKey",
+                    "s3.session-token": "token"
+                },
+                "expiration-time-ms": 1234567890000_i64
+            }],
+            "required-protocol": {
+                "min-reader-version": 3,
+                "min-writer-version": 7,
+                "reader-features": ["deletionVectors", "vacuumProtocolCheck"],
+                "writer-features": ["catalogManaged", "deletionVectors"]
+            },
+            "suggested-protocol": {
+                "reader-features": ["typeWidening"],
+                "writer-features": ["domainMetadata", "rowTracking"]
+            },
+            "required-properties": { "delta.checkpointPolicy": "v2" },
+            "suggested-properties": {
+                "delta.rowTracking.materializedRowIdColumnName": null,
+                "delta.rowTracking.materializedRowCommitVersionColumnName": null
+            }
+        }));
+    }
+
+    #[test]
+    fn create_table_request_with_decimal_and_partition() {
+        round_trip::<DeltaCreateTableRequest>(json!({
+            "name": "sales",
+            "location": "s3://bucket/warehouse/catalog/schema/sales",
+            "table-type": "MANAGED",
+            "columns": {
+                "type": "struct",
+                "fields": [
+                    { "name": "id", "type": "long", "nullable": false, "metadata": {} },
+                    {
+                        "name": "amount",
+                        "type": { "type": "decimal", "precision": 10, "scale": 2 },
+                        "nullable": true,
+                        "metadata": {}
+                    }
+                ]
+            },
+            "partition-columns": ["id"],
+            "protocol": {
+                "min-reader-version": 3,
+                "min-writer-version": 7,
+                "reader-features": ["deletionVectors"],
+                "writer-features": ["deletionVectors", "invariants"]
+            },
+            "properties": { "delta.enableDeletionVectors": "true" },
+            "last-commit-timestamp-ms": 1704067400000_i64
+        }));
+    }
+
+    #[test]
+    fn struct_type_carries_type_tag() {
+        // A bare `columns` value round-trips with its `type: "struct"` tag.
+        round_trip::<DeltaStructType>(json!({
+            "type": "struct",
+            "fields": [
+                { "name": "id", "type": "long", "nullable": false, "metadata": {} },
+                { "name": "name", "type": "string", "nullable": true, "metadata": {} }
+            ]
+        }));
+    }
+
+    #[test]
+    fn nested_array_and_map_types() {
+        round_trip::<DeltaStructField>(json!({
+            "name": "tags",
+            "type": {
+                "type": "array",
+                "element-type": "string",
+                "contains-null": true
+            },
+            "nullable": true,
+            "metadata": {}
+        }));
+        round_trip::<DeltaStructField>(json!({
+            "name": "props",
+            "type": {
+                "type": "map",
+                "key-type": "string",
+                "value-type": "long",
+                "value-contains-null": false
+            },
+            "nullable": true,
+            "metadata": {}
+        }));
+    }
+
+    #[test]
+    fn load_table_response_with_commits() {
+        round_trip::<DeltaLoadTableResponse>(json!({
+            "metadata": {
+                "etag": "etag-1",
+                "table-type": "MANAGED",
+                "table-uuid": "123e4567-e89b-12d3-a456-426614174000",
+                "location": "s3://bucket/warehouse/catalog/schema/table",
+                "created-time": 1705600000000_i64,
+                "updated-time": 1705600000000_i64,
+                "columns": { "type": "struct", "fields": [] },
+                "properties": { "delta.checkpointPolicy": "v2" },
+                "last-commit-version": 0,
+                "last-commit-timestamp-ms": 1704067400000_i64
+            },
+            "commits": [{
+                "version": 1,
+                "timestamp": 1704067200000_i64,
+                "file-name": "00000000-0000-0000-0000-00000000002a.json",
+                "file-size": 2048,
+                "file-modification-timestamp": 1704067200000_i64
+            }],
+            "latest-table-version": 1
+        }));
+    }
+
+    #[test]
+    fn update_table_request_add_commit() {
+        round_trip::<DeltaUpdateTableRequest>(json!({
+            "requirements": [
+                { "type": "assert-table-uuid", "uuid": "123e4567-e89b-12d3-a456-426614174000" },
+                { "type": "assert-etag", "etag": "etag-1" }
+            ],
+            "updates": [
+                {
+                    "action": "add-commit",
+                    "commit": {
+                        "version": 1,
+                        "timestamp": 1704067200000_i64,
+                        "file-name": "v.uuid1.json",
+                        "file-size": 2048,
+                        "file-modification-timestamp": 1704067200000_i64
+                    }
+                },
+                { "action": "set-latest-backfilled-version", "latest-published-version": 0 }
+            ]
+        }));
+    }
+
+    #[test]
+    fn update_table_request_metadata_actions() {
+        round_trip::<DeltaUpdateTableRequest>(json!({
+            "requirements": [],
+            "updates": [
+                { "action": "set-properties", "updates": { "k": "v" } },
+                { "action": "remove-properties", "removals": ["old"] },
+                { "action": "set-table-comment", "comment": "hello" },
+                {
+                    "action": "set-protocol",
+                    "protocol": { "min-reader-version": 3, "min-writer-version": 7 }
+                },
+                { "action": "set-partition-columns", "partition-columns": ["id"] },
+                {
+                    "action": "update-metadata-snapshot-version",
+                    "last-commit-version": 5,
+                    "last-commit-timestamp-ms": 1704067400000_i64
+                }
+            ]
+        }));
+    }
+
+    #[test]
+    fn update_table_domain_metadata_actions() {
+        round_trip::<DeltaUpdateTableRequest>(json!({
+            "requirements": [],
+            "updates": [
+                {
+                    "action": "set-domain-metadata",
+                    "updates": {
+                        "delta.clustering": { "clusteringColumns": [["id"], ["address", "city"]] },
+                        "delta.rowTracking": { "rowIdHighWaterMark": 42 }
+                    }
+                },
+                { "action": "remove-domain-metadata", "domains": ["delta.clustering"] }
+            ]
+        }));
+    }
+
+    #[test]
+    fn credentials_response() {
+        round_trip::<DeltaCredentialsResponse>(json!({
+            "storage-credentials": [{
+                "prefix": "s3://bucket/path/",
+                "operation": "READ",
+                "config": { "s3.access-key-id": "AK", "s3.secret-access-key": "SK" },
+                "expiration-time-ms": 1234567890000_i64
+            }]
+        }));
+    }
+
+    #[test]
+    fn catalog_config() {
+        round_trip::<DeltaCatalogConfig>(json!({
+            "endpoints": ["GET /v1/config"],
+            "protocol-version": "1.0"
+        }));
+    }
+
+    #[test]
+    fn report_metrics_request() {
+        round_trip::<DeltaReportMetricsRequest>(json!({
+            "table-id": "123e4567-e89b-12d3-a456-426614174000",
+            "report": {
+                "commit-report": {
+                    "num-files-added": 10,
+                    "num-bytes-added": 104857600_i64,
+                    "file-size-histogram": {
+                        "sorted-bin-boundaries": [0, 1024, 2048],
+                        "file-counts": [100, 40, 5],
+                        "total-bytes": [104857600_i64, 167772160_i64, 83886080_i64],
+                        "commit-version": 6
+                    }
+                }
+            }
+        }));
+    }
+
+    #[test]
+    fn uniform_metadata_round_trips() {
+        round_trip::<DeltaUniformMetadata>(json!({
+            "iceberg": {
+                "metadata-location": "s3://bucket/metadata/v1.json",
+                "converted-delta-version": 42,
+                "converted-delta-timestamp": 1704067200000_i64
+            }
+        }));
+    }
+}

--- a/crates/server/src/rest/routers/delta/models.rs
+++ b/crates/server/src/rest/routers/delta/models.rs
@@ -12,7 +12,12 @@
 
 use std::collections::BTreeMap;
 
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
+
+use crate::Error;
 
 // ===================================================================
 // Enums
@@ -522,6 +527,120 @@ pub struct DeltaReportMetricsRequest {
     pub table_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub report: Option<DeltaReport>,
+}
+
+// ===================================================================
+// Errors (the /delta/v1 envelope)
+// ===================================================================
+
+/// Error type identifier returned in Delta API error responses. Mirrors the
+/// `DeltaErrorType` enum in `delta.yaml`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeltaErrorType {
+    BadRequestException,
+    InvalidParameterValueException,
+    UnsupportedTableFormatException,
+    NotAuthorizedException,
+    PermissionDeniedException,
+    NotFoundException,
+    NoSuchCatalogException,
+    NoSuchSchemaException,
+    NoSuchTableException,
+    AlreadyExistsException,
+    CommitVersionConflictException,
+    UpdateRequirementConflictException,
+    ResourceExhaustedException,
+    TooManyRequestsException,
+    CommitStateUnknownException,
+    InternalServerErrorException,
+    NotImplementedException,
+}
+
+/// The JSON error payload (`DeltaErrorModel` in `delta.yaml`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeltaErrorModel {
+    pub message: String,
+    #[serde(rename = "type")]
+    pub error_type: DeltaErrorType,
+    /// HTTP response code.
+    pub code: u16,
+}
+
+/// The JSON wrapper for all Delta API error responses (`DeltaErrorResponse`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeltaErrorResponse {
+    pub error: DeltaErrorModel,
+}
+
+/// Error wrapper used as the error half of every Delta handler's `Result`. It maps
+/// the server's internal [`Error`] onto the Delta API envelope
+/// (`{ "error": { message, type, code } }`) so `/delta/v1/` responses match the
+/// reference `DeltaApiExceptionHandler`, distinct from the server's standard
+/// `{errorCode, message}` envelope.
+#[derive(Debug)]
+pub struct DeltaError(pub Error);
+
+impl From<Error> for DeltaError {
+    fn from(e: Error) -> Self {
+        DeltaError(e)
+    }
+}
+
+impl DeltaError {
+    fn parts(&self) -> (StatusCode, DeltaErrorType) {
+        use DeltaErrorType::*;
+        match &self.0 {
+            Error::NotFound | Error::ResourceStore { .. } => {
+                (StatusCode::NOT_FOUND, NoSuchTableException)
+            }
+            // The wrapped common error carries its own semantics; dispatch on its
+            // machine-readable code so e.g. an "already exists" doesn't surface as 404.
+            Error::Common { source } => match source.error_code() {
+                "RESOURCE_ALREADY_EXISTS" => (StatusCode::CONFLICT, AlreadyExistsException),
+                "INVALID_PARAMETER_VALUE" => {
+                    (StatusCode::BAD_REQUEST, InvalidParameterValueException)
+                }
+                "PERMISSION_DENIED" => (StatusCode::FORBIDDEN, PermissionDeniedException),
+                "COMMIT_VERSION_CONFLICT" => (StatusCode::CONFLICT, CommitVersionConflictException),
+                "RESOURCE_EXHAUSTED" => (StatusCode::TOO_MANY_REQUESTS, ResourceExhaustedException),
+                _ => (StatusCode::NOT_FOUND, NotFoundException),
+            },
+            Error::NotAllowed => (StatusCode::FORBIDDEN, PermissionDeniedException),
+            Error::Unauthenticated => (StatusCode::UNAUTHORIZED, NotAuthorizedException),
+            Error::AlreadyExists => (StatusCode::CONFLICT, AlreadyExistsException),
+            Error::CommitVersionConflict(_) => {
+                (StatusCode::CONFLICT, CommitVersionConflictException)
+            }
+            Error::UpdateRequirementConflict(_) => {
+                (StatusCode::CONFLICT, UpdateRequirementConflictException)
+            }
+            Error::ResourceExhausted(_) => {
+                (StatusCode::TOO_MANY_REQUESTS, ResourceExhaustedException)
+            }
+            Error::InvalidArgument(_) | Error::InvalidIdentifier(_) | Error::MissingRecipient => {
+                (StatusCode::BAD_REQUEST, InvalidParameterValueException)
+            }
+            Error::NotImplemented(_) => (StatusCode::NOT_IMPLEMENTED, NotImplementedException),
+            _ => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                InternalServerErrorException,
+            ),
+        }
+    }
+}
+
+impl IntoResponse for DeltaError {
+    fn into_response(self) -> Response {
+        let (status, error_type) = self.parts();
+        let body = DeltaErrorResponse {
+            error: DeltaErrorModel {
+                message: self.0.to_string(),
+                error_type,
+                code: status.as_u16(),
+            },
+        };
+        (status, Json(body)).into_response()
+    }
 }
 
 #[cfg(test)]

--- a/crates/server/src/rest/routers/mod.rs
+++ b/crates/server/src/rest/routers/mod.rs
@@ -6,8 +6,10 @@ use crate::api::{
 };
 use axum::routing::{delete, get, patch, post};
 
+pub use delta::get_router as create_delta_router;
 pub use sharing::get_router as create_sharing_router;
 
+pub mod delta;
 mod sharing;
 
 pub fn create_catalogs_router<T, Cx>(handler: T) -> axum::Router

--- a/crates/server/src/services/managed_delta_contract.rs
+++ b/crates/server/src/services/managed_delta_contract.rs
@@ -1,0 +1,661 @@
+//! The UC catalog-managed Delta table contract, the stored-property projection,
+//! and the Delta-API ↔ UC column conversion.
+//!
+//! Ported from the Unity Catalog Java reference
+//! (`service/delta/{UcManagedDeltaContract,DeltaConsts,DeltaPropertyMapper}.java`
+//! and `utils/ColumnUtils.java`). The contract is the single source of truth that
+//! `createStagingTable` advertises and that `createTable` / `updateTable` validate
+//! against, so producer and consumer cannot drift.
+
+use std::collections::BTreeMap;
+
+use unitycatalog_common::models::tables::v1::{Column, ColumnTypeName};
+
+use crate::rest::routers::delta::models::{
+    DeltaArrayType, DeltaCreateTableRequest, DeltaDataType, DeltaDecimalType,
+    DeltaDomainMetadataUpdates, DeltaMapType, DeltaProtocol, DeltaStructField, DeltaStructType,
+};
+use crate::{Error, Result};
+
+// ===================================================================
+// Contract constants (DeltaConsts + UcManagedDeltaContract)
+// ===================================================================
+
+/// Reader version 3 is the minimum that supports per-feature reader-features negotiation.
+pub const REQUIRED_MIN_READER_VERSION: i32 = 3;
+/// Writer version 7 is the minimum that supports per-feature writer-features negotiation.
+pub const REQUIRED_MIN_WRITER_VERSION: i32 = 7;
+
+// Table-feature spec names.
+const FEATURE_CATALOG_MANAGED: &str = "catalogManaged";
+const FEATURE_DELETION_VECTORS: &str = "deletionVectors";
+const FEATURE_V2_CHECKPOINT: &str = "v2Checkpoint";
+const FEATURE_VACUUM_PROTOCOL_CHECK: &str = "vacuumProtocolCheck";
+const FEATURE_COLUMN_MAPPING: &str = "columnMapping";
+const FEATURE_IN_COMMIT_TIMESTAMP: &str = "inCommitTimestamp";
+const FEATURE_DOMAIN_METADATA: &str = "domainMetadata";
+const FEATURE_ROW_TRACKING: &str = "rowTracking";
+
+/// Required reader-features (the reader-writer subset of the required features).
+pub const REQUIRED_READER_FEATURES: &[&str] = &[
+    FEATURE_CATALOG_MANAGED,
+    FEATURE_V2_CHECKPOINT,
+    FEATURE_VACUUM_PROTOCOL_CHECK,
+    FEATURE_DELETION_VECTORS,
+];
+/// Required writer-features (reader-writer features + the writer-only `inCommitTimestamp`).
+pub const REQUIRED_WRITER_FEATURES: &[&str] = &[
+    FEATURE_CATALOG_MANAGED,
+    FEATURE_V2_CHECKPOINT,
+    FEATURE_VACUUM_PROTOCOL_CHECK,
+    FEATURE_DELETION_VECTORS,
+    FEATURE_IN_COMMIT_TIMESTAMP,
+];
+/// Suggested reader-features.
+pub const SUGGESTED_READER_FEATURES: &[&str] = &[FEATURE_COLUMN_MAPPING];
+/// Suggested writer-features.
+pub const SUGGESTED_WRITER_FEATURES: &[&str] = &[
+    FEATURE_COLUMN_MAPPING,
+    FEATURE_DOMAIN_METADATA,
+    FEATURE_ROW_TRACKING,
+];
+
+// Table-property keys.
+pub const PROP_UC_TABLE_ID: &str = "io.unitycatalog.tableId";
+pub const PROP_LAST_UPDATE_VERSION: &str = "delta.lastUpdateVersion";
+pub const PROP_LAST_COMMIT_TIMESTAMP: &str = "delta.lastCommitTimestamp";
+pub const PROP_CHECKPOINT_POLICY: &str = "delta.checkpointPolicy";
+pub const PROP_ENABLE_DELETION_VECTORS: &str = "delta.enableDeletionVectors";
+pub const PROP_ENABLE_IN_COMMIT_TIMESTAMPS: &str = "delta.enableInCommitTimestamps";
+pub const PROP_CHECKPOINT_WRITE_STATS_AS_STRUCT: &str = "delta.checkpoint.writeStatsAsStruct";
+pub const PROP_CHECKPOINT_WRITE_STATS_AS_JSON: &str = "delta.checkpoint.writeStatsAsJson";
+const PROP_MIN_READER_VERSION: &str = "delta.minReaderVersion";
+const PROP_MIN_WRITER_VERSION: &str = "delta.minWriterVersion";
+const PROP_CLUSTERING_COLUMNS: &str = "delta.clusteringColumns";
+const PROP_ROW_TRACKING_HIGH_WATER_MARK: &str = "delta.rowTracking.rowIdHighWaterMark";
+const FEATURE_PREFIX: &str = "delta.feature.";
+const FEATURE_SUPPORTED: &str = "supported";
+
+/// Required properties with fixed values (excludes `io.unitycatalog.tableId`, which is
+/// per-table). Order is irrelevant; kept as a slice of pairs.
+pub const REQUIRED_FIXED_PROPERTIES: &[(&str, &str)] = &[
+    (PROP_ENABLE_DELETION_VECTORS, "true"),
+    (PROP_CHECKPOINT_POLICY, "v2"),
+    (PROP_ENABLE_IN_COMMIT_TIMESTAMPS, "true"),
+    (PROP_CHECKPOINT_WRITE_STATS_AS_STRUCT, "true"),
+    (PROP_CHECKPOINT_WRITE_STATS_AS_JSON, "true"),
+];
+
+/// Suggested properties advertised in the staging response. `None` values mean the
+/// client generates the value at commit time.
+pub fn suggested_properties() -> BTreeMap<String, Option<String>> {
+    BTreeMap::from([
+        (
+            "delta.columnMapping.mode".to_string(),
+            Some("name".to_string()),
+        ),
+        ("delta.columnMapping.maxColumnId".to_string(), None),
+        (
+            "delta.enableRowTracking".to_string(),
+            Some("true".to_string()),
+        ),
+        (
+            "delta.rowTracking.materializedRowIdColumnName".to_string(),
+            None,
+        ),
+        (
+            "delta.rowTracking.materializedRowCommitVersionColumnName".to_string(),
+            None,
+        ),
+        (
+            "delta.randomizeFilePrefixes".to_string(),
+            Some("true".to_string()),
+        ),
+        (
+            "delta.parquet.compression.codec".to_string(),
+            Some("zstd".to_string()),
+        ),
+    ])
+}
+
+/// Required properties advertised in the staging response: the fixed values plus the
+/// per-table `io.unitycatalog.tableId` bound to the allocated UUID.
+pub fn required_properties(table_id: &str) -> BTreeMap<String, Option<String>> {
+    let mut props: BTreeMap<String, Option<String>> = REQUIRED_FIXED_PROPERTIES
+        .iter()
+        .map(|(k, v)| (k.to_string(), Some(v.to_string())))
+        .collect();
+    props.insert(PROP_UC_TABLE_ID.to_string(), Some(table_id.to_string()));
+    props
+}
+
+// ===================================================================
+// Contract validation (MANAGED tables only)
+// ===================================================================
+
+/// Validate that the supplied protocol, domain-metadata, and properties satisfy the
+/// UC catalog-managed Delta contract. Apply only to MANAGED tables; EXTERNAL tables
+/// mirror what the client wrote and skip this. All failures map to
+/// [`Error::InvalidArgument`] (HTTP 400, the spec's `INVALID_PARAMETER_VALUE`).
+pub fn validate(
+    protocol: &DeltaProtocol,
+    domain_metadata: Option<&DeltaDomainMetadataUpdates>,
+    properties: &BTreeMap<String, String>,
+) -> Result<()> {
+    validate_reader_feature_subset(protocol)?;
+    validate_required_versions(protocol)?;
+    validate_required_features(protocol)?;
+    validate_domain_metadata_against_protocol(protocol, domain_metadata)?;
+    validate_required_properties(properties)?;
+    Ok(())
+}
+
+/// Every reader-feature must also be a writer-feature (Delta-spec rule).
+fn validate_reader_feature_subset(protocol: &DeltaProtocol) -> Result<()> {
+    let Some(reader) = protocol.reader_features.as_ref() else {
+        return Ok(());
+    };
+    let writer: &[String] = protocol.writer_features.as_deref().unwrap_or(&[]);
+    for rf in reader {
+        if !writer.iter().any(|wf| wf == rf) {
+            return Err(Error::invalid_argument(format!(
+                "Feature '{rf}' is in reader-features but not writer-features. Per the Delta \
+                 protocol, every reader-feature must also be a writer-feature."
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_required_versions(protocol: &DeltaProtocol) -> Result<()> {
+    if protocol.min_reader_version < REQUIRED_MIN_READER_VERSION {
+        return Err(Error::invalid_argument(format!(
+            "MANAGED table minReaderVersion must be at least {REQUIRED_MIN_READER_VERSION} \
+             (got {}).",
+            protocol.min_reader_version
+        )));
+    }
+    if protocol.min_writer_version < REQUIRED_MIN_WRITER_VERSION {
+        return Err(Error::invalid_argument(format!(
+            "MANAGED table minWriterVersion must be at least {REQUIRED_MIN_WRITER_VERSION} \
+             (got {}).",
+            protocol.min_writer_version
+        )));
+    }
+    Ok(())
+}
+
+fn validate_required_features(protocol: &DeltaProtocol) -> Result<()> {
+    let reader: &[String] = protocol.reader_features.as_deref().unwrap_or(&[]);
+    let writer: &[String] = protocol.writer_features.as_deref().unwrap_or(&[]);
+    for required in REQUIRED_READER_FEATURES {
+        if !reader.iter().any(|f| f == required) {
+            return Err(Error::invalid_argument(format!(
+                "MANAGED table missing required reader-feature '{required}'."
+            )));
+        }
+    }
+    for required in REQUIRED_WRITER_FEATURES {
+        if !writer.iter().any(|f| f == required) {
+            return Err(Error::invalid_argument(format!(
+                "MANAGED table missing required writer-feature '{required}'."
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_domain_metadata_against_protocol(
+    protocol: &DeltaProtocol,
+    domain_metadata: Option<&DeltaDomainMetadataUpdates>,
+) -> Result<()> {
+    let Some(dm) = domain_metadata else {
+        return Ok(());
+    };
+    let writer: &[String] = protocol.writer_features.as_deref().unwrap_or(&[]);
+    if dm.delta_clustering.is_some() && !writer.iter().any(|f| f == "clustering") {
+        return Err(Error::invalid_argument(
+            "domain-metadata.delta.clustering requires the 'clustering' writer feature.",
+        ));
+    }
+    if dm.delta_row_tracking.is_some() && !writer.iter().any(|f| f == FEATURE_ROW_TRACKING) {
+        return Err(Error::invalid_argument(
+            "domain-metadata.delta.rowTracking requires the 'rowTracking' writer feature.",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_required_properties(properties: &BTreeMap<String, String>) -> Result<()> {
+    for (key, expected) in REQUIRED_FIXED_PROPERTIES {
+        match properties.get(*key) {
+            Some(actual) if actual == expected => {}
+            actual => {
+                return Err(Error::invalid_argument(format!(
+                    "MANAGED table required property '{key}' must be '{expected}' (got '{}').",
+                    actual.map(String::as_str).unwrap_or("<missing>")
+                )));
+            }
+        }
+    }
+    match properties.get(PROP_UC_TABLE_ID) {
+        Some(v) if !v.is_blank_trim() => {}
+        _ => {
+            return Err(Error::invalid_argument(format!(
+                "MANAGED table required property '{PROP_UC_TABLE_ID}' is missing."
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Cross-check the client's `io.unitycatalog.tableId` property against the
+/// UC-allocated UUID for the table (the staging UUID at create time).
+pub fn validate_table_id_property(
+    properties: &BTreeMap<String, String>,
+    expected_table_id: &str,
+) -> Result<()> {
+    let actual = properties.get(PROP_UC_TABLE_ID).ok_or_else(|| {
+        Error::invalid_argument(format!("Properties does not contain {PROP_UC_TABLE_ID}."))
+    })?;
+    if actual != expected_table_id {
+        return Err(Error::invalid_argument(format!(
+            "the table id ({expected_table_id}) does not match the properties \
+             {PROP_UC_TABLE_ID}({actual})."
+        )));
+    }
+    Ok(())
+}
+
+trait BlankExt {
+    fn is_blank_trim(&self) -> bool;
+}
+impl BlankExt for String {
+    fn is_blank_trim(&self) -> bool {
+        self.trim().is_empty()
+    }
+}
+
+// ===================================================================
+// Stored-property projection (DeltaPropertyMapper)
+// ===================================================================
+
+/// Build the stored UC table-property map from a createTable request: client
+/// properties first, then overlay protocol-derived (`delta.feature.*`,
+/// `delta.minReaderVersion`/`minWriterVersion`), domain-metadata projections, the
+/// version-0 commit timestamp, and `delta.lastUpdateVersion=0`.
+pub fn build_stored_properties(req: &DeltaCreateTableRequest) -> BTreeMap<String, String> {
+    let mut merged = req.properties.clone();
+    derive_from_protocol(&mut merged, &req.protocol);
+    if let Some(dm) = req.domain_metadata.as_ref() {
+        derive_from_domain_metadata(&mut merged, dm);
+    }
+    merged.insert(
+        PROP_LAST_COMMIT_TIMESTAMP.to_string(),
+        req.last_commit_timestamp_ms.to_string(),
+    );
+    // createTable is always the version-0 commit.
+    merged.insert(PROP_LAST_UPDATE_VERSION.to_string(), "0".to_string());
+    merged
+}
+
+/// Overlay the `delta.feature.*` + version properties implied by a protocol block.
+pub fn derive_from_protocol(props: &mut BTreeMap<String, String>, protocol: &DeltaProtocol) {
+    props.insert(
+        PROP_MIN_READER_VERSION.to_string(),
+        protocol.min_reader_version.to_string(),
+    );
+    props.insert(
+        PROP_MIN_WRITER_VERSION.to_string(),
+        protocol.min_writer_version.to_string(),
+    );
+    for feature in protocol
+        .reader_features
+        .iter()
+        .chain(protocol.writer_features.iter())
+        .flatten()
+    {
+        props.insert(
+            format!("{FEATURE_PREFIX}{feature}"),
+            FEATURE_SUPPORTED.to_string(),
+        );
+    }
+}
+
+/// Overlay the table properties implied by a domain-metadata block.
+pub fn derive_from_domain_metadata(
+    props: &mut BTreeMap<String, String>,
+    dm: &DeltaDomainMetadataUpdates,
+) {
+    if let Some(clustering) = dm.delta_clustering.as_ref() {
+        // Encode as JSON so nested column paths don't collapse into dotted strings.
+        if let Ok(json) = serde_json::to_string(&clustering.clustering_columns) {
+            props.insert(PROP_CLUSTERING_COLUMNS.to_string(), json);
+        }
+    }
+    if let Some(row_tracking) = dm.delta_row_tracking.as_ref() {
+        props.insert(
+            PROP_ROW_TRACKING_HIGH_WATER_MARK.to_string(),
+            row_tracking.row_id_high_water_mark.to_string(),
+        );
+    }
+}
+
+// ===================================================================
+// Column conversion (ColumnUtils)
+// ===================================================================
+
+/// Convert Delta API columns + partition-column names into UC [`Column`]s, mirroring
+/// the reference `ColumnUtils.toColumnInfos` + `applyPartitionColumns`.
+pub fn delta_columns_to_uc(
+    columns: &DeltaStructType,
+    partition_columns: Option<&[String]>,
+) -> Result<Vec<Column>> {
+    let partition_index = |name: &str| {
+        partition_columns
+            .and_then(|pcs| pcs.iter().position(|p| p.eq_ignore_ascii_case(name)))
+            .map(|i| i as i32)
+    };
+    let cols = columns
+        .fields
+        .iter()
+        .enumerate()
+        .map(|(idx, f)| {
+            Ok(Column {
+                name: f.name.clone(),
+                type_text: catalog_string(&f.data_type),
+                type_json: serde_json::to_string(f)?,
+                type_name: resolve_column_type_name(&f.data_type)? as i32,
+                position: Some(idx as i32),
+                nullable: Some(f.nullable),
+                partition_index: partition_index(&f.name),
+                ..Default::default()
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    // Every named partition column must exist in the schema.
+    if let Some(pcs) = partition_columns {
+        for pc in pcs {
+            if !columns
+                .fields
+                .iter()
+                .any(|f| f.name.eq_ignore_ascii_case(pc))
+            {
+                return Err(Error::invalid_argument(format!(
+                    "partition column '{pc}' is not present in the table schema"
+                )));
+            }
+        }
+    }
+    Ok(cols)
+}
+
+/// Reconstruct the Delta API `columns` from stored UC [`Column`]s for `loadTable`.
+/// Uses each column's stored `type_json` (the original Delta type), falling back to
+/// the bare type name string when absent.
+pub fn uc_columns_to_delta(columns: &[Column]) -> DeltaStructType {
+    let mut sorted: Vec<&Column> = columns.iter().collect();
+    sorted.sort_by_key(|c| c.position.unwrap_or(i32::MAX));
+    let fields = sorted
+        .into_iter()
+        .map(|c| {
+            let data_type = serde_json::from_str::<DeltaDataType>(&c.type_json)
+                .unwrap_or_else(|_| DeltaDataType::Primitive(c.type_text.clone()));
+            DeltaStructField {
+                name: c.name.clone(),
+                data_type,
+                nullable: c.nullable.unwrap_or(true),
+                metadata: Default::default(),
+            }
+        })
+        .collect();
+    DeltaStructType {
+        type_tag: Default::default(),
+        fields,
+    }
+}
+
+/// Map a Delta data type to the UC [`ColumnTypeName`], mirroring
+/// `ColumnUtils.resolveColumnTypeName`. Primitive names follow the Delta schema
+/// serialization format; `decimal(p,s)` strings resolve to `Decimal`.
+fn resolve_column_type_name(data_type: &DeltaDataType) -> Result<ColumnTypeName> {
+    Ok(match data_type {
+        DeltaDataType::Array(_) => ColumnTypeName::Array,
+        DeltaDataType::Map(_) => ColumnTypeName::Map,
+        DeltaDataType::Struct(_) => ColumnTypeName::Struct,
+        DeltaDataType::Decimal(_) => ColumnTypeName::Decimal,
+        DeltaDataType::Primitive(p) => primitive_type_name(p)?,
+    })
+}
+
+fn primitive_type_name(primitive: &str) -> Result<ColumnTypeName> {
+    if primitive.starts_with("decimal") {
+        return Ok(ColumnTypeName::Decimal);
+    }
+    Ok(match primitive {
+        "boolean" => ColumnTypeName::Boolean,
+        "byte" => ColumnTypeName::Byte,
+        "short" => ColumnTypeName::Short,
+        "integer" => ColumnTypeName::Int,
+        "long" => ColumnTypeName::Long,
+        "float" => ColumnTypeName::Float,
+        "double" => ColumnTypeName::Double,
+        "date" => ColumnTypeName::Date,
+        "timestamp" => ColumnTypeName::Timestamp,
+        "timestamp_ntz" => ColumnTypeName::TimestampNtz,
+        "string" => ColumnTypeName::String,
+        "binary" => ColumnTypeName::Binary,
+        "variant" => ColumnTypeName::Variant,
+        other => {
+            return Err(Error::invalid_argument(format!(
+                "unsupported Delta primitive type '{other}'"
+            )));
+        }
+    })
+}
+
+/// The SQL/catalog-string form of a Delta data type (mirrors `ColumnUtils.toCatalogString`).
+fn catalog_string(data_type: &DeltaDataType) -> String {
+    match data_type {
+        DeltaDataType::Primitive(p) => p.clone(),
+        DeltaDataType::Decimal(DeltaDecimalType {
+            precision, scale, ..
+        }) => format!("decimal({precision},{scale})"),
+        DeltaDataType::Array(a) => {
+            let DeltaArrayType { element_type, .. } = a.as_ref();
+            format!("array<{}>", catalog_string(element_type))
+        }
+        DeltaDataType::Map(m) => {
+            let DeltaMapType {
+                key_type,
+                value_type,
+                ..
+            } = m.as_ref();
+            format!(
+                "map<{},{}>",
+                catalog_string(key_type),
+                catalog_string(value_type)
+            )
+        }
+        DeltaDataType::Struct(s) => {
+            let inner = s
+                .fields
+                .iter()
+                .map(|f| format!("{}:{}", f.name, catalog_string(&f.data_type)))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("struct<{inner}>")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rest::routers::delta::models::DeltaProtocol;
+
+    fn compliant_protocol() -> DeltaProtocol {
+        DeltaProtocol {
+            min_reader_version: 3,
+            min_writer_version: 7,
+            reader_features: Some(
+                REQUIRED_READER_FEATURES
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+            ),
+            writer_features: Some(
+                REQUIRED_WRITER_FEATURES
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+            ),
+        }
+    }
+
+    fn compliant_properties(table_id: &str) -> BTreeMap<String, String> {
+        let mut p: BTreeMap<String, String> = REQUIRED_FIXED_PROPERTIES
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        p.insert(PROP_UC_TABLE_ID.to_string(), table_id.to_string());
+        p
+    }
+
+    #[test]
+    fn compliant_passes() {
+        assert!(validate(&compliant_protocol(), None, &compliant_properties("id-1")).is_ok());
+    }
+
+    #[test]
+    fn missing_feature_rejected() {
+        let mut proto = compliant_protocol();
+        proto.writer_features = Some(vec!["deletionVectors".to_string()]);
+        let err = validate(&proto, None, &compliant_properties("id-1")).unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "{err:?}");
+    }
+
+    #[test]
+    fn low_version_rejected() {
+        let mut proto = compliant_protocol();
+        proto.min_writer_version = 5;
+        let err = validate(&proto, None, &compliant_properties("id-1")).unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "{err:?}");
+    }
+
+    #[test]
+    fn reader_not_subset_of_writer_rejected() {
+        let mut proto = compliant_protocol();
+        proto.reader_features = Some(vec!["someReaderOnly".to_string()]);
+        let err = validate(&proto, None, &compliant_properties("id-1")).unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "{err:?}");
+    }
+
+    #[test]
+    fn missing_fixed_property_rejected() {
+        let mut props = compliant_properties("id-1");
+        props.remove(PROP_CHECKPOINT_POLICY);
+        let err = validate(&compliant_protocol(), None, &props).unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "{err:?}");
+    }
+
+    #[test]
+    fn table_id_mismatch_rejected() {
+        let props = compliant_properties("id-1");
+        let err = validate_table_id_property(&props, "id-2").unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "{err:?}");
+        assert!(validate_table_id_property(&props, "id-1").is_ok());
+    }
+
+    #[test]
+    fn build_stored_properties_derives_features() {
+        let req = DeltaCreateTableRequest {
+            name: "t".into(),
+            location: "s3://b/t".into(),
+            table_type: crate::rest::routers::delta::models::DeltaTableType::Managed,
+            comment: None,
+            columns: DeltaStructType {
+                type_tag: Default::default(),
+                fields: vec![],
+            },
+            partition_columns: None,
+            protocol: compliant_protocol(),
+            properties: compliant_properties("id-1"),
+            domain_metadata: None,
+            last_commit_timestamp_ms: 1700,
+            uniform: None,
+        };
+        let props = build_stored_properties(&req);
+        assert_eq!(
+            props
+                .get("delta.feature.catalogManaged")
+                .map(String::as_str),
+            Some("supported")
+        );
+        assert_eq!(
+            props.get(PROP_LAST_UPDATE_VERSION).map(String::as_str),
+            Some("0")
+        );
+        assert_eq!(
+            props.get(PROP_LAST_COMMIT_TIMESTAMP).map(String::as_str),
+            Some("1700")
+        );
+        assert_eq!(
+            props.get(PROP_MIN_WRITER_VERSION).map(String::as_str),
+            Some("7")
+        );
+    }
+
+    #[test]
+    fn column_conversion_roundtrips_primitive_and_partition() {
+        let columns = DeltaStructType {
+            type_tag: Default::default(),
+            fields: vec![
+                DeltaStructField {
+                    name: "id".into(),
+                    data_type: DeltaDataType::Primitive("long".into()),
+                    nullable: false,
+                    metadata: Default::default(),
+                },
+                DeltaStructField {
+                    name: "amount".into(),
+                    data_type: DeltaDataType::Decimal(DeltaDecimalType {
+                        type_tag: Default::default(),
+                        precision: 10,
+                        scale: 2,
+                    }),
+                    nullable: true,
+                    metadata: Default::default(),
+                },
+            ],
+        };
+        let uc = delta_columns_to_uc(&columns, Some(&["id".to_string()])).unwrap();
+        assert_eq!(uc.len(), 2);
+        assert_eq!(uc[0].name, "id");
+        assert_eq!(uc[0].type_name, ColumnTypeName::Long as i32);
+        assert_eq!(uc[0].partition_index, Some(0));
+        assert_eq!(uc[1].type_text, "decimal(10,2)");
+        assert_eq!(uc[1].type_name, ColumnTypeName::Decimal as i32);
+
+        // Reverse: stored type_json should reconstruct the Delta types.
+        let back = uc_columns_to_delta(&uc);
+        assert_eq!(back.fields.len(), 2);
+        assert_eq!(back.fields[0].name, "id");
+    }
+
+    #[test]
+    fn unknown_partition_column_rejected() {
+        let columns = DeltaStructType {
+            type_tag: Default::default(),
+            fields: vec![DeltaStructField {
+                name: "id".into(),
+                data_type: DeltaDataType::Primitive("long".into()),
+                nullable: false,
+                metadata: Default::default(),
+            }],
+        };
+        let err = delta_columns_to_uc(&columns, Some(&["missing".to_string()])).unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "{err:?}");
+    }
+}

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -20,6 +20,7 @@ use unitycatalog_common::services::commit_coordinator::{
 pub mod credential_vending;
 pub(crate) mod kernel;
 pub mod location;
+pub mod managed_delta_contract;
 pub(crate) mod object_store;
 pub mod secrets;
 mod session;

--- a/openapi/delta.yaml
+++ b/openapi/delta.yaml
@@ -1,0 +1,1602 @@
+openapi: 3.1.1
+servers:
+  - url: "{scheme}://{host}:{port}/api/2.1/unity-catalog"
+    description: Unity Catalog server
+    variables:
+      scheme:
+        description: The URI scheme (http or https)
+        default: https
+        enum:
+          - http
+          - https
+      host:
+        description: The server host address
+        default: localhost
+      port:
+        description: The server port number
+        default: "8080"
+  - url: http://localhost:8080/api/2.1/unity-catalog
+    description: Localhost reference server
+info:
+  title: UC Delta API
+  summary: REST API for Delta Lake table catalog operations
+  version: '1.0'
+  description: |
+    This is a new catalog API for external Delta client access to UC managed and external
+    Delta tables. While inspired by the Apache Iceberg REST Catalog (IRC) API style, this API
+    is Delta-centric and only communicates native Delta schema and metadata over RPCs. It is
+    meant to be used by Delta clients, not Iceberg clients, and co-exists with the fully
+    IRC-compatible APIs for Iceberg clients to access UniForm and DBI tables.
+
+    Authentication: This API uses the same OAuth 2.0 bearer token authentication as the
+    Unity Catalog API (all.yaml). Clients must include an `Authorization: Bearer <token>`
+    header on every request. Authentication is not redefined here to stay consistent with
+    the existing UC API spec.
+
+tags:
+  - name: DeltaConfiguration
+    description: |
+      Configuration endpoint for getting catalog configuration and supported endpoints.
+      This initial /config request also serves as API versioning: the server advertises versioned
+      endpoints to clients so they can adapt to the correct API version.
+  - name: DeltaTables
+    description: |
+      Table operations for Delta tables: create, load, update, delete, list, rename,
+      and commit metrics reporting. Includes Delta-only staging table endpoints for
+      managed table creation.
+  - name: DeltaTemporaryCredentials
+    description: |
+      Temporary credential vending for accessing table data in cloud storage.
+      Credentials are scoped by operation level (READ or READ_WRITE).
+
+paths:
+  /delta/v1/config:
+    get:
+      tags:
+        - DeltaConfiguration
+      operationId: getConfig
+      summary: Get catalog configuration
+      description: |
+        Get catalog configuration and supported endpoints. This endpoint also serves as the
+        API versioning mechanism: the client sends its supported versions via `protocol-versions`,
+        and the server returns versioned endpoints for the newest version both sides support.
+      parameters:
+        - name: catalog
+          in: query
+          description: Catalog name
+          required: true
+          schema:
+            type: string
+        - name: protocol-versions
+          in: query
+          description: |
+            Comma-separated list of highest protocol versions the client supports per major version
+            (e.g., 1.1,2.3 means the client supports 1.0-1.1 and 2.0-2.3).
+            The server selects the highest mutually supported protocol version and returns endpoints for that version.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Configuration retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaCatalogConfig'
+              example:
+                endpoints:
+                  - "POST /v1/catalogs/{catalog}/schemas/{schema}/staging-tables"
+                  - "POST /v1/catalogs/{catalog}/schemas/{schema}/tables"
+                  - "GET /v1/catalogs/{catalog}/schemas/{schema}/tables"
+                  - "GET /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}"
+                  - "POST /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}"
+                  - "DELETE /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}"
+                  - "HEAD /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}"
+                  - "POST /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/rename"
+                  - "GET /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials"
+                  - "POST /v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/metrics"
+                  - "GET /v1/staging-tables/{table_id}/credentials"
+                  - "GET /v1/temporary-path-credentials"
+                protocol-version: "1.0"
+        '400':
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '500':
+          $ref: '#/components/responses/ServerErrorResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+
+  /delta/v1/catalogs/{catalog}/schemas/{schema}/staging-tables:
+    parameters:
+      - $ref: '#/components/parameters/catalog'
+      - $ref: '#/components/parameters/schema'
+    post:
+      tags:
+        - DeltaTables
+      operationId: createStagingTable
+      summary: Create a staging table
+      description: |
+        Create a staging table that will become a catalog managed table. The server allocates
+        a table UUID and a storage location for the table. This is a new endpoint for Delta only.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeltaCreateStagingTableRequest'
+      responses:
+        '200':
+          description: Staging table created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaStagingTableResponse'
+              example:
+                table-id: "123e4567-e89b-12d3-a456-426614174000"
+                table-type: "MANAGED"
+                location: "s3://bucket/warehouse/catalog/schema/table"
+                storage-credentials:
+                  - prefix: "s3://bucket/warehouse/catalog/schema/table/"
+                    operation: "READ_WRITE"
+                    expiration-time-ms: 1234567890000
+                    config:
+                      s3.access-key-id: "AK...example"
+                      s3.secret-access-key: "ExampleKey"
+                      s3.session-token: "token"
+                required-protocol:
+                  min-reader-version: 3
+                  min-writer-version: 7
+                  reader-features:
+                    - "deletionVectors"
+                    - "vacuumProtocolCheck"
+                  writer-features:
+                    - "catalogManaged"
+                    - "deletionVectors"
+                    - "inCommitTimestamp"
+                    - "v2Checkpoint"
+                    - "vacuumProtocolCheck"
+                suggested-protocol:
+                  reader-features:
+                    - "typeWidening"
+                  writer-features:
+                    - "domainMetadata"
+                    - "rowTracking"
+                    - "typeWidening"
+                required-properties:
+                  delta.checkpointPolicy: "v2"
+                suggested-properties:
+                  delta.rowTracking.materializedRowIdColumnName: null
+                  delta.rowTracking.materializedRowCommitVersionColumnName: null
+        '400':
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '409':
+          $ref: '#/components/responses/AlreadyExistsResponse'
+        '500':
+          $ref: '#/components/responses/ServerErrorResponse'
+
+  /delta/v1/catalogs/{catalog}/schemas/{schema}/tables:
+    parameters:
+      - $ref: '#/components/parameters/catalog'
+      - $ref: '#/components/parameters/schema'
+    post:
+      tags:
+        - DeltaTables
+      operationId: createTable
+      summary: Create a table
+      description: |
+        Create a new Delta table in the specified schema.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeltaCreateTableRequest'
+      responses:
+        '200':
+          description: Table created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaLoadTableResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '409':
+          $ref: '#/components/responses/AlreadyExistsResponse'
+
+  /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}:
+    parameters:
+      - $ref: '#/components/parameters/catalog'
+      - $ref: '#/components/parameters/schema'
+      - $ref: '#/components/parameters/table'
+    get:
+      tags:
+        - DeltaTables
+      operationId: loadTable
+      summary: Load table metadata
+      description: |
+        Load table metadata including columns, properties, and optionally credentials.
+      responses:
+        '200':
+          description: Table loaded successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaLoadTableResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+    post:
+      tags:
+        - DeltaTables
+      operationId: updateTable
+      summary: Update table
+      description: |
+        Update table properties, columns, or commit Delta changes. Unlike IRC, this endpoint
+        does not support table creation. This endpoint also covers the coordinated commit flow
+        described in the Unity Catalog Managed Tables Specification.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeltaUpdateTableRequest'
+      responses:
+        '200':
+          description: Table updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaLoadTableResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '409':
+          description:
+            Conflict - CommitVersionConflictException or UpdateRequirementConflictException.
+            The client should reload the table and retry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaErrorResponse'
+        '429':
+          description: Too many unbackfilled commits. See DeltaErrorType for details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaErrorResponse'
+        '500':
+          $ref: '#/components/responses/ServerErrorResponse'
+    delete:
+      tags:
+        - DeltaTables
+      operationId: deleteTable
+      summary: Delete a table
+      description: |
+        Delete a table from the catalog.
+      responses:
+        '204':
+          description: Table deleted successfully
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+    head:
+      tags:
+        - DeltaTables
+      operationId: tableExists
+      summary: Check if table exists
+      description: |
+        Check if the specified table exists.
+      responses:
+        '204':
+          description: Table exists
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+
+  /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials:
+    parameters:
+      - $ref: '#/components/parameters/catalog'
+      - $ref: '#/components/parameters/schema'
+      - $ref: '#/components/parameters/table'
+    get:
+      tags:
+        - DeltaTemporaryCredentials
+      operationId: getTableCredentials
+      summary: Get table credentials
+      description: |
+        Get temporary credentials for accessing table data (vended credentials).
+        The operation parameter controls the access level.
+      parameters:
+        - name: operation
+          in: query
+          description: The operation the credential is scoped to.
+          required: true
+          schema:
+            $ref: '#/components/schemas/DeltaCredentialOperation'
+      responses:
+        '200':
+          description: Credentials retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaCredentialsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+
+  /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/metrics:
+    parameters:
+      - $ref: '#/components/parameters/catalog'
+      - $ref: '#/components/parameters/schema'
+      - $ref: '#/components/parameters/table'
+    post:
+      tags:
+        - DeltaTables
+      operationId: reportMetrics
+      summary: Report commit metrics
+      description: |
+        Report commit metrics (telemetry) for a table. The path {table}
+        and the body table-id must identify the same table; the server
+        validates this and rejects mismatches.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeltaReportMetricsRequest'
+      responses:
+        '204':
+          description: Metrics received successfully
+        '400':
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+
+  /delta/v1/staging-tables/{table_id}/credentials:
+    parameters:
+      - name: table_id
+        in: path
+        description: Staging table UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - DeltaTemporaryCredentials
+      operationId: getStagingTableCredentials
+      summary: Get staging table credentials by UUID
+      description: |
+        Get temporary credentials for accessing staging table data by UUID. The staging table
+        is identified solely by its UUID -- catalog and schema are not needed since the UUID
+        is globally unique. Credentials are always READ_WRITE since the client needs to write
+        the initial commit. This is a new endpoint for Delta only.
+      responses:
+        '200':
+          description: Credentials retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaCredentialsResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+
+  /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/rename:
+    parameters:
+      - $ref: '#/components/parameters/catalog'
+      - $ref: '#/components/parameters/schema'
+      - $ref: '#/components/parameters/table'
+    post:
+      tags:
+        - DeltaTables
+      operationId: renameTable
+      summary: Rename a table
+      description: |
+        Rename a table within the same catalog and schema.
+        Cross-schema and cross-catalog moves are not supported.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeltaRenameTableRequest'
+      responses:
+        '204':
+          description: Table renamed successfully
+        '400':
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '409':
+          $ref: '#/components/responses/AlreadyExistsResponse'
+
+  /delta/v1/temporary-path-credentials:
+    get:
+      tags:
+        - DeltaTemporaryCredentials
+      operationId: getTemporaryPathCredentials
+      summary: Get temporary path credentials
+      description: |
+        Get temporary credentials of a storage path for creating a new external table.
+        This path will later be registered in UC as a real external table.
+        The URL has no catalog or schema because the path isn't part of any catalog or namespace.
+        This is a new endpoint for Delta only.
+      parameters:
+        - name: location
+          in: query
+          description: Storage path for the external table
+          required: true
+          schema:
+            type: string
+        - name: operation
+          in: query
+          description: Operation type for the path credential.
+          required: true
+          schema:
+            $ref: '#/components/schemas/DeltaCredentialOperation'
+      responses:
+        '200':
+          description: Credentials retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeltaCredentialsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+
+components:
+
+  # Path Parameters
+  parameters:
+    catalog:
+      name: catalog
+      in: path
+      description: Catalog name
+      required: true
+      schema:
+        type: string
+    schema:
+      name: schema
+      in: path
+      description: Schema name
+      required: true
+      schema:
+        type: string
+    table:
+      name: table
+      in: path
+      description: Table name
+      required: true
+      schema:
+        type: string
+
+  schemas:
+
+
+    # Enums
+
+    DeltaTableType:
+      type: string
+      description: The type of a Delta table.
+      enum:
+        - MANAGED
+        - EXTERNAL
+
+    DeltaCredentialOperation:
+      type: string
+      description: |
+        The permission level for a storage credential.
+      enum:
+        - READ
+        - READ_WRITE
+
+    # Shared Types
+
+    DeltaStorageCredential:
+      type: object
+      description: |
+        Temporary storage credential with prefix and config.
+        Indicates a storage location prefix where the credential is relevant.
+        Clients should choose the most specific prefix (by selecting the longest prefix)
+        if several credentials of the same type are available.
+      required:
+        - prefix
+        - operation
+        - expiration-time-ms
+        - config
+      properties:
+        prefix:
+          type: string
+          description: Storage path prefix this credential applies to
+        operation:
+          $ref: '#/components/schemas/DeltaCredentialOperation'
+        config:
+          type: object
+          description: |
+            Cloud provider-specific credential configuration.
+            Only keys for the relevant cloud provider are populated; the others are null.
+          properties:
+            s3.access-key-id:
+              type: string
+              description: AWS access key ID
+            s3.secret-access-key:
+              type: string
+              description: AWS secret access key
+            s3.session-token:
+              type: string
+              description: AWS session token for temporary credentials
+            azure.sas-token:
+              type: string
+              description: Azure SAS (Shared Access Signature) token
+            gcs.oauth-token:
+              type: string
+              description: GCP OAuth token
+        expiration-time-ms:
+          type: integer
+          format: int64
+          description: |
+            Credential expiration time in epoch milliseconds.
+            This standardized field avoids the need for provider-specific expiration keys
+            (e.g., s3.session-token-expires-at-ms, adls.sas-token-expires-at-ms, etc.)
+
+    DeltaCredentialsResponse:
+      type: object
+      required:
+        - storage-credentials
+      properties:
+        storage-credentials:
+          type: array
+          description: Temporary cloud storage credentials.
+          items:
+            $ref: '#/components/schemas/DeltaStorageCredential'
+
+
+    # Configuration
+
+    DeltaCatalogConfig:
+      type: object
+      properties:
+        endpoints:
+          type: array
+          description: List of supported endpoints
+          items:
+            type: string
+        protocol-version:
+          type: string
+          description: The negotiated protocol version (e.g., "1.0")
+      required:
+        - endpoints
+        - protocol-version
+
+
+    # Table Lifecycle
+
+    DeltaCreateStagingTableRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The table name
+      required:
+        - name
+      example:
+        name: "sales"
+
+    DeltaStagingTableResponse:
+      type: object
+      properties:
+        table-id:
+          type: string
+          format: uuid
+          description: Table UUID allocated by UC
+        table-type:
+          $ref: '#/components/schemas/DeltaTableType'
+          description: Table type (always MANAGED for staging tables)
+        location:
+          type: string
+          description: UC allocated storage location for this table
+        storage-credentials:
+          type: array
+          description: Temporary credentials for initial commit
+          items:
+            $ref: '#/components/schemas/DeltaStorageCredential'
+        required-protocol:
+          allOf:
+            - $ref: '#/components/schemas/DeltaProtocol'
+            - description: Required protocol - client must write an initial commit with at least this protocol.
+        suggested-protocol:
+          type: object
+          description: Suggested protocol - client should enable these additional features if supported
+          properties:
+            reader-features:
+              type: array
+              description: Suggested reader features
+              items:
+                type: string
+            writer-features:
+              type: array
+              description: Suggested writer features
+              items:
+                type: string
+        required-properties:
+          type: object
+          description: Table properties that must be set; null values mean any valid value is allowed
+          additionalProperties:
+            type: ["string", "null"]
+        suggested-properties:
+          type: object
+          description: Table properties that should be set whenever possible; null values mean client generates the value
+          additionalProperties:
+            type: ["string", "null"]
+      required:
+        - table-id
+        - table-type
+        - location
+        - storage-credentials
+        - required-protocol
+        - required-properties
+
+    DeltaCreateTableRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The table name
+        location:
+          type: string
+          description: Storage location
+        table-type:
+          $ref: '#/components/schemas/DeltaTableType'
+        comment:
+          type: string
+          description: Table comment
+        columns:
+          $ref: '#/components/schemas/DeltaStructType'
+        partition-columns:
+          type: array
+          description: Partition column names
+          items:
+            type: string
+        protocol:
+          $ref: '#/components/schemas/DeltaProtocol'
+          description: Delta protocol version and feature requirements
+        properties:
+          type: object
+          description: Delta table properties
+          additionalProperties:
+            type: string
+        domain-metadata:
+          $ref: '#/components/schemas/DeltaDomainMetadataUpdates'
+        last-commit-timestamp-ms:
+          type: integer
+          format: int64
+          description: |
+            Timestamp of version 0 (the commit the client wrote  before calling this endpoint),
+            in epoch milliseconds.
+        uniform:
+          $ref: '#/components/schemas/DeltaUniformMetadata'
+          description: |
+            Optional UniForm conversion metadata. When present, the table is registered as
+            UniForm-enabled, so readers can access it via either the Delta or Iceberg REST
+            Catalog. The engine generates the Iceberg metadata file at the supplied
+            metadata-location before calling createTable.
+      required:
+        - name
+        - location
+        - table-type
+        - columns
+        - protocol
+        - properties
+        - last-commit-timestamp-ms
+      example:
+        name: "sales"
+        location: "s3://bucket/warehouse/catalog/schema/sales"
+        table-type: "MANAGED"
+        columns:
+          type: "struct"
+          fields:
+            - name: "id"
+              type: "long"
+              nullable: false
+              metadata: {}
+            - name: "amount"
+              type:
+                type: "decimal"
+                precision: 10
+                scale: 2
+              nullable: true
+              metadata: {}
+        partition-columns:
+          - "id"
+        protocol:
+          min-reader-version: 3
+          min-writer-version: 7
+          reader-features:
+            - "deletionVectors"
+          writer-features:
+            - "deletionVectors"
+            - "invariants"
+        properties:
+          "delta.enableDeletionVectors": "true"
+
+    DeltaLoadTableResponse:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/DeltaTableMetadata'
+          description: Complete table metadata including schema and properties
+        commits:
+          type: array
+          description: All unbackfilled CCv2 commits
+          items:
+            $ref: '#/components/schemas/DeltaCommit'
+        uniform:
+          $ref: '#/components/schemas/DeltaUniformMetadata'
+        latest-table-version:
+          type: integer
+          format: int64
+          description: The latest ratified table version tracked by the server, including data-only commits. Compare with metadata.last-commit-version which only tracks metadata-changing commits.
+      required:
+        - metadata
+
+    DeltaTableMetadata:
+      type: object
+      properties:
+        etag:
+          type: string
+          description: Entity tag for optimistic concurrency control
+        table-type:
+          $ref: '#/components/schemas/DeltaTableType'
+        table-uuid:
+          type: string
+          format: uuid
+          description: Unique identifier for the table
+        location:
+          type: string
+          description: Storage location of the table
+        created-time:
+          type: integer
+          format: int64
+          description: Creation time in epoch milliseconds
+        updated-time:
+          type: integer
+          format: int64
+          description: Last update time in epoch milliseconds
+        columns:
+          $ref: '#/components/schemas/DeltaStructType'
+        partition-columns:
+          type: array
+          description: Partition column names
+          items:
+            type: string
+        properties:
+          type: object
+          description: Table properties
+          additionalProperties:
+            type: string
+        last-commit-version:
+          type: integer
+          format: int64
+          description: The version of the last commit that changed table metadata (delta.lastUpdateVersion). Data-only commits do not update this value.
+        last-commit-timestamp-ms:
+          type: integer
+          format: int64
+          description: Timestamp of the last commit that changed table metadata, in epoch milliseconds (delta.lastCommitTimestamp).
+      required:
+        - etag
+        - table-type
+        - table-uuid
+        - location
+        - created-time
+        - updated-time
+        - columns
+        - properties
+
+    DeltaRenameTableRequest:
+      type: object
+      properties:
+        new-name:
+          type: string
+          description: New table name
+      required:
+        - new-name
+
+
+    # Table Update Operations
+
+    DeltaUpdateTableRequest:
+      type: object
+      description: Request to update a table with requirements and updates
+      properties:
+        requirements:
+          type: array
+          description: Pre-conditions that must be met for the update
+          items:
+            $ref: '#/components/schemas/DeltaTableRequirement'
+        updates:
+          type: array
+          description: Updates to apply to the table
+          items:
+            $ref: '#/components/schemas/DeltaTableUpdate'
+      required:
+        - requirements
+        - updates
+
+    # Requirements
+
+    DeltaTableRequirement:
+      discriminator:
+        propertyName: type
+        mapping:
+          assert-table-uuid: '#/components/schemas/DeltaAssertTableUUID'
+          assert-etag: '#/components/schemas/DeltaAssertEtag'
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+
+    DeltaAssertTableUUID:
+      allOf:
+        - $ref: '#/components/schemas/DeltaTableRequirement'
+      description: Assert that the table UUID matches the expected value
+      properties:
+        type:
+          type: string
+          const: "assert-table-uuid"
+        uuid:
+          type: string
+          format: uuid
+          description: Expected table UUID
+      required:
+        - uuid
+
+    DeltaAssertEtag:
+      allOf:
+        - $ref: '#/components/schemas/DeltaTableRequirement'
+      description: Assert that the table etag matches the expected value for optimistic concurrency
+      properties:
+        type:
+          type: string
+          const: "assert-etag"
+        etag:
+          type: string
+          description: Expected etag value
+      required:
+        - etag
+
+    # Updates
+
+    DeltaTableUpdate:
+      discriminator:
+        propertyName: action
+        mapping:
+          set-properties: '#/components/schemas/DeltaSetPropertiesUpdate'
+          remove-properties: '#/components/schemas/DeltaRemovePropertiesUpdate'
+          set-columns: '#/components/schemas/DeltaSetSchemaUpdate'
+          set-table-comment: '#/components/schemas/DeltaSetTableCommentUpdate'
+          add-commit: '#/components/schemas/DeltaAddCommitUpdate'
+          set-latest-backfilled-version: '#/components/schemas/DeltaSetLatestBackfilledVersionUpdate'
+          set-protocol: '#/components/schemas/DeltaSetProtocolUpdate'
+          set-domain-metadata: '#/components/schemas/DeltaSetDomainMetadataUpdate'
+          remove-domain-metadata: '#/components/schemas/DeltaRemoveDomainMetadataUpdate'
+          set-partition-columns: '#/components/schemas/DeltaSetPartitionColumnsUpdate'
+          update-metadata-snapshot-version: '#/components/schemas/DeltaUpdateSnapshotVersionUpdate'
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+
+    DeltaSetPropertiesUpdate:
+      allOf:
+        - $ref: '#/components/schemas/DeltaTableUpdate'
+      required:
+        - updates
+      properties:
+        action:
+          type: string
+          const: "set-properties"
+        updates:
+          type: object
+          description: Properties to set
+          additionalProperties:
+            type: string
+
+    DeltaRemovePropertiesUpdate:
+      allOf:
+        - $ref: '#/components/schemas/DeltaTableUpdate'
+      description: Remove table properties
+      properties:
+        action:
+          type: string
+          const: "remove-properties"
+        removals:
+          type: array
+          description: Property keys to remove
+          items:
+            type: string
+      required:
+        - action
+        - removals
+
+    DeltaSetSchemaUpdate:
+      allOf:
+        - $ref: '#/components/schemas/DeltaTableUpdate'
+      description: |
+        Set table columns. The metadata field on each field carries Spark/Delta field metadata
+        from metaData.schemaString in the Delta commit log.
+      properties:
+        action:
+          type: string
+          const: "set-columns"
+        columns:
+          $ref: '#/components/schemas/DeltaStructType'
+      required:
+        - action
+        - columns
+
+    DeltaSetTableCommentUpdate:
+      allOf:
+        - $ref: '#/components/schemas/DeltaTableUpdate'
+      description: Set table comment
+      properties:
+        action:
+          type: string
+          const: "set-table-comment"
+        comment:
+          type: string
+          description: New table comment
+      required:
+        - action
+        - comment
+
+    DeltaAddCommitUpdate:
+      allOf:
+        - $ref: '#/components/schemas/DeltaTableUpdate'
+      description: Add a CCv2 commit to the table (managed tables only)
+      properties:
+        action:
+          type: string
+          const: "add-commit"
+        commit:
+          $ref: '#/components/schemas/DeltaCommit'
+          description: Commit metadata including version, timestamp, and file information
+        uniform:
+          $ref: '#/components/schemas/DeltaUniformMetadata'
+      required:
+        - action
+        - commit
+
+    DeltaSetLatestBackfilledVersionUpdate:
+      allOf:
+        - $ref: '#/components/schemas/DeltaTableUpdate'
+      description: Set the latest backfilled version for the table
+      properties:
+        action:
+          type: string
+          const: "set-latest-backfilled-version"
+        latest-published-version:
+          type: integer
+          format: int64
+          description: Latest backfilled/published version
+      required:
+        - action
+        - latest-published-version
+
+    DeltaSetProtocolUpdate:
+      allOf:
+        - $ref: '#/components/schemas/DeltaTableUpdate'
+      description: Set Delta protocol version and features (full replacement)
+      properties:
+        action:
+          type: string
+          const: "set-protocol"
+        protocol:
+          $ref: '#/components/schemas/DeltaProtocol'
+      required:
+        - action
+        - protocol
+
+    DeltaSetDomainMetadataUpdate:
+      allOf:
+        - $ref: '#/components/schemas/DeltaTableUpdate'
+      description: |
+        Set domain metadata. The `updates` object contains one or more
+        domain entries, each keyed by domain name with a typed configuration.
+      properties:
+        action:
+          type: string
+          const: "set-domain-metadata"
+        updates:
+          $ref: '#/components/schemas/DeltaDomainMetadataUpdates'
+      required:
+        - action
+        - updates
+
+    DeltaDomainMetadataUpdates:
+      type: object
+      description: |
+        Domain metadata entries keyed by domain name. Include one or more.
+      properties:
+        delta.clustering:
+          $ref: '#/components/schemas/DeltaClusteringDomainMetadata'
+        delta.rowTracking:
+          $ref: '#/components/schemas/DeltaRowTrackingDomainMetadata'
+
+    DeltaRemoveDomainMetadataUpdate:
+      allOf:
+        - $ref: '#/components/schemas/DeltaTableUpdate'
+      description: Remove domain metadata for specified domains
+      properties:
+        action:
+          type: string
+          const: "remove-domain-metadata"
+        domains:
+          type: array
+          items:
+            type: string
+          description: Domain names to remove
+      required:
+        - action
+        - domains
+
+    DeltaSetPartitionColumnsUpdate:
+      allOf:
+        - $ref: '#/components/schemas/DeltaTableUpdate'
+      description: Set partition columns (table-level property, typically only during creation)
+      properties:
+        action:
+          type: string
+          const: "set-partition-columns"
+        partition-columns:
+          type: array
+          items:
+            type: string
+          description: Partition column names
+      required:
+        - action
+        - partition-columns
+
+    DeltaUpdateSnapshotVersionUpdate:
+      allOf:
+        - $ref: '#/components/schemas/DeltaTableUpdate'
+      description: Update snapshot version (external tables only, used by post-commit hook)
+      properties:
+        action:
+          type: string
+          const: "update-metadata-snapshot-version"
+        last-commit-version:
+          type: integer
+          format: int64
+          description: Last commit version (delta.lastUpdateVersion)
+        last-commit-timestamp-ms:
+          type: integer
+          format: int64
+          description: Last commit timestamp in ms (delta.lastCommitTimestamp)
+      required:
+        - action
+        - last-commit-version
+        - last-commit-timestamp-ms
+
+
+
+    # Domain Metadata
+
+    DeltaClusteringDomainMetadata:
+      type: object
+      description: Configuration for Clustered Tables. Present when the clustering writer feature is enabled.
+      properties:
+        clusteringColumns:
+          type: array
+          description: Clustering column paths. Each inner array is a path from root schema to a column. If Column Mapping is enabled, physical column names are used.
+          items:
+            type: array
+            items:
+              type: string
+      required:
+        - clusteringColumns
+
+    DeltaRowTrackingDomainMetadata:
+      type: object
+      description: Configuration for Row Tracking. Present when the rowTracking writer feature is enabled.
+      properties:
+        rowIdHighWaterMark:
+          type: integer
+          format: int64
+          description: The highest fresh Row ID assigned so far.
+      required:
+        - rowIdHighWaterMark
+
+
+    # Delta Data Types
+
+    DeltaProtocol:
+      type: object
+      description: Delta table protocol specification
+      properties:
+        min-reader-version:
+          type: integer
+          format: int32
+          description: Minimum reader version
+        min-writer-version:
+          type: integer
+          format: int32
+          description: Minimum writer version
+        reader-features:
+          type: array
+          description: Enabled reader features
+          items:
+            type: string
+        writer-features:
+          type: array
+          description: Enabled writer features
+          items:
+            type: string
+      required:
+        - min-reader-version
+        - min-writer-version
+
+    DeltaUniformMetadata:
+      type: object
+      description: UniForm conversion metadata. Present only for Uniform (Delta + Iceberg) tables.
+      properties:
+        iceberg:
+          type: object
+          description: Iceberg-specific conversion metadata
+          properties:
+            metadata-location:
+              type: string
+              description: Iceberg metadata file location
+            converted-delta-version:
+              type: integer
+              format: int64
+              description: Delta version that was converted to Iceberg
+            converted-delta-timestamp:
+              type: integer
+              format: int64
+              description: Timestamp of the conversion, in epoch milliseconds
+            base-converted-delta-version:
+              type: integer
+              format: int64
+              description: Delta version used as the base for incremental conversion
+      required:
+        - iceberg
+
+    DeltaCommit:
+      type: object
+      description: Delta commit information for CCv2
+      properties:
+        version:
+          type: integer
+          format: int64
+          description: Commit version
+        timestamp:
+          type: integer
+          format: int64
+          description: In-commit timestamp, in epoch milliseconds
+        file-name:
+          type: string
+          description: UUID-based commit file name
+        file-size:
+          type: integer
+          format: int64
+          description: Commit file size in bytes
+        file-modification-timestamp:
+          type: integer
+          format: int64
+          description: File modification timestamp, in epoch milliseconds
+      required:
+        - version
+        - timestamp
+        - file-name
+        - file-size
+        - file-modification-timestamp
+
+    DeltaStructField:
+      type: object
+      description: |
+        A field in a DeltaStructType. Contains the field name, type, nullability, and metadata
+        matching the Delta schema field format.
+        Field names are case-preserving but case-insensitive: within a DeltaStructType no two fields
+        may have names equal under ASCII lowercase comparison. Every API reference to a column
+        name (partition-columns, delta.clustering.clusteringColumns, etc.) matches
+        case-insensitively. Per Delta [PROTOCOL.md](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#schema-serialization-format).
+      properties:
+        name:
+          type: string
+          description: Column name. Case-preserving; unique case-insensitively within the parent DeltaStructType.
+        type:
+          $ref: '#/components/schemas/DeltaDataType'
+        nullable:
+          type: boolean
+          description: Whether this column can be null
+        metadata:
+          $ref: '#/components/schemas/DeltaStructFieldMetadata'
+      required:
+        - name
+        - type
+        - nullable
+        - metadata
+
+    DeltaStructFieldMetadata:
+      type: object
+      description: Additional column metadata (arbitrary key-value pairs, e.g., comment, delta.columnMapping.id)
+      additionalProperties:
+        description: Metadata values can be strings, numbers, booleans, or nested objects
+      properties:
+        _placeholder:
+          type: object
+          description: |
+            Schema-only marker; never sent on the wire. Declared so the OpenAPI generator emits a
+            wrapper class for this schema instead of inlining `metadata` on the parent DeltaStructField
+            `new HashMap<>()` -- that would erase the "metadata absent" signal. Use the Map
+            accessors (e.g., `metadata.put("comment", ...)` and `metadata.get("comment")`) for 
+            actual metadata keys.
+
+    DeltaDataType:
+      description: |
+        Column data type. For primitive types, a bare JSON string (e.g., "long", "string",
+        "decimal(10,2)"). For complex types, a JSON object with a "type" discriminator
+        field ("array", "map", or "struct").
+      discriminator:
+        propertyName: type
+        mapping:
+          array: '#/components/schemas/DeltaArrayType'
+          map: '#/components/schemas/DeltaMapType'
+          struct: '#/components/schemas/DeltaStructType'
+          decimal: '#/components/schemas/DeltaDecimalType'
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          description: Type identifier
+
+    DeltaPrimitiveType:
+      description: |
+        Primitive data type (e.g., "long", "string", "boolean"). On the wire,
+        primitive types are bare JSON strings. The custom DeltaDataTypeModule
+        converts them into DeltaPrimitiveType instances.
+      allOf:
+        - $ref: '#/components/schemas/DeltaDataType'
+
+    DeltaDecimalType:
+      description: |
+        Decimal data type with precision and scale. On the wire, represented as
+        "decimal(precision,scale)" (e.g., "decimal(10,2)"). The custom
+        DeltaDataTypeModule parses the string into a DeltaDecimalType instance.
+      allOf:
+        - $ref: '#/components/schemas/DeltaDataType'
+      properties:
+        precision:
+          type: integer
+          description: Total number of digits
+        scale:
+          type: integer
+          description: Number of digits after the decimal point
+      required:
+        - precision
+        - scale
+
+    DeltaArrayType:
+      description: Array type containing elements of a specific type
+      allOf:
+        - $ref: '#/components/schemas/DeltaDataType'
+      properties:
+        element-type:
+          $ref: '#/components/schemas/DeltaDataType'
+        contains-null:
+          type: boolean
+          description: Whether array elements can be null
+      required:
+        - element-type
+        - contains-null
+
+    DeltaMapType:
+      description: Map type with key-value pairs
+      allOf:
+        - $ref: '#/components/schemas/DeltaDataType'
+      properties:
+        key-type:
+          $ref: '#/components/schemas/DeltaDataType'
+        value-type:
+          $ref: '#/components/schemas/DeltaDataType'
+        value-contains-null:
+          type: boolean
+          description: Whether map values can be null
+      required:
+        - key-type
+        - value-type
+        - value-contains-null
+
+    DeltaStructType:
+      description: Struct type containing named fields
+      allOf:
+        - $ref: '#/components/schemas/DeltaDataType'
+      properties:
+        fields:
+          type: array
+          description: Array of field definitions
+          items:
+            $ref: '#/components/schemas/DeltaStructField'
+      required:
+        - fields
+      example:
+        type: "struct"
+        fields:
+          - name: "id"
+            type: "long"
+            nullable: false
+            metadata: {}
+          - name: "name"
+            type: "string"
+            nullable: true
+            metadata: {}
+
+
+    # Metrics
+
+    DeltaReportMetricsRequest:
+      type: object
+      required:
+        - table-id
+      properties:
+        table-id:
+          type: string
+          format: uuid
+          description: |
+            Table UUID. Must match the table identified by the path
+            {catalog}/{schema}/{table}. Obtained from loadTable
+            response metadata.table-uuid.
+        report:
+          type: object
+          description: Contains the metrics being reported
+          properties:
+            commit-report:
+              type: object
+              description: Commit report metrics
+              properties:
+                num-files-added:
+                  type: integer
+                  format: int64
+                  description: Number of files added by this commit
+                num-bytes-added:
+                  type: integer
+                  format: int64
+                  description: Number of bytes added by this commit
+                num-files-removed:
+                  type: integer
+                  format: int64
+                  description: Number of files removed by this commit
+                num-bytes-removed:
+                  type: integer
+                  format: int64
+                  description: Number of bytes removed by this commit
+                num-rows-inserted:
+                  type: integer
+                  format: int64
+                  description: Number of rows inserted by this commit
+                num-rows-removed:
+                  type: integer
+                  format: int64
+                  description: Number of rows removed by this commit
+                num-rows-updated:
+                  type: integer
+                  format: int64
+                  description: Number of rows updated by this commit
+                file-size-histogram:
+                  type: object
+                  description: Histogram tracking file counts and total bytes across size ranges
+                  properties:
+                    sorted-bin-boundaries:
+                      type: array
+                      items:
+                        type: integer
+                        format: int64
+                      description: Sorted bin boundary values
+                    file-counts:
+                      type: array
+                      items:
+                        type: integer
+                        format: int64
+                      description: Count of files in each bin
+                    total-bytes:
+                      type: array
+                      items:
+                        type: integer
+                        format: int64
+                      description: Total bytes in each bin
+                    commit-version:
+                      type: integer
+                      format: int64
+                      description: The commit version this histogram is for
+                  required:
+                    - sorted-bin-boundaries
+                    - file-counts
+                    - total-bytes
+
+
+    # Errors
+
+    DeltaErrorType:
+      type: string
+      description: Error type identifier returned in error responses.
+      enum:
+        - BadRequestException
+        - InvalidParameterValueException
+        - UnsupportedTableFormatException
+        - NotAuthorizedException
+        - PermissionDeniedException
+        - NotFoundException
+        - NoSuchCatalogException
+        - NoSuchSchemaException
+        - NoSuchTableException
+        - AlreadyExistsException
+        - CommitVersionConflictException
+        - UpdateRequirementConflictException
+        - ResourceExhaustedException
+        - TooManyRequestsException
+        - CommitStateUnknownException
+        - InternalServerErrorException
+        - NotImplementedException
+      # Keep enum order aligned with x-enum-descriptions below
+      x-enum-descriptions:
+        - 'BadRequestException: (400) Malformed request or invalid action.'
+        - 'InvalidParameterValueException: (400) Server-side validation failed (e.g., missing required fields or table features).'
+        - 'UnsupportedTableFormatException: (400) The table is not a Delta table, or a Delta table not yet supported by this endpoint. In any case, clients should fallback to the existing UC API.'
+        - 'NotAuthorizedException: (401) Authentication credentials are missing, expired, or invalid.'
+        - 'PermissionDeniedException: (403) Authenticated user does not have the necessary permissions.'
+        - 'NotFoundException: (404) The requested resource does not exist.'
+        - 'NoSuchCatalogException: (404) The specified catalog does not exist.'
+        - 'NoSuchSchemaException: (404) The specified catalog or schema does not exist.'
+        - 'NoSuchTableException: (404) The specified table or staging table does not exist.'
+        - 'AlreadyExistsException: (409) A resource with the same name already exists.'
+        - 'CommitVersionConflictException: (409) Commit rejected due to a concurrent conflicting commit. The client should rebuild the snapshot and retry.'
+        - 'UpdateRequirementConflictException: (409) An assert-etag or assert-table-uuid requirement was not met. The client should reload the table and retry.'
+        - 'ResourceExhaustedException: (429) The maximum number of unbackfilled commits has been reached. The client should backfill pending commits before retrying.'
+        - 'TooManyRequestsException: (429) Too many requests. The client may retry after a delay.'
+        - 'CommitStateUnknownException: (500) Commit outcome unknown (e.g., network failure after the server received the request). The client should check the table state before retrying.'
+        - 'InternalServerErrorException: (500) A server-side problem that might not be addressable from the client side.'
+        - 'NotImplementedException: (501) The requested functionality is not supported by the server.'
+
+    DeltaErrorModel:
+      type: object
+      description: JSON error payload returned in a response with further details on the error
+      required:
+        - message
+        - type
+        - code
+      properties:
+        message:
+          type: string
+          description: Human-readable error message
+        type:
+          $ref: '#/components/schemas/DeltaErrorType'
+        code:
+          type: integer
+          minimum: 400
+          maximum: 600
+          description: HTTP response code
+        stack:
+          type: array
+          description: Stack trace (only in debug mode)
+          items:
+            type: string
+
+    DeltaErrorResponse:
+      description: JSON wrapper for all error responses (non-2xx)
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          $ref: '#/components/schemas/DeltaErrorModel'
+      additionalProperties: false
+
+  # Reusable Responses
+  # Error type is identified by the DeltaErrorType enum in the response body.
+  responses:
+    BadRequestErrorResponse:
+      description: |
+        Bad request. The request is malformed or contains invalid parameters.
+        Error type will be BadRequestException or InvalidParameterValueException.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DeltaErrorResponse'
+
+    UnauthorizedResponse:
+      description: Unauthorized. Credentials are missing, expired, or invalid.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DeltaErrorResponse'
+
+    ForbiddenResponse:
+      description: Forbidden. Insufficient permissions.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DeltaErrorResponse'
+
+    NotFoundResponse:
+      description: |
+        Not found. The requested catalog, schema, table, or staging table does not exist.
+        Error type will be NoSuchCatalogException, NoSuchSchemaException, or NoSuchTableException.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DeltaErrorResponse'
+
+    AlreadyExistsResponse:
+      description: Conflict. A resource with the same name already exists.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DeltaErrorResponse'
+
+    ServerErrorResponse:
+      description: Internal server error.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DeltaErrorResponse'
+
+    ServiceUnavailableResponse:
+      description: Service unavailable. The client may retry after a delay.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DeltaErrorResponse'


### PR DESCRIPTION
## Summary

Adds the dedicated **`/delta/v1` Delta REST API** (`DeltaApiService`) that the Unity Catalog Java reference now ships, bringing our server to behavioral parity with it. This is the surface modern Delta clients (Spark, Delta Kernel) use; previously we only had the legacy UC-REST tables surface plus `/delta/preview/commits`.

Because the Delta REST protocol is standalone and not resource-CRUD shaped (and uses kebab-case JSON), it is **hand-written rather than generated from proto** — mirroring the existing Delta Sharing router precedent. The vendored spec lives at `openapi/delta.yaml` (an exact copy of the reference `api/delta.yaml`) and is served via its own Swagger UI definition.

The work landed in two commits:

**Phase 1 — surface scaffold**
- Vendored `openapi/delta.yaml`; hand-written kebab-case serde models for every schema (incl. the `updateTable` action list, requirements, and the primitive-string-vs-object `DeltaDataType` split).
- `DeltaApiHandler` trait + hand-written Axum router mounting all 12 operations.
- Mounted in the standard and hybrid servers, served under a distinct Swagger prefix so its asset routes don't collide with the main API.

**Phase 2 — server behavior**
- `managed_delta_contract`: ports `UcManagedDeltaContract` + `DeltaConsts` (5 required features, min reader 3 / writer 7, fixed properties, reader⊆writer rule, `io.unitycatalog.tableId` identity), the `DeltaPropertyMapper` stored-property projection, and the Delta ↔ UC column converter.
- Delta error envelope `{error:{message,type,code}}` with the `DeltaErrorType` enum (matching the reference `DeltaApiExceptionHandler`), distinct from the server's standard envelope. Adds `Error::UpdateRequirementConflict` (409).
- Real `DeltaApiHandler` impl delegating resource ops / permission checks / credential vending to the existing handler traits and adding the Delta logic: `createStagingTable` advertises the contract + vends READ_WRITE creds; `createTable` validates the contract (MANAGED) and finalizes the staging reservation, trusting the request rather than reading `0.json`; `loadTable` builds metadata + inline unbackfilled commits; `updateTable` dispatches the action list in canonical order and routes add-commit/backfill through the commit coordinator.
- Fixes a flagged divergence: the legacy `commits.rs` `commit()` now applies a commit's `metadata.configuration` to the table (previously dropped).

## Test plan

- [x] `cargo test -p unitycatalog-server` — 86 lib tests pass, including new contract-validation, column-conversion, and create/load/update/report handler tests, plus 12 serde round-trip tests over the spec's example payloads.
- [x] `cargo clippy` clean (no findings in the new Delta code).
- [x] End-to-end over HTTP (`just rest`): `getConfig` → 200 with the full endpoint list; `loadTable` missing → 404; `createTable` with missing staging reservation → 404; `createTable` MANAGED with non-compliant protocol → 400 — all rendered in the Delta error envelope.
- [ ] createStagingTable/createTable happy path over HTTP needs real cloud STS credential vending (not reachable in the sandbox); covered by unit tests instead.

## Follow-ups

- #176 — implement `renameTable` (currently `NotImplemented`; no store rename op yet)
- #177 — consume `reportMetrics` for maintenance scheduling (currently accept-and-ack)
- #178 — fix the latent staging-row name-arity bug in the legacy `tables.rs` managed create path
- #179 — UniForm/Iceberg metadata end-to-end
- #159 (existing) — DataFusion read/write path for catalog-managed Delta tables (consume the coordinator's ratified commits)

This pull request and its description were written by Isaac.
