### PR TITLE
feat: metric-view support with Spark-style MEASURE() late binding (#191)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ prost-types = { version = "0.14.1" }
 pyo3 = { version = "0.24", features = ["macros", "indexmap"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
+serde_yml = { version = "0.0.12" }
 strum = { version = "0.27", features = ["derive"] }
 sqlx = { version = "0.8.3" }
 thiserror = { version = "2" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -39,7 +39,7 @@ console = "0.15"
 crossterm = { version = "0.28", features = ["event-stream"] }
 futures = "0.3"
 ratatui = "0.29"
-serde_yml = { version = "0.0.12" }
+serde_yml = { workspace = true }
 swagger-ui-dist = { version = "5.18.3" }
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["trace"] }

--- a/crates/datafusion/Cargo.toml
+++ b/crates/datafusion/Cargo.toml
@@ -27,10 +27,16 @@ deltalake-core = { workspace = true, optional = true }
 # source with `deltalake-core` so the `Snapshot` types unify.
 delta_kernel = { workspace = true, optional = true }
 
+# Metric-view YAML deserialization (the `metric-view` feature).
+serde = { workspace = true, optional = true }
+serde_yml = { workspace = true, optional = true }
+
 [features]
-default = ["delta"]
+default = ["delta", "metric-view"]
 # Expose a Delta-backed `TableProviderBuilder` (pulls in delta-rs).
 delta = ["dep:deltalake-core", "dep:delta_kernel"]
+# Lower Unity Catalog metric-view YAML into a DataFusion `LogicalPlan`.
+metric-view = ["dep:serde", "dep:serde_yml"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
@@ -49,3 +55,7 @@ required-features = ["delta"]
 [[example]]
 name = "managed_table_write"
 required-features = ["delta"]
+
+[[example]]
+name = "metric_view"
+required-features = ["metric-view"]

--- a/crates/datafusion/examples/metric_view.rs
+++ b/crates/datafusion/examples/metric_view.rs
@@ -1,0 +1,98 @@
+//! Query a Unity Catalog metric view through DataFusion with Spark-style
+//! `MEASURE()` late binding.
+//!
+//! A *metric view* is a semantic layer: a base relation annotated with
+//! `dimensions` (group-by expressions) and `measures` (aggregate expressions),
+//! defined as SQL strings in a YAML body. Unity Catalog returns this YAML as a
+//! table's definition when the table is a metric view. This example registers
+//! such a view over an in-memory `orders` table (so it runs with no external
+//! services) and queries it:
+//!
+//! ```text
+//! cargo run -p datafusion-unitycatalog --features metric-view --example metric_view
+//! ```
+//!
+//! The query references measures through `MEASURE(...)`. The
+//! `ResolveMetricView` analyzer rule rewrites the view into a concrete
+//! aggregation over the source, materializing only the dimensions grouped and
+//! measures referenced — mirroring Apache Spark (SPIP SPARK-54119).
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Date32Array, Float64Array, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::MemTable;
+use datafusion_unitycatalog::metric_view::{
+    MetricView, MetricViewTableProvider, metric_view_context,
+};
+
+/// The metric-view YAML Unity Catalog would return for this table (UC `1.1`).
+const METRIC_VIEW_YAML: &str = r#"
+version: "1.1"
+source: main.sales.orders
+filter: o_orderdate >= '2022-01-01'
+dimensions:
+  - name: order_date
+    expr: o_orderdate
+  - name: status
+    expr: o_orderstatus
+measures:
+  - name: order_count
+    expr: COUNT(1)
+  - name: total_revenue
+    expr: SUM(o_totalprice)
+  - name: open_revenue
+    expr: SUM(o_totalprice) FILTER (WHERE o_orderstatus = 'O')
+"#;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // A session with the MEASURE() UDF and the ResolveMetricView analyzer rule
+    // registered (the rule is ordered before type coercion).
+    let ctx = metric_view_context();
+
+    // 1. Register an in-memory `orders` table standing in for the view's source.
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("o_orderdate", DataType::Date32, false),
+        Field::new("o_orderstatus", DataType::Utf8, false),
+        Field::new("o_totalprice", DataType::Float64, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            // 2022-01-23, 2022-01-23, 2022-01-24, 2022-01-24 (days since epoch).
+            Arc::new(Date32Array::from(vec![19_015, 19_015, 19_016, 19_016])),
+            Arc::new(StringArray::from(vec!["O", "F", "O", "O"])),
+            Arc::new(Float64Array::from(vec![100.0, 50.0, 200.0, 75.0])),
+        ],
+    )?;
+    ctx.register_table(
+        "orders",
+        Arc::new(MemTable::try_new(schema, vec![vec![batch]])?),
+    )?;
+
+    // 2. Build a metric-view provider and register it as `orders_metrics`.
+    let view = MetricView::from_yaml(METRIC_VIEW_YAML)?;
+    let source = ctx.table("orders").await?.into_unoptimized_plan();
+    let provider = MetricViewTableProvider::try_new(&ctx.state(), &view, source)?;
+    ctx.register_table("orders_metrics", Arc::new(provider))?;
+
+    // 3. Query the view through MEASURE(). Only `total_revenue` is referenced,
+    //    so only it is materialized (late binding) — `order_count` and
+    //    `open_revenue` never enter the plan.
+    let query = "SELECT order_date, MEASURE(total_revenue) AS revenue \
+                 FROM orders_metrics GROUP BY order_date ORDER BY order_date";
+
+    let resolved = ctx.sql(query).await?.into_optimized_plan()?;
+    println!(
+        "query:\n  {query}\n\nresolved plan (note: only sum() materialized):\n{}\n",
+        resolved.display_indent()
+    );
+
+    let batches = ctx.sql(query).await?.collect().await?;
+    println!("result:");
+    datafusion::arrow::util::pretty::print_batches(&batches)?;
+
+    Ok(())
+}

--- a/crates/datafusion/src/catalog/builder.rs
+++ b/crates/datafusion/src/catalog/builder.rs
@@ -27,4 +27,28 @@ pub trait TableProviderBuilder: Send + Sync + std::fmt::Debug {
         location: &Url,
         table: &Table,
     ) -> Result<Arc<dyn TableProvider>, TableProviderError>;
+
+    /// Build a provider for a metric view.
+    ///
+    /// `view` is the parsed metric-view definition and `source` is the
+    /// already-resolved provider for the view's source relation (the resolver
+    /// resolves it through the same Unity Catalog path, so its credentials and
+    /// object store are registered). Implementations turn `source` into a
+    /// logical plan and lower the view into a
+    /// [`MetricViewTableProvider`](crate::metric_view::MetricViewTableProvider).
+    ///
+    /// The default errors: only embedders that build a session with metric-view
+    /// support (see [`crate::metric_view::session`]) can resolve metric views.
+    #[cfg(feature = "metric-view")]
+    async fn build_metric_view(
+        &self,
+        view: &crate::metric_view::MetricView,
+        source: Arc<dyn TableProvider>,
+        source_name: &str,
+    ) -> Result<Arc<dyn TableProvider>, TableProviderError> {
+        let _ = (view, source, source_name);
+        Err(TableProviderError::NotImplemented(
+            "this TableProviderBuilder does not support metric views".to_string(),
+        ))
+    }
 }

--- a/crates/datafusion/src/catalog/delta.rs
+++ b/crates/datafusion/src/catalog/delta.rs
@@ -186,4 +186,26 @@ impl TableProviderBuilder for DeltaTableProviderBuilder {
 
         self.provider_from_snapshot(snapshot, log_store).await
     }
+
+    #[cfg(feature = "metric-view")]
+    async fn build_metric_view(
+        &self,
+        view: &crate::metric_view::MetricView,
+        source: Arc<dyn TableProvider>,
+        source_name: &str,
+    ) -> Result<Arc<dyn TableProvider>, TableProviderError> {
+        use datafusion::datasource::provider_as_source;
+        use datafusion::logical_expr::LogicalPlanBuilder;
+
+        use crate::metric_view::MetricViewTableProvider;
+
+        // Build a scan over the resolved source provider as the view's input
+        // plan. The metric view's dimension/measure expressions are written
+        // against this relation's columns.
+        let source_plan =
+            LogicalPlanBuilder::scan(source_name, provider_as_source(source), None)?.build()?;
+
+        let provider = MetricViewTableProvider::try_new(&self.ctx.state(), view, source_plan)?;
+        Ok(Arc::new(provider))
+    }
 }

