### PR TITLE
ci: add Docker and binary release pipelines

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,238 @@
+name: Release Docker Image
+
+# Build and publish the `uc` service image to the GitHub Container Registry.
+# Adapted from open-lakehouse/hydrofoil's docker-release.yml; this repo ships a
+# single binary (`uc`), so the matrix axis is the *platform* only (no BIN
+# build-arg), and one GHCR image is produced. We publish to GHCR only (keyless
+# GITHUB_TOKEN — no stored registry secret).
+#
+# A `v*` tag push builds multi-arch (amd64 + native arm64), pushes each arch by
+# digest, then a merge job assembles the multi-arch manifest list, applies the
+# tags, and signs the index keyless via cosign. PRs / main pushes build for
+# validation but do not publish (see the `build` job's `if:` gate).
+
+on:
+  push:
+    tags: ["v*"]
+    branches: [main]
+    # Limit branch/main builds to inputs that affect the image. Tag pushes
+    # ignore `paths` and always run.
+    paths:
+      - crates/**
+      - Cargo.toml
+      - Cargo.lock
+      - crates/cli/Dockerfile
+      - .dockerignore
+      - .github/workflows/docker-release.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - crates/**
+      - Cargo.toml
+      - Cargo.lock
+      - crates/cli/Dockerfile
+      - .dockerignore
+      - .github/workflows/docker-release.yml
+  workflow_dispatch: {}
+
+# Cancel superseded runs on the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+# Least privilege by default; jobs opt into more.
+permissions: {}
+
+env:
+  IMAGE: ghcr.io/unitycatalog-incubator/unitycatalog-rs
+
+jobs:
+  # Build each platform on its NATIVE runner and push BY DIGEST (no tags).
+  # Native arm64 avoids slow QEMU emulation of the Rust/cargo compile.
+  build:
+    name: Build (${{ matrix.platform.arch }})
+    runs-on: ${{ matrix.platform.runner }}
+
+    # Publish from the canonical repo on pushes to main / tags, not on PRs.
+    if: ${{ contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.repository == 'unitycatalog-incubator/unitycatalog-rs' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main') }}
+
+    permissions:
+      contents: read
+      packages: write   # push to ghcr.io with GITHUB_TOKEN
+      id-token: write   # build provenance / SBOM attestations
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - arch: amd64
+            os: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            os: linux/arm64
+            runner: ubuntu-24.04-arm   # native arm64 hosted runner
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # OCI labels + manifest-level annotations for the per-arch image. (Index-
+      # level annotations are applied later in the merge job.)
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest
+        with:
+          images: ${{ env.IMAGE }}
+          labels: |
+            org.opencontainers.image.title=unitycatalog-rs
+            org.opencontainers.image.description=Unity Catalog server and CLI (uc)
+            org.opencontainers.image.vendor=unitycatalog-incubator
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.source=https://github.com/unitycatalog-incubator/unitycatalog-rs
+
+      # Build + push by digest only (no tags here — the merge job assembles the
+      # multi-arch manifest list and applies the tags). Per-arch cache scope so
+      # concurrent matrix builds do not clobber each other's gha cache.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: crates/cli/Dockerfile
+          platforms: ${{ matrix.platform.os }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          sbom: true
+          provenance: mode=max
+          cache-from: type=gha,scope=${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform.arch }}
+
+      - name: Export digest
+        # Route the digest through env (not inline ${{ }}) so it is never
+        # spliced into the shell — keeps the template-injection audit clean.
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digests-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the per-arch digests into one multi-arch manifest list, apply the
+  # tags, then sign the resulting index by digest (keyless).
+  merge:
+    name: Merge and sign
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write   # cosign keyless signing
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: digests-*
+          merge-multiple: true
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Tagging strategy:
+      #   tag push v* -> <version> (e.g. 1.2.3) + the raw git tag + `latest`
+      #   main push   -> `main`, `main-<sha>`, and `edge` (latest dev build);
+      #                  never `latest`
+      # DOCKER_METADATA_ANNOTATIONS_LEVELS=index emits index-level OCI
+      # annotations (manifest-level labels from a per-arch build do NOT
+      # propagate to the multi-arch index created by imagetools).
+      - name: Generate metadata and tags
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=tag
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=main-,enable=${{ github.ref == 'refs/heads/main' }}
+          flavor: |
+            latest=auto
+          labels: |
+            org.opencontainers.image.title=unitycatalog-rs
+            org.opencontainers.image.description=Unity Catalog server and CLI (uc)
+            org.opencontainers.image.vendor=unitycatalog-incubator
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.source=https://github.com/unitycatalog-incubator/unitycatalog-rs
+
+      # Create the manifest list referencing the per-arch digests, for each tag.
+      # Index-level OCI annotations from metadata-action are applied here (they
+      # cannot be set on the index by the per-arch build step).
+      - name: Create and push manifest list
+        working-directory: /tmp/digests
+        env:
+          IMAGE: ${{ env.IMAGE }}
+        run: |
+          # Build arrays so no unquoted word-splitting is needed.
+          mapfile -t tags < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          tag_args=(); for t in "${tags[@]}"; do tag_args+=(-t "$t"); done
+          ann_args=()
+          while IFS= read -r a; do
+            [ -n "$a" ] && ann_args+=(--annotation "$a")
+          done <<< "$DOCKER_METADATA_OUTPUT_ANNOTATIONS"
+          srcs=(); for d in *; do srcs+=("${IMAGE}@sha256:${d}"); done
+          docker buildx imagetools create "${tag_args[@]}" "${ann_args[@]}" "${srcs[@]}"
+
+      - name: Inspect and capture index digest
+        id: digest
+        run: |
+          ref=$(jq -r '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          docker buildx imagetools inspect "$ref"
+          d=$(docker buildx imagetools inspect "$ref" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "index=$d" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+      # Keyless signing via GitHub OIDC (Fulcio/Rekor). Sign each distinct
+      # repo@indexDigest once.
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.digest.outputs.index }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          echo "$TAGS" | sed "s/:.*\$/@$DIGEST/" | sort -u | \
+            xargs --no-run-if-empty cosign sign --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,192 @@
+name: Release Binaries
+
+# Cross-compile the `uc` CLI for each supported platform, sign the artifacts,
+# and attach them to a GitHub Release. The CLI is rustls-only (no OpenSSL/C
+# deps), so every target builds natively on a matching runner — no QEMU and no
+# `cross` needed; Linux uses static musl builds.
+#
+# Each binary gets a SLSA build-provenance attestation (keyless OIDC). The
+# combined SHA256SUMS manifest is additionally signed with cosign sign-blob.
+#
+# Verify a download, e.g.:
+#   gh attestation verify uc --repo unitycatalog-incubator/unitycatalog-rs
+#   cosign verify-blob \
+#     --certificate-identity-regexp 'https://github.com/unitycatalog-incubator/unitycatalog-rs/.*' \
+#     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+#     --signature SHA256SUMS.sig --certificate SHA256SUMS.pem SHA256SUMS
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag/version label for a manual dry-run (no Release published)"
+        required: false
+        default: "v0.0.0-dev"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+
+    permissions:
+      contents: read
+      id-token: write       # build-provenance attestation (keyless OIDC)
+      attestations: write   # write the attestation to the repo
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            runner: macos-14
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel   # Intel-hosted macOS runner (macos-13 retired)
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            archive: zip
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffc87aec921533aa9aff # v1.13.0
+        with:
+          target: ${{ matrix.target }}
+          # Release builds must not depend on a (potentially poisoned) shared
+          # cache — build from clean for reproducible, trustworthy artifacts.
+          cache: false
+
+      # musl static builds need the musl C toolchain for the linker.
+      - name: Install musl tools
+        if: ${{ endsWith(matrix.target, '-linux-musl') }}
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      # SQLX_OFFLINE uses the committed `.sqlx` cache — no database at build time.
+      - name: Build uc
+        env:
+          SQLX_OFFLINE: "true"
+        run: cargo build --release --bin uc --target ${{ matrix.target }}
+
+      # Package the binary + a per-archive checksum. Naming:
+      #   uc-<ref>-<target>.{tar.gz,zip}
+      # The version label comes from the tag (push) or the dispatch input.
+      - name: Package (unix)
+        id: package_unix
+        if: ${{ matrix.archive == 'tar.gz' }}
+        env:
+          TARGET: ${{ matrix.target }}
+          REF_NAME: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
+        run: |
+          bin="target/${TARGET}/release/uc"
+          strip "$bin" || true
+          name="uc-${REF_NAME}-${TARGET}"
+          mkdir -p "dist/$name"
+          cp "$bin" "dist/$name/uc"
+          cp README.md LICENSE "dist/$name/" 2>/dev/null || true
+          tar -C dist -czf "dist/${name}.tar.gz" "$name"
+          ( cd dist && shasum -a 256 "${name}.tar.gz" > "${name}.tar.gz.sha256" )
+          echo "binary=$bin" >> "$GITHUB_OUTPUT"
+          echo "artifact=dist/${name}.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - name: Package (windows)
+        id: package_windows
+        if: ${{ matrix.archive == 'zip' }}
+        shell: pwsh
+        env:
+          TARGET: ${{ matrix.target }}
+          REF_NAME: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
+        run: |
+          $bin = "target/$env:TARGET/release/uc.exe"
+          $name = "uc-$env:REF_NAME-$env:TARGET"
+          New-Item -ItemType Directory -Force -Path "dist/$name" | Out-Null
+          Copy-Item $bin "dist/$name/uc.exe"
+          Compress-Archive -Path "dist/$name/*" -DestinationPath "dist/$name.zip"
+          (Get-FileHash "dist/$name.zip" -Algorithm SHA256).Hash.ToLower() + "  $name.zip" | Out-File -Encoding ascii "dist/$name.zip.sha256"
+          "binary=$bin" | Out-File -Append -Encoding ascii $env:GITHUB_OUTPUT
+          "artifact=dist/$name.zip" | Out-File -Append -Encoding ascii $env:GITHUB_OUTPUT
+
+      # SLSA build provenance for the binary itself (keyless OIDC).
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-path: ${{ steps.package_unix.outputs.binary || steps.package_windows.outputs.binary }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: uc-${{ matrix.target }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.sha256
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Sign and publish release
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write   # create/update the GitHub Release
+      id-token: write   # cosign keyless sign-blob
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: dist
+          merge-multiple: true
+
+      # Combine the per-archive sums into one manifest over all archives.
+      - name: Build SHA256SUMS
+        working-directory: dist
+        run: |
+          cat ./*.sha256 | sort -k2 > SHA256SUMS
+          rm -f ./*.sha256
+          cat SHA256SUMS
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+      # Keyless sign-blob over the manifest -> .sig + .pem (cert chain).
+      - name: Sign SHA256SUMS (keyless)
+        working-directory: dist
+        run: |
+          cosign sign-blob --yes \
+            --output-signature SHA256SUMS.sig \
+            --output-certificate SHA256SUMS.pem \
+            SHA256SUMS
+
+      # Only publish a real Release on a tag push; dispatch runs stop here.
+      - name: Publish GitHub Release
+        if: ${{ github.ref_type == 'tag' }}
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
+        with:
+          files: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/SHA256SUMS
+            dist/SHA256SUMS.sig
+            dist/SHA256SUMS.pem
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/crates/cli/Dockerfile
+++ b/crates/cli/Dockerfile
@@ -1,61 +1,78 @@
-FROM rust:1.89 AS chef
+# Multi-stage build for the `uc` Unity Catalog CLI/server binary.
+#
+# Layout:
+#   chef    -> installs cargo-chef for dependency-layer caching
+#   planner -> computes the dependency recipe from the workspace
+#   builder -> cooks deps (cached layer), then compiles the `uc` release binary
+#   cleaner -> copies a distroless rootfs into a staging dir (distroless has no
+#              shell/rm, so file surgery has to happen in a stage that does)
+#   final   -> scratch + the distroless rootfs + the `uc` binary, run as nonroot
+#
+# Base images are pinned by digest for reproducible, tamper-evident builds.
+# Refresh a digest with: docker buildx imagetools inspect <image:tag>
 
-ARG NO_CHEF=false
-ENV NO_CHEF=${NO_CHEF}
+# rust:1.89-bookworm
+FROM rust@sha256:948f9b08a66e7fe01b03a98ef1c7568292e07ec2e4fe90d88c07bb14563c84ff AS chef
 
-RUN $NO_CHEF || cargo install cargo-chef
+RUN cargo install cargo-chef --locked
 
 WORKDIR /app
 
 FROM chef AS planner
 COPY . .
-RUN ($NO_CHEF && touch recipe.json) || cargo chef prepare  --recipe-path recipe.json
+RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 
 COPY --from=planner /app/recipe.json recipe.json
-# Build dependencies - this is the caching Docker layer!
-RUN $NO_CHEF || cargo chef cook --release --recipe-path recipe.json --bin uc
-# Build application
-COPY . .
+# Build dependencies first — this is the cached Docker layer that survives
+# source-only changes.
+RUN cargo chef cook --release --recipe-path recipe.json --bin uc
 
+# Build the application. SQLX_OFFLINE uses the committed `.sqlx` query cache so
+# no database is required at build time.
+COPY . .
 ENV SQLX_OFFLINE=true
 RUN cargo build --release --bin uc
 
-# our final base
-FROM gcr.io/distroless/cc-debian12:nonroot AS base
+# Distroless `cc` (nonroot) gives us libgcc/libssl-free glibc + CA certs +
+# a nonroot passwd entry, without a shell or package manager.
+# gcr.io/distroless/cc-debian12:nonroot
+FROM gcr.io/distroless/cc-debian12@sha256:b0ae8e989418b458e0f25489bc3be523718938a2b70864cc0f6a00af1ddbd985 AS base
 
-
-FROM busybox:1.37.0 AS cleaner
-# small diversion through busybox to remove some files
-# (no rm in distroless)
+# busybox:1.37.0 — has a shell + coreutils so we can stage the distroless
+# rootfs into a plain directory before copying it into `scratch`.
+FROM busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028 AS cleaner
 
 COPY --from=base / /clean
-
-# RUN rm -r /clean/usr/lib/*-linux-gnu/libgomp*  \
-#   /clean/usr/lib/*-linux-gnu/libssl*  \
-#   /clean/usr/lib/*-linux-gnu/libstdc++* \
-#   /clean/usr/lib/*-linux-gnu/engines-3 \
-#   /clean/usr/lib/*-linux-gnu/ossl-modules \
-#   /clean/usr/lib/*-linux-gnu/libcrypto.so.3 \
-#   /clean/usr/lib/*-linux-gnu/gconv \
-#   /clean/var/lib/dpkg/status.d/libgomp1*  \
-#   /clean/var/lib/dpkg/status.d/libssl3*  \
-#   /clean/var/lib/dpkg/status.d/libstdc++6* \
-#   /clean/usr/share/doc/libssl3 \
-#   /clean/usr/share/doc/libstdc++6 \
-#   /clean/usr/share/doc/libgomp1
 
 
 FROM scratch
 
-ARG EXPIRES=Never
-LABEL maintainer="robstar.pack@gmail.com" quay.expires-after=${EXPIRES}
+# OCI image labels. The release workflow layers its own via docker/metadata-action,
+# but baking them here keeps locally/`just build-docker`-built images labelled too.
+LABEL org.opencontainers.image.title="unitycatalog-rs" \
+      org.opencontainers.image.description="Unity Catalog server and CLI (uc)" \
+      org.opencontainers.image.source="https://github.com/unitycatalog-incubator/unitycatalog-rs" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="unitycatalog-incubator"
 
+# Bring in the distroless rootfs (CA certs, glibc, nonroot passwd/group).
 COPY --from=cleaner /clean /
 
-# copy the build artifact from the build stage
-COPY --from=builder /app/target/release/uc /home/nonroot/uc
+# Copy the release binary from the build stage.
+COPY --from=builder /app/target/release/uc /usr/local/bin/uc
 
-# # set the startup command to run your binary
-ENTRYPOINT ["/home/nonroot/uc"]
+# The server binds 0.0.0.0:8080 by default (`uc server`).
+EXPOSE 8080
+
+# Run unprivileged. The distroless rootfs above provides the `nonroot` (65532)
+# user/group entries this references.
+USER nonroot
+
+# No HEALTHCHECK: distroless has no shell and `uc` has no self-probe subcommand.
+# Orchestrators should health-check the REST API directly, e.g.
+#   GET /api/2.1/unity-catalog/catalogs
+# (see dev/uc-oss.compose.yaml for a compose-level healthcheck example).
+
+ENTRYPOINT ["/usr/local/bin/uc"]


### PR DESCRIPTION
Add two GitHub Actions release workflows and harden the CLI Dockerfile.

docker-release.yml: multi-arch (amd64 + native arm64) GHCR image built per-arch by digest, merged into a manifest list, and signed keyless via cosign. SBOM and max provenance attestations; publishes only on main/tags from the canonical repo, PRs build for validation only.

release.yml: cross-compiles the `uc` CLI for five targets (musl Linux x86_64/ aarch64, macOS arm64/x86_64, Windows x86_64) on native runners, packages tar.gz/zip with checksums, attaches a SLSA build-provenance attestation per binary, and cosign sign-blobs the combined SHA256SUMS before publishing a GitHub Release. SQLX_OFFLINE matches the Dockerfile; cache disabled for reproducible release builds.

crates/cli/Dockerfile: pin base images by digest, add OCI labels, drop the personal/Quay labels and dead busybox block, run as nonroot, EXPOSE 8080, and install the binary to /usr/local/bin. Drop the unused NO_CHEF escape hatch.

All actions SHA-pinned. Validated locally: actionlint + zizmor clean on both workflows, hadolint clean on the Dockerfile, and the uc cross-compile + packaging path verified end-to-end.

AI-assisted-by: Isaac

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->