### PR TITLE
feat: complete managed-table commit lifecycle (publish, backfill, ret…

### DIFF
--- a/crates/datafusion/Cargo.toml
+++ b/crates/datafusion/Cargo.toml
@@ -36,6 +36,7 @@ delta = ["dep:deltalake-core", "dep:delta_kernel"]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 serde_json = { workspace = true }
+olai-http = { workspace = true }
 
 [[example]]
 name = "unity_catalog"

--- a/crates/datafusion/src/managed/append.rs
+++ b/crates/datafusion/src/managed/append.rs
@@ -9,29 +9,66 @@
 //!    `DefaultEngine::write_parquet` → `add_files` → `commit`. The committer stages the
 //!    commit and ratifies it via UC `updateTable add-commit`.
 //!
-//! Publishing the staged commit to `_delta_log/<v>.json` is intentionally *not* done here:
-//! UC's `loadTable` returns the ratified-but-unpublished commit in its tail, so readers
-//! (via `build_catalog_managed_snapshot`) see it without publish. Publish is a maintenance
-//! optimization left as a follow-up.
+//! ## Post-commit obligations (ManagedTablesSpec §"Write to the table", lines 75-77)
+//!
+//! After UC ratifies a commit the client **must** complete the commit lifecycle:
+//!
+//! - **Publish**: copy the ratified staged commit into `_delta_log/<v>.json` so
+//!   non-catalog-aware readers see the new version, and so UC can stop tracking the
+//!   unbackfilled tail (an unbounded tail eventually trips UC's `429`
+//!   `ResourceExhaustedException` and blocks all further writes).
+//! - **Backfill notify**: once published, tell UC via `set-latest-backfilled-version`.
+//! - **Metrics**: report commit metrics so UC can schedule table maintenance.
+//!
+//! All three are **best-effort**: the commit is already ratified, so a publish/notify/
+//! metrics failure must never be reported as a failed write — we log and move on, and the
+//! next write (or the 429 backfill handler below) catches up.
+//!
+//! ## Retry (delta.yaml updateTable errors; ManagedTablesSpec commit-errors table)
+//!
+//! The commit is wrapped in a bounded retry loop:
+//!
+//! - **409 conflict** (`CommitVersionConflictException` / `AlreadyExistsException`): a
+//!   concurrent writer took our version. Reload the table, rebuild the snapshot at the new
+//!   latest version, re-stage, retry.
+//! - **429 resource-exhausted** (`ResourceExhaustedException` / `TooManyRequestsException`):
+//!   the unbackfilled tail is too long. Publish + backfill the pending tail, then retry.
+//! - **500 commit-state-unknown** (`CommitStateUnknownException`): the outcome is ambiguous.
+//!   Reload the table and look for the exact staged file we proposed — if present the commit
+//!   landed (success, never re-commit); if absent, retry.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use datafusion::arrow::array::RecordBatch;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::default::DefaultEngineBuilder;
-use delta_kernel::snapshot::Snapshot as KernelSnapshot;
+use delta_kernel::snapshot::{Snapshot as KernelSnapshot, SnapshotRef};
 use delta_kernel::transaction::CommitResult;
-use delta_kernel::{LogPath, Version};
-use unitycatalog_common::models::delta::v1::DeltaCommit;
+use delta_kernel::{Engine, LogPath, Version};
+use tracing::{debug, info, warn};
+use unitycatalog_client::DeltaV1Client;
+use unitycatalog_common::models::delta::v1::{
+    DeltaCommit, DeltaCommitReport, DeltaLoadTableResponse, DeltaReport, DeltaReportMetricsRequest,
+    DeltaTableRequirement, DeltaTableUpdate, DeltaUpdateTableRequest,
+};
 use unitycatalog_object_store::{TableOperation, UnityObjectStoreFactory};
 use url::Url;
 
 use super::committer::UnityCatalogCommitter;
 use super::create::CreateManagedTableError;
 
+/// Maximum number of commit attempts before giving up (1 initial try + retries).
+const MAX_COMMIT_ATTEMPTS: u32 = 5;
+/// Base backoff between retry attempts; jittered and capped per attempt.
+const RETRY_BASE_BACKOFF: Duration = Duration::from_millis(50);
+const RETRY_MAX_BACKOFF: Duration = Duration::from_secs(2);
+
 /// Append `batch` as a new commit to the existing managed table `catalog.schema.table`.
 ///
 /// Returns the committed table version. `engine_info` is recorded in the commit's `commitInfo`.
+/// On success the ratified commit is published, backfilled, and its metrics reported on a
+/// best-effort basis (a failure of any of those does not fail the already-ratified write).
 pub async fn append_to_managed_table(
     factory: Arc<UnityObjectStoreFactory>,
     catalog: &str,
@@ -41,9 +78,317 @@ pub async fn append_to_managed_table(
     engine_info: &str,
 ) -> Result<Version, CreateManagedTableError> {
     let client = Arc::new(factory.unity_client().delta_v1());
+    let num_rows = batch.num_rows() as i64;
 
-    // 1. Ask the catalog for the table id, location, and ratified commit tail.
+    // The credentialed store + engine are stable across retries (the table exists, so we vend
+    // by name). Build them once.
+    let uc_store = factory
+        .for_table(
+            format!("{catalog}.{schema}.{table}"),
+            TableOperation::ReadWrite,
+        )
+        .await?;
+    let engine = DefaultEngineBuilder::new(uc_store.root()).build();
+
+    let mut attempt: u32 = 0;
+    loop {
+        attempt += 1;
+
+        // 1. Load the catalog's ratified state and build a snapshot from it.
+        let loaded = client.load_table(catalog, schema, table).await?;
+        let (table_id, location) = table_id_and_location(catalog, schema, table, &loaded)?;
+        let snapshot = build_snapshot(&loaded, &location, &engine)?;
+
+        // 2. Write the batch through a transaction committed by our catalog committer.
+        let committer =
+            UnityCatalogCommitter::new(client.clone(), catalog, schema, table, table_id.clone());
+        let mut txn = snapshot
+            .transaction(Box::new(committer.clone()), &engine)
+            .map_err(CreateManagedTableError::Kernel)?
+            .with_engine_info(engine_info);
+
+        let write_context = txn
+            .unpartitioned_write_context()
+            .map_err(CreateManagedTableError::Kernel)?;
+        let add_metadata = engine
+            .write_parquet(&ArrowEngineData::new(batch.clone()), &write_context)
+            .await
+            .map_err(CreateManagedTableError::Kernel)?;
+        txn.add_files(add_metadata);
+
+        let outcome = match txn.commit(&engine) {
+            Ok(CommitResult::CommittedTransaction(c)) => {
+                let version = c.commit_version();
+                info!(version, attempt, "committed managed-table append");
+                let post = c.post_commit_snapshot().cloned();
+                run_post_commit(
+                    &client, catalog, schema, table, &table_id, &engine, post, version, num_rows,
+                )
+                .await;
+                return Ok(version);
+            }
+            // 409: a concurrent writer ratified our version first. Reload + rebuild + retry.
+            Ok(CommitResult::ConflictedTransaction(c)) => {
+                warn!(
+                    conflict_version = c.conflict_version(),
+                    attempt, "commit conflict; reloading and retrying"
+                );
+                RetryOutcome::Retry
+            }
+            // Retryable (kernel IO error): recover the typed UC error and dispatch on it.
+            Ok(CommitResult::RetryableTransaction(rt)) => {
+                handle_typed_retry(
+                    &client, catalog, schema, table, &committer, &engine, attempt, rt.error,
+                )
+                .await?
+            }
+            // Generic Err: same dispatch (the committer collapses UC errors into a kernel Err).
+            Err(kernel_err) => {
+                handle_typed_retry(
+                    &client, catalog, schema, table, &committer, &engine, attempt, kernel_err,
+                )
+                .await?
+            }
+        };
+
+        match outcome {
+            RetryOutcome::Succeeded(version) => return Ok(version),
+            RetryOutcome::Retry => {
+                if attempt >= MAX_COMMIT_ATTEMPTS {
+                    return Err(CreateManagedTableError::other(format!(
+                        "managed-table commit failed after {attempt} attempts"
+                    )));
+                }
+                backoff(attempt).await;
+            }
+        }
+    }
+}
+
+/// The result of inspecting a failed commit attempt.
+enum RetryOutcome {
+    /// A `CommitStateUnknown` check confirmed the commit actually landed at this version.
+    Succeeded(Version),
+    /// Retry the commit (after the caller's backoff).
+    Retry,
+}
+
+/// Inspect the typed UC error the committer recorded for the just-failed attempt and decide
+/// whether to retry, fail, or treat the commit as already-landed.
+///
+/// `kernel_err` is the kernel error to surface when the failure is not a recognised UC error
+/// (or attempts are exhausted).
+#[allow(clippy::too_many_arguments)]
+async fn handle_typed_retry(
+    client: &DeltaV1Client,
+    catalog: &str,
+    schema: &str,
+    table: &str,
+    committer: &UnityCatalogCommitter,
+    engine: &dyn Engine,
+    attempt: u32,
+    kernel_err: delta_kernel::Error,
+) -> Result<RetryOutcome, CreateManagedTableError> {
+    let Some(uc_err) = committer.take_last_error() else {
+        // No typed UC error → a kernel-side / IO failure. Retry while attempts remain.
+        if attempt >= MAX_COMMIT_ATTEMPTS {
+            return Err(CreateManagedTableError::Kernel(kernel_err));
+        }
+        warn!(attempt, error = %kernel_err, "retryable kernel commit error; retrying");
+        return Ok(RetryOutcome::Retry);
+    };
+
+    // 500 CommitStateUnknown: the commit may or may not have landed. Reload and look for the
+    // exact staged file we proposed — never blind-retry (duplicate commit) nor blind-fail
+    // (falsely failed write).
+    if uc_err.is_commit_state_unknown() {
+        return match commit_landed(client, catalog, schema, table, committer).await? {
+            Some(version) => {
+                info!(
+                    version,
+                    "commit-state-unknown resolved: proposed commit present; success"
+                );
+                Ok(RetryOutcome::Succeeded(version))
+            }
+            None if attempt >= MAX_COMMIT_ATTEMPTS => Err(CreateManagedTableError::Client(uc_err)),
+            None => {
+                warn!(
+                    attempt,
+                    "commit-state-unknown: proposed commit absent; retrying"
+                );
+                Ok(RetryOutcome::Retry)
+            }
+        };
+    }
+
+    // 429 ResourceExhausted: the unbackfilled tail is too long. Publish + backfill it, then retry.
+    if uc_err.is_resource_exhausted() {
+        if attempt >= MAX_COMMIT_ATTEMPTS {
+            return Err(CreateManagedTableError::Client(uc_err));
+        }
+        warn!(
+            attempt,
+            "resource-exhausted (429); backfilling pending tail before retry"
+        );
+        if let Err(e) = backfill_pending_tail(client, catalog, schema, table, engine).await {
+            warn!(error = %e, "backfill before retry failed; retrying anyway");
+        }
+        return Ok(RetryOutcome::Retry);
+    }
+
+    // Any other UC error is permanent (400 invalid, 403 denied, 404 missing, …).
+    Err(CreateManagedTableError::Client(uc_err))
+}
+
+/// If the staged commit the committer last proposed is present in the table's ratified tail (or
+/// already published), return the version it landed at. Used to resolve a `CommitStateUnknown`.
+async fn commit_landed(
+    client: &DeltaV1Client,
+    catalog: &str,
+    schema: &str,
+    table: &str,
+    committer: &UnityCatalogCommitter,
+) -> Result<Option<Version>, CreateManagedTableError> {
+    let Some((version, file_name)) = committer.last_proposed() else {
+        return Ok(None);
+    };
+    let landed_version: Version = version
+        .try_into()
+        .map_err(|_| CreateManagedTableError::other("negative proposed commit version"))?;
     let loaded = client.load_table(catalog, schema, table).await?;
+    let in_tail = loaded
+        .commits
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .any(|c| c.version == version && c.file_name == file_name);
+    // It may already have been published (and dropped from the tail) if a previous attempt's
+    // best-effort publish ran; treat "latest ratified version >= our version" as landed too.
+    let published = loaded
+        .latest_table_version
+        .or(loaded.metadata.last_commit_version)
+        .map(|v| v >= version)
+        .unwrap_or(false);
+    Ok((in_tail || published).then_some(landed_version))
+}
+
+/// Run the best-effort post-commit lifecycle: publish the ratified tail to `_delta_log/`,
+/// notify UC via `set-latest-backfilled-version`, and report commit metrics. None of these
+/// failing turns the (already ratified) commit into a failed write.
+#[allow(clippy::too_many_arguments)]
+async fn run_post_commit(
+    client: &DeltaV1Client,
+    catalog: &str,
+    schema: &str,
+    table: &str,
+    table_id: &str,
+    engine: &dyn Engine,
+    post_commit_snapshot: Option<SnapshotRef>,
+    version: Version,
+    num_rows: i64,
+) {
+    match post_commit_snapshot {
+        Some(snapshot) => {
+            match publish_and_backfill(client, catalog, schema, table, table_id, engine, &snapshot)
+                .await
+            {
+                Ok(published_to) => {
+                    debug!(published_to, "published + backfilled managed-table commits")
+                }
+                Err(e) => {
+                    warn!(error = %e, "best-effort publish/backfill failed; commit remains ratified")
+                }
+            }
+        }
+        // No post-commit snapshot (kernel didn't return one): publish is a maintenance step the
+        // next write or the 429 handler will catch up; skip rather than rebuild here.
+        None => debug!(
+            version,
+            "no post-commit snapshot; deferring publish to a later write"
+        ),
+    }
+
+    // Metrics (best-effort).
+    let request = DeltaReportMetricsRequest {
+        table_id: table_id.to_string(),
+        report: Some(DeltaReport {
+            commit_report: Some(DeltaCommitReport {
+                num_files_added: Some(1),
+                num_rows_inserted: Some(num_rows),
+                ..Default::default()
+            }),
+        }),
+    };
+    if let Err(e) = client
+        .report_metrics(catalog, schema, table, &request)
+        .await
+    {
+        warn!(version, error = %e, "best-effort report_metrics failed");
+    }
+}
+
+/// Publish `snapshot`'s unpublished catalog commits to `_delta_log/<v>.json`, then notify UC
+/// with `set-latest-backfilled-version`. Returns the version published up to.
+async fn publish_and_backfill(
+    client: &DeltaV1Client,
+    catalog: &str,
+    schema: &str,
+    table: &str,
+    table_id: &str,
+    engine: &dyn Engine,
+    snapshot: &SnapshotRef,
+) -> Result<i64, CreateManagedTableError> {
+    // A `UnityCatalogCommitter` is a catalog committer whose `publish` copies staged commits to
+    // their published path (idempotent on already-published files). `publish` is a no-op when
+    // nothing is unpublished, returning the same snapshot.
+    let committer =
+        UnityCatalogCommitter::new(Arc::new(client.clone()), catalog, schema, table, table_id);
+    let published = snapshot
+        .publish(engine, &committer)
+        .map_err(CreateManagedTableError::Kernel)?;
+    let published_to: i64 = published
+        .version()
+        .try_into()
+        .map_err(|_| CreateManagedTableError::other("published version does not fit into i64"))?;
+
+    let request = DeltaUpdateTableRequest {
+        requirements: vec![DeltaTableRequirement::AssertTableUuid {
+            uuid: table_id.to_string(),
+        }],
+        updates: vec![DeltaTableUpdate::SetLatestBackfilledVersion {
+            latest_published_version: published_to,
+        }],
+    };
+    client
+        .update_table(catalog, schema, table, &request)
+        .await?;
+    debug!(published_to, "set-latest-backfilled-version");
+    Ok(published_to)
+}
+
+/// Reload the table and publish + backfill its current unpublished tail. Used by the 429 handler
+/// to drain the tail before retrying a commit.
+async fn backfill_pending_tail(
+    client: &DeltaV1Client,
+    catalog: &str,
+    schema: &str,
+    table: &str,
+    engine: &dyn Engine,
+) -> Result<(), CreateManagedTableError> {
+    let loaded = client.load_table(catalog, schema, table).await?;
+    let (table_id, location) = table_id_and_location(catalog, schema, table, &loaded)?;
+    let snapshot = build_snapshot(&loaded, &location, engine)?;
+    publish_and_backfill(client, catalog, schema, table, &table_id, engine, &snapshot).await?;
+    Ok(())
+}
+
+/// Extract the UC table id and trailing-slash-normalised location from a loadTable response.
+fn table_id_and_location(
+    catalog: &str,
+    schema: &str,
+    table: &str,
+    loaded: &DeltaLoadTableResponse,
+) -> Result<(String, Url), CreateManagedTableError> {
     let table_id = loaded
         .metadata
         .properties
@@ -57,6 +402,16 @@ pub async fn append_to_managed_table(
         })?;
     let location = Url::parse(&ensure_trailing_slash(&loaded.metadata.location))
         .map_err(|e| CreateManagedTableError::other(format!("invalid table location: {e}")))?;
+    Ok((table_id, location))
+}
+
+/// Build a kernel snapshot from the catalog's ratified state (the catalog is the source of
+/// truth). A catalog-managed table always requires `max_catalog_version`.
+fn build_snapshot(
+    loaded: &DeltaLoadTableResponse,
+    location: &Url,
+    engine: &dyn Engine,
+) -> Result<SnapshotRef, CreateManagedTableError> {
     let commits = loaded.commits.as_deref().unwrap_or(&[]);
     let latest = loaded
         .latest_table_version
@@ -64,54 +419,11 @@ pub async fn append_to_managed_table(
     let latest: Version = latest
         .try_into()
         .map_err(|_| CreateManagedTableError::other("negative latest_table_version"))?;
-
-    // 2. Credentialed object store (table exists now, so vend by name) + kernel engine.
-    let uc_store = factory
-        .for_table(
-            format!("{catalog}.{schema}.{table}"),
-            TableOperation::ReadWrite,
-        )
-        .await?;
-    let engine = DefaultEngineBuilder::new(uc_store.root()).build();
-
-    // Build the kernel snapshot from the catalog's ratified state. A catalog-managed table
-    // always requires `max_catalog_version` (even with an empty unbackfilled tail — e.g. a
-    // freshly created table whose only commit is the published `0.json`).
-    let snapshot = KernelSnapshot::builder_for(location.as_str())
-        .with_log_tail(to_log_tail(&location, commits)?)
+    KernelSnapshot::builder_for(location.as_str())
+        .with_log_tail(to_log_tail(location, commits)?)
         .with_max_catalog_version(latest)
-        .build(&engine)
-        .map_err(CreateManagedTableError::Kernel)?;
-
-    // 3. Write the batch through a transaction committed by our catalog committer.
-    let committer = UnityCatalogCommitter::new(client, catalog, schema, table, table_id);
-    let mut txn = snapshot
-        .transaction(Box::new(committer), &engine)
-        .map_err(CreateManagedTableError::Kernel)?
-        .with_engine_info(engine_info);
-
-    let write_context = txn
-        .unpartitioned_write_context()
-        .map_err(CreateManagedTableError::Kernel)?;
-    let add_metadata = engine
-        .write_parquet(&ArrowEngineData::new(batch), &write_context)
-        .await
-        .map_err(CreateManagedTableError::Kernel)?;
-    txn.add_files(add_metadata);
-
-    match txn
-        .commit(&engine)
-        .map_err(CreateManagedTableError::Kernel)?
-    {
-        CommitResult::CommittedTransaction(c) => Ok(c.commit_version()),
-        CommitResult::ConflictedTransaction(c) => Err(CreateManagedTableError::other(format!(
-            "commit conflicted at version {}",
-            c.conflict_version()
-        ))),
-        CommitResult::RetryableTransaction(_) => Err(CreateManagedTableError::other(
-            "retryable error during append commit",
-        )),
-    }
+        .build(engine)
+        .map_err(CreateManagedTableError::Kernel)
 }
 
 /// Map the loadTable commit tail to kernel staged-commit [`LogPath`]s (mirrors
@@ -138,6 +450,15 @@ fn to_log_tail(
             .map_err(CreateManagedTableError::Kernel)
         })
         .collect()
+}
+
+/// Jittered, capped exponential backoff between commit attempts.
+async fn backoff(attempt: u32) {
+    let exp = RETRY_BASE_BACKOFF.saturating_mul(1u32 << attempt.min(5));
+    let capped = exp.min(RETRY_MAX_BACKOFF);
+    // Deterministic jitter from the attempt count avoids pulling in an RNG dependency.
+    let jitter = Duration::from_millis((attempt as u64 * 7) % 25);
+    tokio::time::sleep(capped + jitter).await;
 }
 
 fn ensure_trailing_slash(s: &str) -> String {

--- a/crates/datafusion/src/managed/committer.rs
+++ b/crates/datafusion/src/managed/committer.rs
@@ -16,12 +16,14 @@
 //! via `tokio::task::block_in_place` + `Handle::block_on` — this committer therefore
 //! requires a multi-threaded tokio runtime (the default engine's runtime is fine).
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use delta_kernel::committer::{
     CommitMetadata, CommitResponse, CommitType, Committer, PublishMetadata,
 };
-use delta_kernel::{DeltaResult, DeltaResultIterator, Engine, Error as DeltaError, FilteredEngineData};
+use delta_kernel::{
+    DeltaResult, DeltaResultIterator, Engine, Error as DeltaError, FilteredEngineData,
+};
 use tracing::{debug, info};
 use unitycatalog_client::DeltaV1Client;
 use unitycatalog_common::models::delta::v1::{
@@ -54,12 +56,29 @@ pub struct UnityCatalogCommitter {
     schema: String,
     table: String,
     table_id: String,
+    /// The last non-conflict UC error from `update_table`, captured so the caller's
+    /// retry loop can recover the *typed* `unitycatalog_client::Error` (429
+    /// resource-exhausted, 500 commit-state-unknown, …). The `Committer::commit`
+    /// signature only lets us return a kernel `DeltaError`, which erases the UC error
+    /// type; this side channel preserves it. Set on every failed commit attempt and
+    /// inspected by [`append_to_managed_table`](super::append::append_to_managed_table).
+    last_error: Arc<Mutex<Option<unitycatalog_client::Error>>>,
+    /// The `(version, staged_file_name)` of the most recent staged commit this committer
+    /// proposed to UC. After a `CommitStateUnknownException` (500) the retry loop reloads
+    /// the table and checks whether this exact file is present in the ratified tail: if so
+    /// the commit actually succeeded (return success, never re-commit); if absent, retry.
+    /// Matching on the full UUID file name — not just the version — avoids mistaking a
+    /// concurrent writer's commit at the same version for ours.
+    last_proposed: Arc<Mutex<Option<(i64, String)>>>,
 }
 
 impl std::fmt::Debug for UnityCatalogCommitter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UnityCatalogCommitter")
-            .field("table", &format_args!("{}.{}.{}", self.catalog, self.schema, self.table))
+            .field(
+                "table",
+                &format_args!("{}.{}.{}", self.catalog, self.schema, self.table),
+            )
             .field("table_id", &self.table_id)
             .finish()
     }
@@ -80,7 +99,34 @@ impl UnityCatalogCommitter {
             schema: schema.into(),
             table: table.into(),
             table_id: table_id.into(),
+            last_error: Arc::new(Mutex::new(None)),
+            last_proposed: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// The `(version, staged_file_name)` of the last staged commit proposed to UC, if any.
+    /// Used by the retry loop's commit-state-unknown recovery to detect a commit that
+    /// actually landed despite an ambiguous (500) response.
+    pub(crate) fn last_proposed(&self) -> Option<(i64, String)> {
+        self.last_proposed
+            .lock()
+            .expect("committer mutex poisoned")
+            .clone()
+    }
+
+    /// Take the last non-conflict UC error recorded by a failed `update_table` (clearing
+    /// it). The retry loop calls this after `Transaction::commit` returns a generic
+    /// `Err`/`RetryableTransaction` to recover the typed `unitycatalog_client::Error` and
+    /// dispatch on it (429 → backfill+retry, 500 commit-state-unknown → reload+check, …).
+    pub(crate) fn take_last_error(&self) -> Option<unitycatalog_client::Error> {
+        self.last_error
+            .lock()
+            .expect("committer mutex poisoned")
+            .take()
+    }
+
+    fn record_error(&self, err: unitycatalog_client::Error) {
+        *self.last_error.lock().expect("committer mutex poisoned") = Some(err);
     }
 
     fn has_catalog_managed_feature(commit_metadata: &CommitMetadata) -> bool {
@@ -115,12 +161,15 @@ impl UnityCatalogCommitter {
         let config = commit_metadata
             .metadata_configuration()
             .ok_or_else(|| DeltaError::generic("commit metadata is missing table configuration"))?;
-        let table_id = config
-            .get(UC_TABLE_ID_KEY)
-            .ok_or_else(|| DeltaError::generic(format!("table is missing property: {UC_TABLE_ID_KEY}")))?;
+        let table_id = config.get(UC_TABLE_ID_KEY).ok_or_else(|| {
+            DeltaError::generic(format!("table is missing property: {UC_TABLE_ID_KEY}"))
+        })?;
         require!(
             table_id == &self.table_id,
-            format!("table ID mismatch: committer={}, metadata={table_id}", self.table_id)
+            format!(
+                "table ID mismatch: committer={}, metadata={table_id}",
+                self.table_id
+            )
         );
         require!(
             config.get(ENABLE_IN_COMMIT_TIMESTAMPS).map(String::as_str) == Some("true"),
@@ -129,20 +178,39 @@ impl UnityCatalogCommitter {
         Ok(())
     }
 
-    /// Reject ALTER TABLE changes (protocol / metadata / clustering) on a data commit —
-    /// v1 supports append-style commits only, matching the upstream committer.
+    /// Reject ALTER-style changes (protocol / metadata / clustering) on a data commit —
+    /// this committer supports append-style commits only.
+    ///
+    /// **Documented limitation (ManagedTablesSpec §"Write to the table", line 73).** The spec
+    /// requires that schema/property/protocol evolution ride the *same* `updateTable` request as
+    /// the `add-commit` action — i.e. a single commit carries `set-columns` /
+    /// `set-properties` / `set-protocol` (and `set-domain-metadata` for clustering) alongside
+    /// `add-commit`, and UC ratifies the whole bundle atomically. We do not yet build those
+    /// update actions, so rather than write a staged commit that diverges from the catalog's
+    /// metadata, we reject the commit outright (safer than silently desyncing UC).
+    ///
+    /// To lift this limitation, derive the metadata/protocol/domain update actions from
+    /// `commit_metadata` and append them to the `DeltaUpdateTableRequest.updates` next to the
+    /// `add-commit` in [`commit_version_non_zero`](Self::commit_version_non_zero).
     fn validate_no_alter_table_changes(commit_metadata: &CommitMetadata) -> DeltaResult<()> {
         require!(
             !commit_metadata.has_protocol_change(),
-            "changing table protocol is not supported in a catalog-managed commit"
+            "schema/protocol evolution on a catalog-managed table is not yet supported: this \
+             commit changes the table protocol, which must be sent as a `set-protocol` action in \
+             the same updateTable request as the commit (ManagedTablesSpec §Write to the table)"
         );
         require!(
             !commit_metadata.has_metadata_change(),
-            "changing table metadata is not supported in a catalog-managed commit"
+            "schema/property evolution on a catalog-managed table is not yet supported: this \
+             commit changes table metadata, which must be sent as `set-columns`/`set-properties` \
+             actions in the same updateTable request as the commit (ManagedTablesSpec §Write to \
+             the table)"
         );
         require!(
             !commit_metadata.has_domain_metadata_change(CLUSTERING_DOMAIN_NAME),
-            "changing clustering columns is not supported in a catalog-managed commit"
+            "changing clustering columns on a catalog-managed table is not yet supported: it must \
+             be sent as a `set-domain-metadata` action in the same updateTable request as the \
+             commit (ManagedTablesSpec §Write to the table)"
         );
         Ok(())
     }
@@ -188,10 +256,9 @@ impl UnityCatalogCommitter {
         let committed = engine.storage_handler().head(&staged)?;
         debug!(path = %staged, "wrote staged commit file");
 
-        let version: i64 = commit_metadata
-            .version()
-            .try_into()
-            .map_err(|_| DeltaError::generic("commit version does not fit into i64 for UC commit"))?;
+        let version: i64 = commit_metadata.version().try_into().map_err(|_| {
+            DeltaError::generic("commit version does not fit into i64 for UC commit")
+        })?;
         let file_name = staged
             .path_segments()
             .and_then(|mut s| s.next_back())
@@ -201,6 +268,11 @@ impl UnityCatalogCommitter {
             .size
             .try_into()
             .map_err(|_| DeltaError::generic("staged commit size does not fit into i64"))?;
+
+        // Record what we're about to propose so the caller's commit-state-unknown recovery can
+        // recognise this exact commit in the reloaded tail.
+        *self.last_proposed.lock().expect("committer mutex poisoned") =
+            Some((version, file_name.clone()));
 
         let request = DeltaUpdateTableRequest {
             requirements: vec![DeltaTableRequirement::AssertTableUuid {
@@ -219,29 +291,40 @@ impl UnityCatalogCommitter {
         };
 
         match self.block_on_update(request) {
-            Ok(()) => Ok(CommitResponse::Committed { file_meta: committed }),
+            Ok(()) => Ok(CommitResponse::Committed {
+                file_meta: committed,
+            }),
             // A version conflict (UC returns 409) becomes a kernel Conflict so the caller's
             // commit loop can rebuild and retry, rather than a hard error.
             Err(e) if is_conflict(&e) => Ok(CommitResponse::Conflict {
                 version: commit_metadata.version(),
             }),
-            Err(e) => Err(DeltaError::generic(format!("UC add-commit failed: {e}"))),
+            // Any other UC error (429 resource-exhausted, 500 commit-state-unknown, …) must
+            // collapse to a kernel `DeltaError` here, but the retry loop needs the *typed*
+            // error to decide whether/how to retry. Stash it in the side channel first, then
+            // return a generic error carrying the same message for diagnostics.
+            Err(e) => {
+                let msg = format!("UC add-commit failed: {e}");
+                self.record_error(e);
+                Err(DeltaError::generic(msg))
+            }
         }
     }
 
     /// Run an async `update_table` to completion from the synchronous `Committer::commit`.
     /// Requires a multi-threaded tokio runtime (matches the upstream committer).
-    fn block_on_update(
-        &self,
-        request: DeltaUpdateTableRequest,
-    ) -> unitycatalog_client::Result<()> {
+    fn block_on_update(&self, request: DeltaUpdateTableRequest) -> unitycatalog_client::Result<()> {
         let handle = tokio::runtime::Handle::try_current().map_err(|_| {
             unitycatalog_client::Error::Generic(
                 "UnityCatalogCommitter must be used within a tokio runtime".to_string(),
             )
         })?;
         let client = self.client.clone();
-        let (catalog, schema, table) = (self.catalog.clone(), self.schema.clone(), self.table.clone());
+        let (catalog, schema, table) = (
+            self.catalog.clone(),
+            self.schema.clone(),
+            self.table.clone(),
+        );
         tokio::task::block_in_place(|| {
             handle.block_on(async move {
                 client
@@ -274,10 +357,10 @@ impl Committer for UnityCatalogCommitter {
         // Publish = copy each ratified staged commit to its published `_delta_log/<v>.json`
         // path (atomic / put-if-absent). An already-published version is not an error.
         for catalog_commit in publish_metadata.commits_to_publish() {
-            match engine
-                .storage_handler()
-                .copy_atomic(catalog_commit.location(), catalog_commit.published_location())
-            {
+            match engine.storage_handler().copy_atomic(
+                catalog_commit.location(),
+                catalog_commit.published_location(),
+            ) {
                 Ok(()) | Err(DeltaError::FileAlreadyExists(_)) => {}
                 Err(e) => return Err(e),
             }
@@ -302,9 +385,63 @@ fn is_conflict(err: &unitycatalog_client::Error) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_conflict;
-    use unitycatalog_client::{Error, UcApiError};
+    use std::sync::Arc;
+
+    use super::{UnityCatalogCommitter, is_conflict};
+    use olai_http::CloudClient;
+    use unitycatalog_client::{DeltaV1Client, Error, UcApiError};
     use unitycatalog_common::models::delta::v1::{DeltaErrorModel, DeltaErrorType};
+    use url::Url;
+
+    fn test_committer() -> UnityCatalogCommitter {
+        let client = DeltaV1Client::new(
+            CloudClient::new_unauthenticated(),
+            Url::parse("http://localhost/").unwrap(),
+        );
+        UnityCatalogCommitter::new(Arc::new(client), "c", "s", "t", "tid")
+    }
+
+    #[test]
+    fn last_error_side_channel_round_trips_then_clears() {
+        let committer = test_committer();
+        assert!(committer.take_last_error().is_none());
+
+        // A 429 the retry loop should recognise as resource-exhausted.
+        committer.record_error(Error::Delta(DeltaErrorModel {
+            message: "slow down".into(),
+            error_type: DeltaErrorType::ResourceExhaustedException,
+            code: 429,
+            stack: None,
+        }));
+        let taken = committer.take_last_error().expect("error recorded");
+        assert!(taken.is_resource_exhausted());
+        // `take` clears the slot so a subsequent attempt starts clean.
+        assert!(committer.take_last_error().is_none());
+    }
+
+    #[test]
+    fn last_proposed_defaults_none() {
+        let committer = test_committer();
+        assert!(committer.last_proposed().is_none());
+    }
+
+    #[test]
+    fn cloned_committer_shares_side_channels() {
+        // The transaction takes a *clone* of the committer; both must observe the same cells so
+        // the retry loop (holding the original) can read what the clone recorded.
+        let committer = test_committer();
+        let clone = committer.clone();
+        clone.record_error(Error::Delta(DeltaErrorModel {
+            message: "ambiguous".into(),
+            error_type: DeltaErrorType::CommitStateUnknownException,
+            code: 500,
+            stack: None,
+        }));
+        let taken = committer
+            .take_last_error()
+            .expect("clone's error visible on original");
+        assert!(taken.is_commit_state_unknown());
+    }
 
     #[test]
     fn conflict_detects_already_exists_and_409_other() {

--- a/crates/datafusion/src/managed/create.rs
+++ b/crates/datafusion/src/managed/create.rs
@@ -43,6 +43,16 @@ const VACUUM_PROTOCOL_CHECK_FEATURE_KEY: &str = "delta.feature.vacuumProtocolChe
 const V2_CHECKPOINT_FEATURE_KEY: &str = "delta.feature.v2Checkpoint";
 const CHECKPOINT_POLICY_KEY: &str = "delta.checkpointPolicy";
 const CHECKPOINT_POLICY_V2: &str = "v2";
+// Since v0.5.0-20260428 the server's `UcManagedDeltaContract` further requires the
+// `deletionVectors` reader/writer feature and three fixed-value properties
+// (`delta.enableDeletionVectors`, `delta.checkpoint.writeStatsAsStruct`,
+// `delta.checkpoint.writeStatsAsJson`). The enablement property auto-enables the DV
+// protocol feature at create time (the kernel's property-driven enablement), but we keep
+// the explicit feature signal too so the protocol intent is visible in one place.
+const DELETION_VECTORS_FEATURE_KEY: &str = "delta.feature.deletionVectors";
+const ENABLE_DELETION_VECTORS_KEY: &str = "delta.enableDeletionVectors";
+const WRITE_STATS_AS_STRUCT_KEY: &str = "delta.checkpoint.writeStatsAsStruct";
+const WRITE_STATS_AS_JSON_KEY: &str = "delta.checkpoint.writeStatsAsJson";
 const FEATURE_SUPPORTED: &str = "supported";
 const UC_TABLE_ID_KEY: &str = "io.unitycatalog.tableId";
 const METASTORE_LAST_UPDATE_VERSION: &str = "delta.lastUpdateVersion";
@@ -186,6 +196,14 @@ pub fn get_required_properties_for_disk(uc_table_id: &str) -> HashMap<String, St
         (CATALOG_MANAGED_FEATURE_KEY, FEATURE_SUPPORTED),
         (VACUUM_PROTOCOL_CHECK_FEATURE_KEY, FEATURE_SUPPORTED),
         (V2_CHECKPOINT_FEATURE_KEY, FEATURE_SUPPORTED),
+        (DELETION_VECTORS_FEATURE_KEY, FEATURE_SUPPORTED),
+        // Fixed-value properties the server's MANAGED contract checks verbatim. These are
+        // real metadata properties (unlike the feature signals above, which the kernel
+        // strips into the protocol), so they flow into `snapshot.metadata_configuration()`
+        // and from there into the UC createTable request.
+        (ENABLE_DELETION_VECTORS_KEY, "true"),
+        (WRITE_STATS_AS_STRUCT_KEY, "true"),
+        (WRITE_STATS_AS_JSON_KEY, "true"),
         (UC_TABLE_ID_KEY, uc_table_id),
     ]
     .into_iter()

--- a/crates/datafusion/src/managed/create.rs
+++ b/crates/datafusion/src/managed/create.rs
@@ -209,7 +209,10 @@ pub fn get_final_required_properties_for_uc(
     properties.extend(snapshot.get_protocol_derived_properties());
     // The server's MANAGED contract wants `delta.checkpointPolicy=v2` explicitly; it follows
     // from the `v2Checkpoint` feature but isn't emitted by the protocol-derived properties.
-    properties.insert(CHECKPOINT_POLICY_KEY.to_string(), CHECKPOINT_POLICY_V2.to_string());
+    properties.insert(
+        CHECKPOINT_POLICY_KEY.to_string(),
+        CHECKPOINT_POLICY_V2.to_string(),
+    );
     properties.insert(
         METASTORE_LAST_UPDATE_VERSION.to_string(),
         snapshot.version().to_string(),

--- a/crates/datafusion/src/managed/mod.rs
+++ b/crates/datafusion/src/managed/mod.rs
@@ -4,7 +4,9 @@
 //!
 //! - [`UnityCatalogCommitter`] — the catalog-managed committer (v0 publish, v≥1 stage + ratify).
 //! - [`create_managed_table`] — staging → `kernel::create_table` (writes `0.json`) → `createTable`.
-//! - [`append_to_managed_table`] — load snapshot → kernel write transaction → commit (v≥1).
+//! - [`append_to_managed_table`] — load snapshot → kernel write transaction → commit (v≥1)
+//!   with bounded conflict/throttle/ambiguity retry, then best-effort publish + backfill +
+//!   metrics (ManagedTablesSpec §"Write to the table").
 //!
 //! Design + rationale: see open-lakehouse `docs/adr/0010-catalog-managed-table-writes.md`.
 //!
@@ -15,11 +17,11 @@
 //!   contract). The workspace pins the `roeap/delta-rs` fork rev carrying that change. Upstream
 //!   it to delta-rs (a focused PR, not the "demo updates" commit it currently rides on), then
 //!   bump the pin off the fork rev.
-//! - **Client-side publish**: we ratify staged commits via `updateTable add-commit` but do not
-//!   copy them to `_delta_log/<v>.json` or send `set-latest-backfilled-version`. Reads work via
-//!   the catalog's unbackfilled tail; publish is a maintenance step for a later phase.
-//! - **Conflict-retry loop**: `409` maps to `CommitResponse::Conflict` but no rebase/retry loop
-//!   exists yet (only the happy path is exercised).
+//! - **Schema/property evolution on append**: ALTER-style commits (protocol/metadata/clustering
+//!   changes) are rejected, not propagated — see `UnityCatalogCommitter`'s
+//!   `validate_no_alter_table_changes`. Lifting this requires bundling
+//!   `set-columns`/`set-properties`/`set-protocol` actions into the same `updateTable` call as
+//!   `add-commit`.
 //! - **Upstream home**: keep this glue dependency-light so it can move toward
 //!   `delta-rs/crates/catalog-unity`, or adopt the buoyant `delta-kernel-unity-catalog` /
 //!   `unity-catalog-delta-rest-client` crates once they stabilize.
@@ -31,6 +33,6 @@ mod create;
 pub use append::append_to_managed_table;
 pub use committer::UnityCatalogCommitter;
 pub use create::{
-    create_managed_table, get_final_required_properties_for_uc, get_required_properties_for_disk,
-    CreateManagedTableError, ManagedTable,
+    CreateManagedTableError, ManagedTable, create_managed_table,
+    get_final_required_properties_for_uc, get_required_properties_for_disk,
 };


### PR DESCRIPTION
…ry, metrics)

Completes the post-commit protocol obligations and resilience for the catalog-managed write path (ManagedTablesSpec §"Write to the table"), resolving review findings A2, A3, and metrics reporting.

append_to_managed_table now:
- Publishes the ratified commit into _delta_log/<v>.json and notifies UC via set-latest-backfilled-version after each successful commit (A2). Both are best-effort: a publish/notify failure never fails the already-ratified write.
- Reports commit metrics (num_files_added, num_rows_inserted) best-effort via the new DeltaV1Client::report_metrics (A3 metrics).
- Wraps the commit in a bounded, jittered retry loop (A3):
  - 409 conflict  → reload + rebuild snapshot at the new version + retry
  - 429 exhausted → publish/backfill the pending tail, then retry
  - 500 unknown   → reload and check for the exact staged file we proposed;
                    present = success (never re-commit), absent = retry.

To dispatch on the typed UC error from inside the kernel's narrow Committer::commit result channel, UnityCatalogCommitter records the last non-conflict unitycatalog_client::Error and the (version, staged_file_name) it proposed in shared cells the retry loop reads back via take_last_error() / last_proposed().

ALTER-style commits (protocol/metadata/clustering changes) remain rejected rather than propagated, but the error messages and a doc comment now spell out the limitation and point at the spec requirement (bundle set-columns/ set-properties/set-protocol into the same updateTable as add-commit).

The deltalake-core fork pin currently does not compile under the `delta` feature (pre-existing; S02 territory), so the managed module + its unit tests were verified against buoyant_kernel via a temporary kernel-only feature.

AI-assisted-by: Isaac

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->