--- a/crates/datafusion/src/catalog/provider.rs
+++ b/crates/datafusion/src/catalog/provider.rs
@@ -190,7 +190,31 @@ impl AsyncSchemaProvider for UnityCatalogSchemaProvider {
             }
         };
 
-        // 2. Only Delta is supported for now.
+        // 2a. Metric views are resolved before the Delta-only check: they have
+        //     no storage location of their own, only a definition referencing a
+        //     source relation.
+        #[cfg(feature = "metric-view")]
+        if let Some(provider) = self.try_resolve_metric_view(&table).await? {
+            return Ok(Some(provider));
+        }
+
+        // 2. Otherwise resolve as a (Delta) base table.
+        let provider = self.build_base_table(&full_name, &table).await?;
+        Ok(Some(provider))
+    }
+}
+
+impl UnityCatalogSchemaProvider {
+    /// Resolve a base (non-view) Unity Catalog table to a [`TableProvider`].
+    ///
+    /// Vends credentials, registers the per-table object store, and delegates
+    /// provider construction to the host session's builder. Only Delta is
+    /// supported for now.
+    async fn build_base_table(
+        &self,
+        full_name: &str,
+        table: &unitycatalog_common::models::tables::v1::Table,
+    ) -> Result<Arc<dyn TableProvider>> {
         let format = DataSourceFormat::try_from(table.data_source_format)
             .unwrap_or(DataSourceFormat::Unspecified);
         if format != DataSourceFormat::Delta {
@@ -208,12 +232,12 @@ impl AsyncSchemaProvider for UnityCatalogSchemaProvider {
             plan_datafusion_err!("invalid storage location '{location}' for '{full_name}': {e}")
         })?;
 
-        // 3. Vend credentials and build the per-table object store, then route
-        //    it under the bucket's routing store so the engine can read it.
+        // Vend credentials and build the per-table object store, then route it
+        // under the bucket's routing store so the engine can read it.
         let uc_store = self
             .ctx
             .factory
-            .for_table(full_name.clone(), TableOperation::Read)
+            .for_table(full_name.to_string(), TableOperation::Read)
             .await
             .map_err(|e| {
                 plan_datafusion_err!("failed to vend credentials for '{full_name}': {e}")
@@ -223,8 +247,56 @@ impl AsyncSchemaProvider for UnityCatalogSchemaProvider {
         self.ctx
             .register_table_store(uc_store.url(), uc_store.root());
 
-        // 4. Delegate provider construction to the host session.
-        let provider = self.ctx.builder.build_delta(&location, &table).await?;
+        // Delegate provider construction to the host session.
+        self.ctx.builder.build_delta(&location, table).await
+    }
+
+    /// If `table` is a metric view, resolve it: parse the definition, resolve
+    /// the source relation through the same Unity Catalog path, and build a
+    /// metric-view provider. Returns `Ok(None)` for non-metric-view tables.
+    #[cfg(feature = "metric-view")]
+    async fn try_resolve_metric_view(
+        &self,
+        table: &unitycatalog_common::models::tables::v1::Table,
+    ) -> Result<Option<Arc<dyn TableProvider>>> {
+        let view = match crate::metric_view::detect::metric_view_of(table) {
+            Ok(Some(view)) => view,
+            Ok(None) => return Ok(None),
+            Err(e) => {
+                return Err(plan_datafusion_err!(
+                    "metric view '{}': {e}",
+                    table.full_name
+                ));
+            }
+        };
+
+        // Resolve the source relation (a three-part `catalog.schema.table` name).
+        let source_name = view.source.trim();
+        let parts: Vec<&str> = source_name.split('.').collect();
+        let [catalog, schema, table_name] = parts.as_slice() else {
+            return Err(DataFusionError::NotImplemented(format!(
+                "metric-view source '{source_name}' must be a three-part \
+                 catalog.schema.table name (inline SQL sources are not yet supported)"
+            )));
+        };
+
+        let source_table = self
+            .ctx
+            .factory
+            .unity_client()
+            .table(*catalog, *schema, *table_name)
+            .get()
+            .await
+            .map_err(|e| {
+                plan_datafusion_err!("metric-view source '{source_name}' not found: {e}")
+            })?;
+        let source_provider = self.build_base_table(source_name, &source_table).await?;
+
+        let provider = self
+            .ctx
+            .builder
+            .build_metric_view(&view, source_provider, source_name)
+            .await?;
         Ok(Some(provider))
     }
 }

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod catalog;
 #[cfg(feature = "delta")]
 pub mod managed;
+#[cfg(feature = "metric-view")]
+pub mod metric_view;
 pub mod storage;
 
 pub use self::storage::RoutingObjectStore;

--- a/crates/datafusion/src/metric_view/analyzer.rs
+++ b/crates/datafusion/src/metric_view/analyzer.rs
@@ -1,0 +1,223 @@
+//! The [`ResolveMetricView`] analyzer rule — Spark-style `MEASURE()` late
+//! binding for DataFusion.
+//!
+//! After SQL planning, a query against a metric view looks like one of:
+//!
+//! ```text
+//! # Form A: explicit aggregation over the view
+//! Aggregate group=[mv.order_date], aggr=[measure(mv.total_revenue)]
+//! └─ SubqueryAlias(mv)
+//!    └─ MetricViewPlaceholder
+//!       └─ <source>
+//!
+//! # Form B: a bare scan (SELECT * / SELECT order_date FROM mv)
+//! ... └─ SubqueryAlias(mv) └─ MetricViewPlaceholder └─ <source>
+//! ```
+//!
+//! This rule rewrites the placeholder into a concrete `Aggregate` over the
+//! source, **materializing only the dimensions grouped and the measures
+//! referenced via `MEASURE(...)`** — the late-binding property. For Form A, the
+//! enclosing aggregate drives selection: its group-by columns name the
+//! dimensions, its `measure(col)` calls name the measures. For Form B, with no
+//! enclosing aggregate, the full set of dimensions and measures is materialized.
+//!
+//! Mirrors Spark's `ResolveMetricView` (SPIP SPARK-54119).
+
+use std::sync::Arc;
+
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::common::{Column, Result, plan_err};
+use datafusion::logical_expr::expr::AggregateFunction;
+use datafusion::logical_expr::{Aggregate, Expr, LogicalPlan, LogicalPlanBuilder, SubqueryAlias};
+use datafusion::optimizer::AnalyzerRule;
+
+use super::measure::MEASURE_UDF_NAME;
+use super::placeholder::{MetricViewPlaceholder, NamedExpr};
+
+/// Analyzer rule that resolves metric-view placeholders and `MEASURE()` markers.
+#[derive(Debug, Default)]
+pub struct ResolveMetricView {}
+
+impl ResolveMetricView {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl AnalyzerRule for ResolveMetricView {
+    fn name(&self) -> &str {
+        "resolve_metric_view"
+    }
+
+    fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
+        // Top-down: handle an enclosing `Aggregate` over a placeholder (Form A)
+        // before its child placeholder is reached, so we can read the query's
+        // selected dimensions/measures off the aggregate. Any placeholder not
+        // consumed that way (Form B) is expanded to its full aggregate.
+        plan.transform_down(resolve_node).map(|t| t.data)
+    }
+}
+
+/// If `plan` is (or aliases) a [`MetricViewPlaceholder`], return it and the
+/// alias the inlining attached (if any).
+fn as_placeholder(plan: &LogicalPlan) -> Option<(&MetricViewPlaceholder, Option<&str>)> {
+    match plan {
+        LogicalPlan::Extension(ext) => ext
+            .node
+            .as_any()
+            .downcast_ref::<MetricViewPlaceholder>()
+            .map(|p| (p, None)),
+        LogicalPlan::SubqueryAlias(SubqueryAlias { input, alias, .. }) => {
+            if let LogicalPlan::Extension(ext) = input.as_ref() {
+                ext.node
+                    .as_any()
+                    .downcast_ref::<MetricViewPlaceholder>()
+                    .map(|p| (p, Some(alias.table())))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn resolve_node(node: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
+    // Form A: an Aggregate whose input is (an alias of) a placeholder.
+    if let LogicalPlan::Aggregate(agg) = &node
+        && let Some((placeholder, alias)) = as_placeholder(&agg.input)
+    {
+        let rewritten = resolve_aggregate_over_view(agg, placeholder)?;
+        // Re-wrap under the metric view's alias so the enclosing projection's
+        // qualified column references (e.g. `mv.order_date`) still resolve.
+        let rewritten = reapply_alias(rewritten, alias)?;
+        return Ok(Transformed::yes(rewritten));
+    }
+
+    // Form B: a bare placeholder (no enclosing aggregate consumed it). Expand to
+    // the full aggregate over all dimensions + all measures.
+    if let Some((placeholder, alias)) = as_placeholder(&node) {
+        let full = expand_full_aggregate(placeholder)?;
+        // Preserve the alias so parent column references (e.g. `mv.order_date`)
+        // still resolve.
+        return Ok(Transformed::yes(reapply_alias(full, alias)?));
+    }
+
+    Ok(Transformed::no(node))
+}
+
+/// Wrap `plan` in a [`SubqueryAlias`] for `alias` so a parent's qualified
+/// references (`alias.col`) resolve against the rewritten plan.
+fn reapply_alias(plan: LogicalPlan, alias: Option<&str>) -> Result<LogicalPlan> {
+    match alias {
+        Some(name) => Ok(LogicalPlan::SubqueryAlias(SubqueryAlias::try_new(
+            Arc::new(plan),
+            name.to_string(),
+        )?)),
+        None => Ok(plan),
+    }
+}
+
+/// Rewrite `agg` (an aggregate over the metric view) into an aggregate over the
+/// view's source, materializing only the referenced dimensions/measures.
+///
+/// Each rewritten expression is aliased to the *original* expression's output
+/// name, so the rewritten aggregate's schema matches what the enclosing
+/// projection already references — the substitution is invisible above the
+/// metric view.
+fn resolve_aggregate_over_view(
+    agg: &Aggregate,
+    placeholder: &MetricViewPlaceholder,
+) -> Result<LogicalPlan> {
+    // Group-by expressions must each reference a declared dimension by column
+    // name; substitute the dimension's source expression, preserving the
+    // original output name.
+    let mut group_expr = Vec::with_capacity(agg.group_expr.len());
+    for expr in &agg.group_expr {
+        let Some(col) = single_column(expr) else {
+            return plan_err!(
+                "metric-view GROUP BY must reference a dimension by name, found: {expr}"
+            );
+        };
+        let Some(dim) = placeholder.dimension(&col.name) else {
+            return plan_err!(
+                "'{}' is not a dimension of the metric view (group by a declared dimension)",
+                col.name
+            );
+        };
+        group_expr.push(dim.expr.clone().alias(expr.qualified_name().1));
+    }
+
+    // Aggregate expressions: substitute each MEASURE(measure_col) with the
+    // measure's real aggregate expression. Any non-MEASURE aggregate is rejected
+    // — measures are the only valid aggregations over a metric view.
+    let mut aggr_expr = Vec::with_capacity(agg.aggr_expr.len());
+    for expr in &agg.aggr_expr {
+        let resolved = resolve_measure_expr(expr, placeholder)?;
+        aggr_expr.push(resolved.alias(expr.qualified_name().1));
+    }
+
+    LogicalPlanBuilder::from(placeholder.source.as_ref().clone())
+        .aggregate(group_expr, aggr_expr)?
+        .build()
+}
+
+/// Resolve an aggregate expression wrapping `MEASURE(measure_col)` into the
+/// measure's real aggregate expression (unaliased — the caller aliases it to the
+/// original output name). Aliases on the input are unwrapped.
+fn resolve_measure_expr(expr: &Expr, placeholder: &MetricViewPlaceholder) -> Result<Expr> {
+    match expr {
+        Expr::Alias(alias) => resolve_measure_expr(&alias.expr, placeholder),
+        Expr::AggregateFunction(AggregateFunction { func, params })
+            if func.name() == MEASURE_UDF_NAME =>
+        {
+            let [arg] = params.args.as_slice() else {
+                return plan_err!("MEASURE() takes exactly one argument");
+            };
+            let Some(col) = single_column(arg) else {
+                return plan_err!(
+                    "MEASURE() argument must be a metric-view measure name, found: {arg}"
+                );
+            };
+            let Some(measure) = placeholder.measure(&col.name) else {
+                return plan_err!(
+                    "'{}' is not a measure of the metric view (wrap a declared measure in MEASURE())",
+                    col.name
+                );
+            };
+            Ok(measure.expr.clone())
+        }
+        other => plan_err!(
+            "only MEASURE(<measure>) aggregations are valid over a metric view, found: {other}"
+        ),
+    }
+}
+
+/// Expand a placeholder into the full aggregate over every dimension and
+/// measure (Form B: a bare scan with no enclosing aggregate).
+fn expand_full_aggregate(placeholder: &MetricViewPlaceholder) -> Result<LogicalPlan> {
+    let group_expr: Vec<Expr> = placeholder
+        .dimensions
+        .iter()
+        .map(named_to_aliased)
+        .collect();
+    let aggr_expr: Vec<Expr> = placeholder.measures.iter().map(named_to_aliased).collect();
+
+    LogicalPlanBuilder::from(placeholder.source.as_ref().clone())
+        .aggregate(group_expr, aggr_expr)?
+        .build()
+}
+
+fn named_to_aliased(ne: &NamedExpr) -> Expr {
+    ne.expr.clone().alias(&ne.name)
+}
+
+/// Extract the single [`Column`] a grouping/argument expression refers to, if it
+/// is a plain (optionally aliased) column reference.
+fn single_column(expr: &Expr) -> Option<Column> {
+    match expr {
+        Expr::Column(c) => Some(c.clone()),
+        Expr::Alias(a) => single_column(&a.expr),
+        _ => None,
+    }
+}

--- a/crates/datafusion/src/metric_view/detect.rs
+++ b/crates/datafusion/src/metric_view/detect.rs
@@ -1,0 +1,56 @@
+//! Detecting a metric view on a Unity Catalog [`Table`].
+//!
+//! Proto support for a dedicated `VIEW`/`METRIC_VIEW` table type and a
+//! `view_definition` field is deferred (those are commented out in
+//! `proto/.../tables/v1/models.proto`). Until then, a metric view is carried on
+//! a regular [`Table`] via two well-known properties:
+//!
+//! - [`METRIC_VIEW_TYPE_PROPERTY`] = [`METRIC_VIEW_TYPE_VALUE`] marks the table
+//!   as a metric view; and
+//! - [`METRIC_VIEW_DEFINITION_PROPERTY`] carries the YAML definition.
+//!
+//! When the proto gains a first-class metric-view type, [`metric_view_of`] is
+//! the single place to update.
+
+use unitycatalog_common::models::tables::v1::Table;
+
+use super::model::MetricView;
+
+/// Property key marking a table as a metric view.
+pub const METRIC_VIEW_TYPE_PROPERTY: &str = "unitycatalog.table_subtype";
+/// Value of [`METRIC_VIEW_TYPE_PROPERTY`] indicating a metric view.
+pub const METRIC_VIEW_TYPE_VALUE: &str = "METRIC_VIEW";
+/// Property key carrying the metric-view YAML definition.
+pub const METRIC_VIEW_DEFINITION_PROPERTY: &str = "unitycatalog.view_definition";
+
+/// If `table` is a metric view, parse and return its definition.
+///
+/// Returns `Ok(None)` for a non-metric-view table, `Err` if it is marked as a
+/// metric view but its YAML definition is missing or malformed.
+pub fn metric_view_of(table: &Table) -> Result<Option<MetricView>, MetricViewDetectError> {
+    let is_metric_view = table
+        .properties
+        .get(METRIC_VIEW_TYPE_PROPERTY)
+        .is_some_and(|v| v.eq_ignore_ascii_case(METRIC_VIEW_TYPE_VALUE));
+    if !is_metric_view {
+        return Ok(None);
+    }
+
+    let yaml = table
+        .properties
+        .get(METRIC_VIEW_DEFINITION_PROPERTY)
+        .ok_or(MetricViewDetectError::MissingDefinition)?;
+    let view = MetricView::from_yaml(yaml).map_err(MetricViewDetectError::Parse)?;
+    Ok(Some(view))
+}
+
+/// Failure detecting/parsing a metric view from a [`Table`].
+#[derive(Debug, thiserror::Error)]
+pub enum MetricViewDetectError {
+    #[error(
+        "table is marked as a metric view but has no '{METRIC_VIEW_DEFINITION_PROPERTY}' property"
+    )]
+    MissingDefinition,
+    #[error("invalid metric-view YAML: {0}")]
+    Parse(#[source] serde_yml::Error),
+}

--- a/crates/datafusion/src/metric_view/lower.rs
+++ b/crates/datafusion/src/metric_view/lower.rs
@@ -1,0 +1,85 @@
+//! Build a [`MetricViewPlaceholder`] from a [`MetricView`] definition.
+//!
+//! Parsing the metric-view YAML's dimension/measure/filter SQL strings into
+//! DataFusion [`Expr`]s happens here, against the source relation's schema. The
+//! result is the unresolved [`MetricViewPlaceholder`] node; the actual
+//! aggregation is deferred to [`super::analyzer::ResolveMetricView`] at query
+//! time (Spark-style `MEASURE()` late binding). See the module docs in
+//! [`super`].
+
+use std::sync::Arc;
+
+use datafusion::common::{DFSchema, Result, plan_err};
+use datafusion::execution::session_state::SessionState;
+use datafusion::logical_expr::{LogicalPlan, LogicalPlanBuilder};
+
+use super::model::MetricView;
+use super::placeholder::{MetricViewPlaceholder, NamedExpr};
+
+/// Lower `view` over its resolved `source` plan into a [`MetricViewPlaceholder`].
+///
+/// `state` supplies the SQL dialect and expression planner used to parse each
+/// dimension/measure/filter SQL string into an [`Expr`](datafusion::logical_expr::Expr)
+/// resolved against the source schema. The view's `filter`, if any, is applied
+/// beneath the placeholder so every query sees it.
+pub fn build_placeholder(
+    state: &SessionState,
+    view: &MetricView,
+    source: LogicalPlan,
+) -> Result<MetricViewPlaceholder> {
+    if view.dimensions.is_empty() && view.measures.is_empty() {
+        return plan_err!(
+            "metric view '{}' defines neither dimensions nor measures",
+            view.source
+        );
+    }
+    if !view.joins.is_empty() {
+        return plan_err!(
+            "metric-view joins are not yet supported (source '{}' declares {} join(s))",
+            view.source,
+            view.joins.len()
+        );
+    }
+
+    // The view filter applies beneath the aggregation, exactly as Spark places
+    // the view predicate below the grouping. Fold it into the source plan so it
+    // travels with the placeholder's input.
+    let source = match &view.filter {
+        Some(filter) => {
+            let predicate = state.create_logical_expr(filter, source.schema())?;
+            LogicalPlanBuilder::from(source)
+                .filter(predicate)?
+                .build()?
+        }
+        None => source,
+    };
+    let source_schema: &DFSchema = source.schema();
+
+    let dimensions = view
+        .dimensions
+        .iter()
+        .map(|d| {
+            state
+                .create_logical_expr(&d.expr, source_schema)
+                .map(|expr| NamedExpr {
+                    name: d.name.clone(),
+                    expr,
+                })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let measures = view
+        .measures
+        .iter()
+        .map(|m| {
+            state
+                .create_logical_expr(&m.expr, source_schema)
+                .map(|expr| NamedExpr {
+                    name: m.name.clone(),
+                    expr,
+                })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    MetricViewPlaceholder::try_new(Arc::new(source), dimensions, measures)
+}

--- a/crates/datafusion/src/metric_view/measure.rs
+++ b/crates/datafusion/src/metric_view/measure.rs
@@ -1,0 +1,99 @@
+//! The `MEASURE()` marker aggregate function.
+//!
+//! A query against a metric view references a measure by wrapping the measure's
+//! name in `MEASURE(...)`, e.g.
+//!
+//! ```sql
+//! SELECT order_date, MEASURE(total_revenue)
+//! FROM mv
+//! GROUP BY order_date
+//! ```
+//!
+//! `MEASURE` is registered as an aggregate UDF purely so that such a query
+//! *plans* — the SQL planner accepts it in the select list alongside a
+//! `GROUP BY`, and `total_revenue` resolves against the metric view's declared
+//! schema. It is a **marker only**: [`ResolveMetricView`] rewrites every
+//! `MEASURE(measure_col)` into the measure's real aggregate expression before
+//! execution, so the accumulator below is never actually run. This mirrors
+//! Spark's `Measure` placeholder resolved by `ResolveMetricView`.
+//!
+//! [`ResolveMetricView`]: super::analyzer::ResolveMetricView
+
+use std::any::Any;
+use std::sync::{Arc, LazyLock};
+
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::{exec_err, plan_err};
+use datafusion::error::Result;
+use datafusion::logical_expr::function::{AccumulatorArgs, StateFieldsArgs};
+use datafusion::logical_expr::{
+    Accumulator, AggregateUDF, AggregateUDFImpl, Signature, Volatility,
+};
+
+/// Name of the marker aggregate function, as written in queries.
+pub const MEASURE_UDF_NAME: &str = "measure";
+
+/// The `MEASURE()` marker aggregate UDF. See module docs.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct MeasureMarkerUdf {
+    signature: Signature,
+}
+
+impl Default for MeasureMarkerUdf {
+    fn default() -> Self {
+        Self {
+            // One argument of any type, immutable. The arg is a reference to the
+            // metric view's measure column; its concrete type is whatever the
+            // measure declares.
+            signature: Signature::any(1, Volatility::Immutable),
+        }
+    }
+}
+
+impl AggregateUDFImpl for MeasureMarkerUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        MEASURE_UDF_NAME
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    /// Identity: `MEASURE(col)` types as `col` so the wrapping expression
+    /// type-checks against the metric view's declared measure type.
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        match arg_types {
+            [ty] => Ok(ty.clone()),
+            _ => plan_err!("MEASURE() takes exactly one argument"),
+        }
+    }
+
+    /// Never invoked: `ResolveMetricView` rewrites `MEASURE(...)` away before the
+    /// plan reaches execution. Reaching here means the analyzer rule was not
+    /// registered or did not fire.
+    fn accumulator(&self, _args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
+        exec_err!(
+            "MEASURE() is a metric-view marker and must be resolved by the \
+             ResolveMetricView analyzer rule before execution; it cannot be \
+             evaluated directly"
+        )
+    }
+
+    fn state_fields(
+        &self,
+        _args: StateFieldsArgs,
+    ) -> Result<Vec<datafusion::arrow::datatypes::FieldRef>> {
+        exec_err!("MEASURE() has no execution state; it must be resolved before execution")
+    }
+}
+
+/// The shared [`AggregateUDF`] handle for `MEASURE()`.
+pub fn measure_udf() -> Arc<AggregateUDF> {
+    static UDF: LazyLock<Arc<AggregateUDF>> =
+        LazyLock::new(|| Arc::new(AggregateUDF::from(MeasureMarkerUdf::default())));
+    UDF.clone()
+}

--- a/crates/datafusion/src/metric_view/mod.rs
+++ b/crates/datafusion/src/metric_view/mod.rs
@@ -1,0 +1,60 @@
+//! Unity Catalog metric views as DataFusion plans, with Spark-style `MEASURE()`
+//! late binding.
+//!
+//! A *metric view* is a semantic layer over a base relation: it names
+//! `dimensions` (group-by expressions) and `measures` (aggregate expressions) as
+//! SQL strings in a YAML body ([`model`]). Unity Catalog returns this YAML as a
+//! table's definition when the table is a metric view.
+//!
+//! # How a query against a metric view resolves
+//!
+//! Unlike a plain view, a metric view does not pre-aggregate. Only the
+//! dimensions a query groups by and the measures it references (via the
+//! `MEASURE(...)` marker) are materialized — *late binding*, matching Apache
+//! Spark (SPIP SPARK-54119):
+//!
+//! ```sql
+//! SELECT order_date, MEASURE(total_revenue)
+//! FROM   main.sales.orders_metrics
+//! GROUP BY order_date
+//! ```
+//!
+//! The pipeline:
+//!
+//! 1. [`MetricViewTableProvider`] (built by [`build_placeholder`] +
+//!    [`MetricViewTableProvider::try_new`]) exposes the view's full
+//!    dimension+measure schema and returns a [`MetricViewPlaceholder`] from
+//!    `get_logical_plan`. The SQL planner inlines it in place of the scan.
+//! 2. [`measure`] registers `MEASURE()` as a marker aggregate UDF so the query
+//!    plans.
+//! 3. [`ResolveMetricView`] (an analyzer rule) rewrites the placeholder + the
+//!    enclosing aggregate into a concrete `Aggregate` over the source,
+//!    substituting each `MEASURE(m)` with the measure's real aggregate
+//!    expression and materializing only the referenced dimensions/measures.
+//! 4. [`session`] wires (2) and (3) onto a [`SessionContext`] in the correct
+//!    order (the rule must precede type coercion).
+//!
+//! Use [`metric_view_context`] to get a session with everything registered.
+//!
+//! [`SessionContext`]: datafusion::prelude::SessionContext
+
+pub mod analyzer;
+pub mod detect;
+pub mod lower;
+pub mod measure;
+pub mod model;
+pub mod placeholder;
+pub mod provider;
+pub mod session;
+
+#[cfg(test)]
+mod tests;
+
+pub use analyzer::ResolveMetricView;
+pub use detect::metric_view_of;
+pub use lower::build_placeholder;
+pub use measure::{MEASURE_UDF_NAME, measure_udf};
+pub use model::{Dimension, Join, Measure, MetricView};
+pub use placeholder::{MetricViewPlaceholder, NamedExpr};
+pub use provider::MetricViewTableProvider;
+pub use session::{metric_view_context, metric_view_session_state};

--- a/crates/datafusion/src/metric_view/model.rs
+++ b/crates/datafusion/src/metric_view/model.rs
@@ -1,0 +1,91 @@
+//! Deserializable model of the Unity Catalog metric-view YAML (the `1.1`
+//! user-facing surface).
+//!
+//! A metric view is a semantic layer over a base relation: it names
+//! [`Dimension`]s (group-by expressions) and [`Measure`]s (aggregate
+//! expressions) as SQL strings. Unity Catalog returns this YAML as a table's
+//! definition when the table is a metric view.
+//!
+//! Reference: <https://docs.databricks.com/aws/en/business-semantics/metric-views/yaml-reference>
+//!
+//! This models the field surface needed to lower a metric view into a DataFusion
+//! plan; fields not yet supported by the lowering ([`Join`], `window`,
+//! `materialization`) are intentionally omitted or captured loosely. See
+//! [`crate::metric_view::lower`] for what the spike currently handles.
+
+use serde::Deserialize;
+
+/// A Unity Catalog metric view, deserialized from its YAML definition.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MetricView {
+    /// Spec version, e.g. `"1.1"`. Carried through for diagnostics; the spike
+    /// does not branch on it.
+    #[serde(default)]
+    pub version: Option<String>,
+
+    /// The base relation: a three-part `catalog.schema.table` name, or an inline
+    /// SQL query. The spike treats this as an opaque relation name supplied by
+    /// the caller; inline-SQL sources are a documented follow-up.
+    pub source: String,
+
+    /// Optional SQL boolean predicate applied to every query against the view.
+    #[serde(default)]
+    pub filter: Option<String>,
+
+    /// Star/snowflake joins. Parsed but not yet lowered (documented follow-up).
+    #[serde(default)]
+    pub joins: Vec<Join>,
+
+    /// Group-by expressions. The UC docs use `fields` as the canonical synonym
+    /// for `dimensions`; accept either.
+    #[serde(default, alias = "fields")]
+    pub dimensions: Vec<Dimension>,
+
+    /// Aggregate expressions.
+    #[serde(default)]
+    pub measures: Vec<Measure>,
+}
+
+/// A group-by expression exposed by the metric view.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Dimension {
+    /// Output column name for the dimension.
+    pub name: String,
+    /// SQL expression evaluated against the source relation.
+    pub expr: String,
+}
+
+/// An aggregate expression exposed by the metric view.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Measure {
+    /// Output column name for the measure.
+    pub name: String,
+    /// SQL aggregate expression, e.g. `SUM(o_totalprice)`.
+    pub expr: String,
+}
+
+/// A join in a star/snowflake metric view. Captured for completeness; the spike
+/// does not lower joins yet.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Join {
+    /// Alias for the joined relation.
+    pub name: String,
+    /// Joined relation: three-part name or inline SQL.
+    pub source: String,
+    /// SQL join condition (`on`). Mutually exclusive with `using` in practice.
+    #[serde(default)]
+    pub on: Option<String>,
+    /// Columns to join on by name, as an alternative to `on`.
+    #[serde(default)]
+    pub using: Vec<String>,
+    /// `many_to_one` (default) or `one_to_many`.
+    #[serde(default)]
+    pub cardinality: Option<String>,
+}
+
+impl MetricView {
+    /// Parse a metric view from its YAML definition.
+    pub fn from_yaml(yaml: &str) -> Result<Self, serde_yml::Error> {
+        serde_yml::from_str(yaml)
+    }
+}

--- a/crates/datafusion/src/metric_view/placeholder.rs
+++ b/crates/datafusion/src/metric_view/placeholder.rs
@@ -1,0 +1,218 @@
+//! The [`MetricViewPlaceholder`] logical plan node.
+//!
+//! A metric view does **not** pre-aggregate. Instead, its [`TableProvider`] (see
+//! [`super::provider`]) returns this placeholder as its logical plan, so that a
+//! query against the view inlines into:
+//!
+//! ```text
+//! <enclosing Projection / Aggregate referencing dims + MEASURE(measures)>
+//! └─ SubqueryAlias(mv)
+//!    └─ MetricViewPlaceholder            <- this node
+//!       └─ <source plan>
+//! ```
+//!
+//! The placeholder's output schema is the metric view's full relational surface
+//! — every dimension and every measure — so name resolution and `MEASURE(col)`
+//! type-checking succeed during analysis. It carries the *parsed* dimension and
+//! measure expressions (resolved against the source schema) but does **not**
+//! aggregate. [`super::analyzer::ResolveMetricView`] rewrites this node, plus the
+//! enclosing aggregate, into the concrete `Aggregate` over the source —
+//! materializing only the dimensions/measures the query actually references
+//! (Spark-style late binding).
+//!
+//! [`TableProvider`]: datafusion::catalog::TableProvider
+
+use std::cmp::Ordering;
+use std::collections::HashSet;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use datafusion::common::{DFSchema, DFSchemaRef, Result};
+use datafusion::logical_expr::{Expr, ExprSchemable, LogicalPlan, UserDefinedLogicalNodeCore};
+
+/// Name used in `EXPLAIN` output and node identification.
+pub const METRIC_VIEW_NODE_NAME: &str = "MetricViewPlaceholder";
+
+/// A named, parsed metric-view expression (a dimension or a measure).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NamedExpr {
+    /// The declared output name (the dimension/measure `name`).
+    pub name: String,
+    /// The expression parsed against the source schema. For a dimension this is
+    /// a scalar expression; for a measure it is an aggregate expression.
+    pub expr: Expr,
+}
+
+/// Unresolved metric-view node: source + declared dimensions/measures, with the
+/// view's full relational schema as output. See module docs.
+#[derive(Debug, Clone)]
+pub struct MetricViewPlaceholder {
+    /// The resolved source relation the view aggregates over.
+    pub source: Arc<LogicalPlan>,
+    /// Group-by expressions, in declaration order.
+    pub dimensions: Vec<NamedExpr>,
+    /// Aggregate expressions, in declaration order.
+    pub measures: Vec<NamedExpr>,
+    /// Output schema: one field per dimension then per measure.
+    schema: DFSchemaRef,
+}
+
+impl MetricViewPlaceholder {
+    /// Build the placeholder, deriving the output schema from the declared
+    /// dimension/measure expressions evaluated against the `source` schema.
+    pub fn try_new(
+        source: Arc<LogicalPlan>,
+        dimensions: Vec<NamedExpr>,
+        measures: Vec<NamedExpr>,
+    ) -> Result<Self> {
+        let source_schema = source.schema();
+        let mut fields = Vec::with_capacity(dimensions.len() + measures.len());
+        for ne in dimensions.iter().chain(measures.iter()) {
+            // Derive the field from the expression (type + nullability) and
+            // rename it to the declared dimension/measure name.
+            let (_, field) = ne.expr.to_field(source_schema)?;
+            let field = field.as_ref().clone().with_name(&ne.name);
+            fields.push((None, Arc::new(field)));
+        }
+        let schema = Arc::new(DFSchema::new_with_metadata(fields, Default::default())?);
+        Ok(Self {
+            source,
+            dimensions,
+            measures,
+            schema,
+        })
+    }
+
+    /// Look up a measure by name (used by the analyzer to resolve `MEASURE`).
+    pub fn measure(&self, name: &str) -> Option<&NamedExpr> {
+        self.measures.iter().find(|m| m.name == name)
+    }
+
+    /// Look up a dimension by name.
+    pub fn dimension(&self, name: &str) -> Option<&NamedExpr> {
+        self.dimensions.iter().find(|d| d.name == name)
+    }
+}
+
+impl UserDefinedLogicalNodeCore for MetricViewPlaceholder {
+    fn name(&self) -> &str {
+        METRIC_VIEW_NODE_NAME
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![self.source.as_ref()]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    /// The dimension and measure expressions are carried as this node's
+    /// expressions so the framework can rewrite column references inside them
+    /// when the source schema changes during optimization.
+    fn expressions(&self) -> Vec<Expr> {
+        self.dimensions
+            .iter()
+            .chain(self.measures.iter())
+            .map(|ne| ne.expr.clone())
+            .collect()
+    }
+
+    /// Never push predicates beneath the placeholder: it represents an
+    /// aggregation boundary that the analyzer has not yet materialized.
+    fn prevent_predicate_push_down_columns(&self) -> HashSet<String> {
+        self.schema
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect()
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let dims: Vec<&str> = self.dimensions.iter().map(|d| d.name.as_str()).collect();
+        let measures: Vec<&str> = self.measures.iter().map(|m| m.name.as_str()).collect();
+        write!(
+            f,
+            "{METRIC_VIEW_NODE_NAME}: dimensions=[{}], measures=[{}]",
+            dims.join(", "),
+            measures.join(", ")
+        )
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        exprs: Vec<Expr>,
+        mut inputs: Vec<LogicalPlan>,
+    ) -> Result<Self> {
+        let source = Arc::new(inputs.pop().ok_or_else(|| {
+            datafusion::common::DataFusionError::Internal(
+                "MetricViewPlaceholder requires exactly one input".into(),
+            )
+        })?);
+
+        // `exprs` are dimensions followed by measures, in the same order as
+        // `expressions()` returned them; re-pair them with their names.
+        let n_dims = self.dimensions.len();
+        let dimensions = self
+            .dimensions
+            .iter()
+            .zip(exprs.iter().take(n_dims))
+            .map(|(ne, expr)| NamedExpr {
+                name: ne.name.clone(),
+                expr: expr.clone(),
+            })
+            .collect();
+        let measures = self
+            .measures
+            .iter()
+            .zip(exprs.iter().skip(n_dims))
+            .map(|(ne, expr)| NamedExpr {
+                name: ne.name.clone(),
+                expr: expr.clone(),
+            })
+            .collect();
+
+        Self::try_new(source, dimensions, measures)
+    }
+}
+
+// Manual Eq/Ord/Hash: `UserDefinedLogicalNodeCore` requires them, and the
+// derived `DFSchemaRef` does not implement `PartialOrd`/`Hash` usefully. Two
+// placeholders are equal when their source, dimensions, and measures match;
+// the schema is derived from those, so it need not participate.
+impl PartialEq for MetricViewPlaceholder {
+    fn eq(&self, other: &Self) -> bool {
+        self.source == other.source
+            && self.dimensions == other.dimensions
+            && self.measures == other.measures
+    }
+}
+
+impl Eq for MetricViewPlaceholder {}
+
+impl PartialOrd for MetricViewPlaceholder {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        // Order by dimensions then measures; sufficient for the framework's
+        // deterministic plan comparisons.
+        match self.dimensions.partial_cmp(&other.dimensions) {
+            Some(Ordering::Equal) => self.measures.partial_cmp(&other.measures),
+            ord => ord,
+        }
+    }
+}
+
+impl Hash for MetricViewPlaceholder {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.source.hash(state);
+        self.dimensions.hash(state);
+        self.measures.hash(state);
+    }
+}
+
+// `NamedExpr` needs `PartialOrd` for the node's `PartialOrd`.
+impl PartialOrd for NamedExpr {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.name.partial_cmp(&other.name)
+    }
+}

--- a/crates/datafusion/src/metric_view/provider.rs
+++ b/crates/datafusion/src/metric_view/provider.rs
@@ -1,0 +1,95 @@
+//! [`MetricViewTableProvider`]: a DataFusion table provider for a metric view.
+//!
+//! The provider exposes the metric view's full relational schema (every
+//! dimension and measure) and returns a [`MetricViewPlaceholder`] from
+//! [`TableProvider::get_logical_plan`]. The SQL planner inlines that placeholder
+//! in place of the table scan, and [`super::analyzer::ResolveMetricView`] later
+//! rewrites it into a concrete aggregation. Because resolution happens during
+//! analysis, [`TableProvider::scan`] is never reached for a metric view; it
+//! errors if somehow called.
+
+use std::any::Any;
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::catalog::{Session, TableProvider};
+use datafusion::common::not_impl_err;
+use datafusion::error::Result;
+use datafusion::execution::session_state::SessionState;
+use datafusion::logical_expr::{Expr, LogicalPlan, TableType};
+use datafusion::physical_plan::ExecutionPlan;
+
+use super::lower::build_placeholder;
+use super::model::MetricView;
+use super::placeholder::MetricViewPlaceholder;
+
+/// A [`TableProvider`] backing a Unity Catalog metric view.
+#[derive(Debug)]
+pub struct MetricViewTableProvider {
+    /// The placeholder logical node, wrapped as a [`LogicalPlan::Extension`].
+    plan: LogicalPlan,
+    /// The view's relational schema (all dimensions + all measures).
+    schema: SchemaRef,
+}
+
+impl MetricViewTableProvider {
+    /// Build a provider from a parsed metric view and its resolved source plan.
+    ///
+    /// `state` supplies the SQL expression planner used to parse the view's
+    /// dimension/measure/filter strings against the `source` schema.
+    pub fn try_new(state: &SessionState, view: &MetricView, source: LogicalPlan) -> Result<Self> {
+        let placeholder = build_placeholder(state, view, source)?;
+        Self::from_placeholder(placeholder)
+    }
+
+    /// Build a provider directly from an already-constructed placeholder.
+    pub fn from_placeholder(placeholder: MetricViewPlaceholder) -> Result<Self> {
+        use datafusion::logical_expr::Extension;
+        let schema = Arc::clone(
+            datafusion::logical_expr::UserDefinedLogicalNodeCore::schema(&placeholder).inner(),
+        );
+        let plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(placeholder),
+        });
+        Ok(Self { plan, schema })
+    }
+}
+
+#[async_trait::async_trait]
+impl TableProvider for MetricViewTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::View
+    }
+
+    /// Hand the planner the placeholder logical plan so it inlines the metric
+    /// view in place of a table scan. [`super::analyzer::ResolveMetricView`]
+    /// then resolves it.
+    fn get_logical_plan(&self) -> Option<Cow<'_, LogicalPlan>> {
+        Some(Cow::Borrowed(&self.plan))
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        _projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // The planner inlines `get_logical_plan` instead of scanning, and the
+        // analyzer rewrites the placeholder before execution. Reaching here
+        // means the placeholder survived planning unresolved.
+        not_impl_err!(
+            "metric view was not resolved before execution; ensure the \
+             ResolveMetricView analyzer rule is registered on the SessionContext"
+        )
+    }
+}

--- a/crates/datafusion/src/metric_view/session.rs
+++ b/crates/datafusion/src/metric_view/session.rs
@@ -1,0 +1,54 @@
+//! Registering metric-view support on a DataFusion session.
+//!
+//! Two things must be installed for metric views to resolve:
+//!
+//! 1. the [`MEASURE()`](super::measure) marker aggregate UDF, so queries that
+//!    reference measures plan; and
+//! 2. the [`ResolveMetricView`] analyzer rule, which must run **before**
+//!    `TypeCoercion` — after the rule rewrites `MEASURE(...)` into real
+//!    aggregate expressions, those expressions still need coercion.
+//!
+//! Since `SessionState::add_analyzer_rule` appends (running after type
+//! coercion), this module rebuilds the analyzer rule list with
+//! [`ResolveMetricView`] prepended.
+
+use std::sync::Arc;
+
+use datafusion::execution::registry::FunctionRegistry;
+use datafusion::execution::session_state::{SessionState, SessionStateBuilder};
+use datafusion::optimizer::AnalyzerRule;
+use datafusion::optimizer::analyzer::Analyzer;
+use datafusion::prelude::SessionContext;
+
+use super::analyzer::ResolveMetricView;
+use super::measure::measure_udf;
+
+/// Return the analyzer rules for metric-view support: [`ResolveMetricView`]
+/// prepended to DataFusion's default rules so it runs before type coercion.
+fn metric_view_analyzer_rules() -> Vec<Arc<dyn AnalyzerRule + Send + Sync>> {
+    let mut rules: Vec<Arc<dyn AnalyzerRule + Send + Sync>> =
+        vec![Arc::new(ResolveMetricView::new())];
+    rules.extend(Analyzer::new().rules);
+    rules
+}
+
+/// Build a [`SessionState`] with metric-view support registered: the `MEASURE()`
+/// UDF and the [`ResolveMetricView`] analyzer rule (ordered before type
+/// coercion).
+pub fn metric_view_session_state() -> SessionState {
+    let mut state = SessionStateBuilder::new()
+        .with_default_features()
+        .with_analyzer_rules(metric_view_analyzer_rules())
+        .build();
+    // Registering on the built state preserves the built-in aggregates that
+    // `with_aggregate_functions` would otherwise replace.
+    state
+        .register_udaf(measure_udf())
+        .expect("register MEASURE() UDF");
+    state
+}
+
+/// Build a [`SessionContext`] with metric-view support registered.
+pub fn metric_view_context() -> SessionContext {
+    SessionContext::new_with_state(metric_view_session_state())
+}

--- a/crates/datafusion/src/metric_view/tests.rs
+++ b/crates/datafusion/src/metric_view/tests.rs
@@ -1,0 +1,233 @@
+//! End-to-end tests for metric-view late binding: register a metric view as a
+//! table, query it through `MEASURE()`, and assert both the resolved plan shape
+//! and the executed result.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Date32Array, Float64Array, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::assert_batches_sorted_eq;
+use datafusion::datasource::MemTable;
+use datafusion::prelude::SessionContext;
+
+use super::model::MetricView;
+use super::provider::MetricViewTableProvider;
+use super::session::metric_view_context;
+
+const ORDERS_METRICS_YAML: &str = r#"
+version: "1.1"
+source: main.sales.orders
+dimensions:
+  - name: order_date
+    expr: o_orderdate
+  - name: status
+    expr: o_orderstatus
+measures:
+  - name: order_count
+    expr: COUNT(1)
+  - name: total_revenue
+    expr: SUM(o_totalprice)
+  - name: open_revenue
+    expr: SUM(o_totalprice) FILTER (WHERE o_orderstatus = 'O')
+"#;
+
+/// Register an in-memory `orders` source and a metric view `orders_metrics` over
+/// it on a metric-view-enabled context.
+async fn ctx_with_metric_view(yaml: &str) -> SessionContext {
+    let ctx = metric_view_context();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("o_orderdate", DataType::Date32, false),
+        Field::new("o_orderstatus", DataType::Utf8, false),
+        Field::new("o_totalprice", DataType::Float64, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            // 2022-01-08, 2022-01-08, 2022-01-09, 2022-01-09
+            Arc::new(Date32Array::from(vec![19_000, 19_000, 19_001, 19_001])),
+            Arc::new(StringArray::from(vec!["O", "F", "O", "O"])),
+            Arc::new(Float64Array::from(vec![100.0, 50.0, 200.0, 75.0])),
+        ],
+    )
+    .unwrap();
+    let source_table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+    ctx.register_table("orders", Arc::new(source_table))
+        .unwrap();
+
+    let view = MetricView::from_yaml(yaml).unwrap();
+    let source = ctx.table("orders").await.unwrap().into_unoptimized_plan();
+    let provider = MetricViewTableProvider::try_new(&ctx.state(), &view, source).unwrap();
+    ctx.register_table("orders_metrics", Arc::new(provider))
+        .unwrap();
+    ctx
+}
+
+#[tokio::test]
+async fn late_binds_only_referenced_measure() {
+    let ctx = ctx_with_metric_view(ORDERS_METRICS_YAML).await;
+
+    // Query references exactly one measure and one dimension.
+    const QUERY: &str =
+        "SELECT order_date, MEASURE(total_revenue) AS rev FROM orders_metrics GROUP BY order_date";
+
+    // The resolved plan must aggregate ONLY total_revenue, not the other
+    // measures — this is the late-binding property. `into_optimized_plan` runs
+    // the analyzer (and our ResolveMetricView rule) before the optimizer.
+    let plan = ctx.sql(QUERY).await.unwrap().into_optimized_plan().unwrap();
+    let rendered = format!("{}", plan.display_indent());
+    assert!(
+        rendered.contains("sum(orders.o_totalprice)"),
+        "expected the referenced measure in the plan:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("count(Int64(1))"),
+        "order_count was not referenced and must not be materialized:\n{rendered}"
+    );
+    // The MEASURE() aggregate call must be resolved away into a real aggregate.
+    // (The original column *label* `measure(...)` may survive as an alias string;
+    // what matters is there is no MEASURE aggregate function in the plan.)
+    assert!(
+        !rendered.contains("aggr=[[measure("),
+        "MEASURE() aggregate call should be resolved away:\n{rendered}"
+    );
+
+    let batches = ctx.sql(QUERY).await.unwrap().collect().await.unwrap();
+    assert_batches_sorted_eq!(
+        [
+            "+------------+-------+",
+            "| order_date | rev   |",
+            "+------------+-------+",
+            "| 2022-01-08 | 150.0 |",
+            "| 2022-01-09 | 275.0 |",
+            "+------------+-------+",
+        ],
+        &batches
+    );
+}
+
+#[tokio::test]
+async fn multiple_measures_and_dimensions() {
+    let ctx = ctx_with_metric_view(ORDERS_METRICS_YAML).await;
+
+    let batches = ctx
+        .sql(
+            "SELECT status, MEASURE(order_count) AS n, MEASURE(open_revenue) AS open \
+             FROM orders_metrics GROUP BY status",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_batches_sorted_eq!(
+        [
+            "+--------+---+-------+",
+            "| status | n | open  |",
+            "+--------+---+-------+",
+            "| F      | 1 |       |",
+            "| O      | 3 | 375.0 |",
+            "+--------+---+-------+",
+        ],
+        &batches
+    );
+}
+
+#[tokio::test]
+async fn filter_on_resolved_measure_works() {
+    let ctx = ctx_with_metric_view(ORDERS_METRICS_YAML).await;
+
+    // A HAVING-style outer filter over the resolved aggregate.
+    let batches = ctx
+        .sql(
+            "SELECT order_date, MEASURE(total_revenue) AS rev \
+             FROM orders_metrics GROUP BY order_date HAVING MEASURE(total_revenue) > 200",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_batches_sorted_eq!(
+        [
+            "+------------+-------+",
+            "| order_date | rev   |",
+            "+------------+-------+",
+            "| 2022-01-09 | 275.0 |",
+            "+------------+-------+",
+        ],
+        &batches
+    );
+}
+
+#[tokio::test]
+async fn view_filter_applies_to_every_query() {
+    // The view's own filter restricts to fulfilled orders.
+    let yaml = r#"
+version: "1.1"
+source: main.sales.orders
+filter: o_orderstatus = 'F'
+dimensions:
+  - name: status
+    expr: o_orderstatus
+measures:
+  - name: revenue
+    expr: SUM(o_totalprice)
+"#;
+    let ctx = ctx_with_metric_view(yaml).await;
+
+    let batches = ctx
+        .sql("SELECT status, MEASURE(revenue) AS r FROM orders_metrics GROUP BY status")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_batches_sorted_eq!(
+        [
+            "+--------+------+",
+            "| status | r    |",
+            "+--------+------+",
+            "| F      | 50.0 |",
+            "+--------+------+",
+        ],
+        &batches
+    );
+}
+
+#[tokio::test]
+async fn bare_scan_materializes_full_aggregate() {
+    // A bare scan with no enclosing aggregate (Form B) materializes every
+    // dimension and measure — useful for `SELECT *`-style introspection. A
+    // projection over it picks columns from the fully-grouped result.
+    //
+    // NOTE: Spark *rejects* referencing a measure column outside MEASURE().
+    // Enforcing that strict rule is a documented follow-up; today the bare form
+    // is defined as "group by all dimensions, expose all measures".
+    let ctx = ctx_with_metric_view(ORDERS_METRICS_YAML).await;
+
+    let batches = ctx
+        .sql("SELECT order_date, status, total_revenue FROM orders_metrics")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_batches_sorted_eq!(
+        [
+            "+------------+--------+---------------+",
+            "| order_date | status | total_revenue |",
+            "+------------+--------+---------------+",
+            "| 2022-01-08 | F      | 50.0          |",
+            "| 2022-01-08 | O      | 100.0         |",
+            "| 2022-01-09 | O      | 275.0         |",
+            "+------------+--------+---------------+",
+        ],
+        &batches
+    );
+}


### PR DESCRIPTION
## Summary

Resolve Unity Catalog **metric views** into DataFusion plans, with Spark-style `MEASURE()` late binding (SPIP [SPARK-54119](https://issues.apache.org/jira/browse/SPARK-54119)).

A metric view is a semantic layer over a base relation — `dimensions` (group-by expressions) and `measures` (aggregate expressions) defined as YAML. Unlike a plain view, it is not pre-aggregated: only the dimensions a query groups by and the measures it references via `MEASURE(...)` are materialized.

```sql
SELECT order_date, MEASURE(total_revenue) AS revenue
FROM   main.sales.orders_metrics
GROUP BY order_date
```

resolves to (note: only `sum` is materialized — other measures never enter the plan):

```
Projection: order_date, sum(orders.o_totalprice) AS revenue
  SubqueryAlias: orders_metrics
    Aggregate: groupBy=[[orders.o_orderdate AS order_date]], aggr=[[sum(orders.o_totalprice) ...]]
      Filter: orders.o_orderdate >= ...
        TableScan: orders projection=[o_orderdate, o_totalprice]
```

All in the `datafusion` crate, behind a new additive `metric-view` feature.

## What's included

- **`measure.rs`** — `MEASURE()` as a marker aggregate UDF (identity return type) so measure queries plan with a `GROUP BY`. The analyzer rewrites it away before execution.
- **`placeholder.rs`** — `MetricViewPlaceholder`, a `UserDefinedLogicalNode` carrying the source plan + parsed dimension/measure exprs, exposing the view's full dimension+measure schema so name resolution and `MEASURE()` type-checking succeed during analysis.
- **`provider.rs`** — `MetricViewTableProvider` returns the placeholder from `get_logical_plan`, so the planner inlines it in place of the scan (DataFusion's eager `ViewTable` cannot express late binding).
- **`analyzer.rs`** — `ResolveMetricView` analyzer rule rewrites the placeholder + enclosing aggregate into a concrete `Aggregate` over the source, substituting `MEASURE(m)` with the measure's real aggregate expression and preserving original output names.
- **`session.rs`** — `metric_view_context()` registers the UDF and orders the rule before type coercion.
- **`detect.rs`** — detect a metric view via table properties (proto `TableType::VIEW` migration deferred — see #196).
- **Catalog wiring** — `UnityCatalogSchemaProvider` resolves a metric view before the Delta-only check, recursively resolving the source table (Delta resolution refactored into a reusable `build_base_table`) and delegating to a new `TableProviderBuilder::build_metric_view` seam on `DeltaTableProviderBuilder`.

## Test plan

- [x] `cargo test -p datafusion-unitycatalog --features metric-view` — 9 lib tests: late-binding plan shape, executed results, view filters, HAVING, multi-measure, bare scan
- [x] `cargo run -p datafusion-unitycatalog --features metric-view --example metric_view` — runs end-to-end
- [x] `cargo clippy` clean on new code; builds under `metric-view`, `delta`, and `delta,metric-view`

## Follow-ups

Deferred work tracked under #191:
- #192 — reject bare measure references outside `MEASURE()`
- #193 — joins (star/snowflake)
- #194 — window / semi-additive measures
- #195 — inline-SQL source
- #196 — first-class proto `TableType::VIEW` + `view_definition`

AI-assisted by Isaac
