### PR TITLE
feat(datafusion): add UC DDL statements + planner (sql module)

### DIFF
--- a/crates/datafusion/Cargo.toml
+++ b/crates/datafusion/Cargo.toml
@@ -27,14 +27,18 @@ deltalake-core = { workspace = true, optional = true }
 # source with `deltalake-core` so the `Snapshot` types unify.
 delta_kernel = { workspace = true, optional = true }
 
-# Metric-view YAML deserialization (the `metric-view` feature).
+# Serialize UC DDL responses into result batches (the `sql` module, `delta`
+# feature) and deserialize metric-view YAML (`metric-view` feature).
 serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 serde_yml = { workspace = true, optional = true }
 
 [features]
 default = ["delta", "metric-view"]
-# Expose a Delta-backed `TableProviderBuilder` (pulls in delta-rs).
-delta = ["dep:deltalake-core", "dep:delta_kernel"]
+# Expose a Delta-backed `TableProviderBuilder` (pulls in delta-rs) and the Unity
+# Catalog DDL statements + planner (the `sql` module), whose managed
+# `CREATE TABLE` path serializes responses with serde/serde_json.
+delta = ["dep:deltalake-core", "dep:delta_kernel", "dep:serde", "dep:serde_json"]
 # Lower Unity Catalog metric-view YAML into a DataFusion `LogicalPlan`.
 metric-view = ["dep:serde", "dep:serde_yml"]
 

--- a/crates/datafusion/src/lib.rs
+++ b/crates/datafusion/src/lib.rs
@@ -1,6 +1,10 @@
 pub mod catalog;
 #[cfg(feature = "delta")]
 pub mod managed;
+// Unity Catalog DDL statements + planner. The managed `CREATE TABLE` path calls
+// into `managed`, so the module rides the same `delta` feature.
+#[cfg(feature = "delta")]
+pub mod sql;
 #[cfg(feature = "metric-view")]
 pub mod metric_view;
 pub mod storage;

--- a/crates/datafusion/src/sql/mod.rs
+++ b/crates/datafusion/src/sql/mod.rs
@@ -1,0 +1,24 @@
+//! Unity Catalog DDL statements lowered for DataFusion execution.
+//!
+//! This module owns the Unity Catalog DDL surface that runs *inside* a
+//! DataFusion plan: the statement types (`CREATE`/`DROP CATALOG`, `CREATE`/`DROP
+//! SCHEMA`, managed `CREATE TABLE`), their execution against a live
+//! [`UnityCatalogClient`](unitycatalog_client::UnityCatalogClient), the
+//! [`ExecuteUnityCatalogPlanNode`] DataFusion `Extension` node, and the
+//! [`UnityCatalogPlanner`] that lowers it to a physical plan.
+//!
+//! The *SQL front end* that recognizes this DDL (a custom `sqlparser`-based
+//! parser) lives in the host application, not here: it is coupled to host-only
+//! concerns such as Delta-table maintenance commands (`VACUUM`/`OPTIMIZE`). The
+//! host parses SQL into a [`UnityCatalogStatement`] and wraps it in an
+//! [`ExecuteUnityCatalogPlanNode`]; everything from there is owned here.
+//!
+//! Authorization for the DDL is the host's Cedar policy layer's responsibility.
+//! That layer matches the extension node purely by its `name()` string
+//! (`CreateCatalog`/`DropCatalog`/`CreateSchema`/`DropSchema`/`CreateManagedTable`)
+//! and reads the securable from the `name=<...>` token in `fmt_for_explain` — a
+//! stable string contract this crate must preserve.
+
+mod unity;
+
+pub use unity::*;

--- a/crates/datafusion/src/sql/unity/catalogs.rs
+++ b/crates/datafusion/src/sql/unity/catalogs.rs
@@ -1,0 +1,81 @@
+use datafusion::arrow::array::RecordBatch;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::sql::sqlparser::ast::{ObjectName, Value};
+use unitycatalog_client::UnityCatalogClient;
+use url::Url;
+
+use crate::sql::unity::{create_response_to_batch, drop_response_to_batch};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+pub struct CreateCatalogStatement {
+    pub name: ObjectName,
+    pub if_not_exists: bool,
+    pub using_share: Option<ObjectName>,
+    pub managed_location: Option<Url>,
+    pub default_collation: Option<String>,
+    pub comment: Option<String>,
+    pub options: Option<Vec<(String, Value)>>,
+}
+
+impl CreateCatalogStatement {
+    pub(crate) async fn execute(&self, client: UnityCatalogClient) -> Result<RecordBatch> {
+        let name = self.name.to_string();
+        let catalog_info = if let Some(location) = self.managed_location.as_ref() {
+            // create a calog with explicit managed location
+            let request = client
+                .create_catalog(&name)
+                .with_storage_root(location.to_string())
+                .with_comment(self.comment.clone());
+            request
+                .await
+                .map_err(|e| DataFusionError::External(Box::new(e)))?
+        } else if let Some(share) = self.using_share.as_ref() {
+            // create a catalog based on a delta share
+            if !share.0.len() == 2 {
+                return Err(DataFusionError::Execution(
+                    "Expected share name to have exactly two segments. <provider>.<share>"
+                        .to_string(),
+                ));
+            }
+            let provider_name = share.0[0].to_string();
+            let share_name = share.0[1].to_string();
+            let request = client
+                .create_catalog(&name)
+                .with_provider_name(provider_name)
+                .with_share_name(share_name)
+                .with_comment(self.comment.clone());
+            request
+                .await
+                .map_err(|e| DataFusionError::External(Box::new(e)))?
+        } else {
+            // create a catalog with default settings
+            let request = client
+                .create_catalog(&name)
+                .with_comment(self.comment.clone());
+            request
+                .await
+                .map_err(|e| DataFusionError::External(Box::new(e)))?
+        };
+        create_response_to_batch(name, "Catalog", catalog_info)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+pub struct DropCatalogStatement {
+    pub name: ObjectName,
+    pub if_exists: bool,
+    pub cascade: bool,
+}
+
+impl DropCatalogStatement {
+    pub(crate) async fn execute(&self, client: UnityCatalogClient) -> Result<RecordBatch> {
+        let name = self.name.to_string();
+        client
+            .catalog(&name)
+            .delete()
+            .with_force(self.cascade)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        drop_response_to_batch(name, "Catalog", "success")
+    }
+}

--- a/crates/datafusion/src/sql/unity/exec.rs
+++ b/crates/datafusion/src/sql/unity/exec.rs
@@ -1,0 +1,126 @@
+//! Physical execution for Unity Catalog DDL.
+//!
+//! A [`ExecuteUnityCatalogPlanNode`] (the logical `Extension` node produced for
+//! `CREATE`/`DROP CATALOG`/`SCHEMA`) is lowered by the [`UnityCatalogPlanner`]
+//! to a [`StreamingTableExec`] over a [`UnityCatalogPartitionStream`], which
+//! runs the statement against a live [`UnityCatalogClient`] and yields a single
+//! result `RecordBatch`. Reusing DataFusion's generic streaming node keeps us
+//! from re-implementing the `ExecutionPlan` boilerplate.
+//!
+//! The client is resolved at planning time from a [`UnityClientExtension`] set
+//! on the session config; if it is absent the planner errors rather than
+//! silently dropping the DDL.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::{exec_datafusion_err, internal_err};
+use datafusion::error::Result;
+use datafusion::execution::context::SessionState;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::streaming::{PartitionStream, StreamingTableExec};
+use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
+use unitycatalog_client::UnityCatalogClient;
+use unitycatalog_object_store::UnityObjectStoreFactory;
+
+use super::{ExecutableUnityCatalogStatement, ExecuteUnityCatalogPlanNode, UnityCatalogStatement};
+
+/// Session-config extension carrying the [`UnityCatalogClient`] used to execute
+/// Unity Catalog DDL. Hydrofoil sets this on the session state when Unity
+/// Catalog is wired; without it, UC DDL cannot be planned.
+#[derive(Clone)]
+pub struct UnityClientExtension(pub UnityCatalogClient);
+
+/// Session-config extension carrying the [`UnityObjectStoreFactory`] used by the
+/// managed-table write paths (bulk ingest append and managed `CREATE TABLE`).
+/// Unlike [`UnityClientExtension`] (which only exposes the catalog client), the
+/// factory also vends fresh per-table object-store credentials, which the kernel
+/// committer needs to stage and publish commits. Set on the session state
+/// alongside [`UnityClientExtension`] when Unity Catalog is wired.
+#[derive(Clone)]
+pub struct UnityFactoryExt(pub Arc<UnityObjectStoreFactory>);
+
+/// [`ExtensionPlanner`] that lowers [`ExecuteUnityCatalogPlanNode`] to a
+/// [`StreamingTableExec`] over a [`UnityCatalogPartitionStream`].
+#[derive(Debug, Default)]
+pub struct UnityCatalogPlanner;
+
+#[async_trait]
+impl ExtensionPlanner for UnityCatalogPlanner {
+    async fn plan_extension(
+        &self,
+        _planner: &dyn PhysicalPlanner,
+        node: &dyn UserDefinedLogicalNode,
+        logical_inputs: &[&LogicalPlan],
+        physical_inputs: &[Arc<dyn ExecutionPlan>],
+        session_state: &SessionState,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let Some(node) = node.as_any().downcast_ref::<ExecuteUnityCatalogPlanNode>() else {
+            return Ok(None);
+        };
+        if !logical_inputs.is_empty() || !physical_inputs.is_empty() {
+            return internal_err!("ExecuteUnityCatalogPlanNode does not take inputs");
+        }
+        let client = session_state
+            .config()
+            .get_extension::<UnityClientExtension>()
+            .ok_or_else(|| {
+                exec_datafusion_err!(
+                    "Unity Catalog is not configured; cannot execute Unity Catalog DDL"
+                )
+            })?;
+
+        let schema: SchemaRef = Arc::new(node.statement.return_schema().as_arrow().clone());
+        let partition = Arc::new(UnityCatalogPartitionStream {
+            statement: node.statement.clone(),
+            client: client.0.clone(),
+            schema: schema.clone(),
+        });
+        let exec = StreamingTableExec::try_new(
+            schema,
+            vec![partition],
+            None,  // no projection
+            None,  // no output ordering
+            false, // not infinite
+            None,  // no limit
+        )?;
+        Ok(Some(Arc::new(exec)))
+    }
+}
+
+/// A single-partition [`PartitionStream`] that executes one
+/// [`UnityCatalogStatement`] against Unity Catalog, yielding one result batch.
+struct UnityCatalogPartitionStream {
+    statement: UnityCatalogStatement,
+    client: UnityCatalogClient,
+    schema: SchemaRef,
+}
+
+impl std::fmt::Debug for UnityCatalogPartitionStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UnityCatalogPartitionStream")
+            .field("statement", &self.statement.command_name())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartitionStream for UnityCatalogPartitionStream {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let statement = self.statement.clone();
+        let client = self.client.clone();
+        let schema = self.schema.clone();
+        let fut = async move { statement.execute(client).await };
+        Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::once(fut),
+        ))
+    }
+}

--- a/crates/datafusion/src/sql/unity/mod.rs
+++ b/crates/datafusion/src/sql/unity/mod.rs
@@ -1,0 +1,403 @@
+use std::{
+    fmt,
+    sync::{Arc, LazyLock},
+};
+
+use datafusion::arrow::{
+    array::{RecordBatch, StringArray},
+    datatypes::{DataType, Field, Schema},
+};
+use datafusion::{
+    common::{DFSchema, DFSchemaRef, internal_err},
+    error::Result,
+    logical_expr::{LogicalPlan, UserDefinedLogicalNodeCore},
+    prelude::Expr,
+};
+use serde::Serialize;
+use unitycatalog_client::UnityCatalogClient;
+
+pub use self::catalogs::*;
+pub use self::exec::*;
+pub use self::schemas::*;
+pub use self::tables::*;
+
+mod catalogs;
+mod exec;
+mod schemas;
+mod tables;
+
+/// A Unity Catalog DDL statement that can be executed against a live Unity
+/// Catalog instance, returning a single result [`RecordBatch`].
+#[async_trait::async_trait]
+pub trait ExecutableUnityCatalogStatement {
+    /// The Arrow schema of the [`RecordBatch`] returned by [`Self::execute`].
+    fn return_schema(&self) -> &DFSchemaRef;
+
+    /// Execute the statement against `client` and return its result batch.
+    async fn execute(&self, client: UnityCatalogClient) -> Result<RecordBatch>;
+}
+
+pub(crate) static CREATE_UC_RETURN_SCHEMA: LazyLock<DFSchemaRef> = LazyLock::new(|| {
+    let arrow_schema = Schema::new(vec![
+        Field::new("securable_name", DataType::Utf8, false),
+        Field::new("securable_type", DataType::Utf8, false),
+        Field::new("securable_object", DataType::Utf8, false),
+    ]);
+    DFSchemaRef::new(DFSchema::try_from(arrow_schema).unwrap())
+});
+
+pub(crate) static DROP_UC_RETURN_SCHEMA: LazyLock<DFSchemaRef> = LazyLock::new(|| {
+    let arrow_schema = Schema::new(vec![
+        Field::new("securable_name", DataType::Utf8, false),
+        Field::new("securable_type", DataType::Utf8, false),
+        Field::new("status", DataType::Utf8, false),
+    ]);
+    DFSchemaRef::new(DFSchema::try_from(arrow_schema).unwrap())
+});
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+pub enum UnityCatalogStatement {
+    CreateCatalog(CreateCatalogStatement),
+    DropCatalog(DropCatalogStatement),
+    CreateSchema(CreateSchemaStatement),
+    DropSchema(DropSchemaStatement),
+    CreateManagedTable(CreateManagedTableStatement),
+}
+
+impl From<CreateCatalogStatement> for UnityCatalogStatement {
+    fn from(value: CreateCatalogStatement) -> Self {
+        UnityCatalogStatement::CreateCatalog(value)
+    }
+}
+
+impl From<DropCatalogStatement> for UnityCatalogStatement {
+    fn from(value: DropCatalogStatement) -> Self {
+        UnityCatalogStatement::DropCatalog(value)
+    }
+}
+
+impl From<CreateSchemaStatement> for UnityCatalogStatement {
+    fn from(value: CreateSchemaStatement) -> Self {
+        UnityCatalogStatement::CreateSchema(value)
+    }
+}
+
+impl From<DropSchemaStatement> for UnityCatalogStatement {
+    fn from(value: DropSchemaStatement) -> Self {
+        UnityCatalogStatement::DropSchema(value)
+    }
+}
+
+impl From<CreateManagedTableStatement> for UnityCatalogStatement {
+    fn from(value: CreateManagedTableStatement) -> Self {
+        UnityCatalogStatement::CreateManagedTable(value)
+    }
+}
+
+impl UnityCatalogStatement {
+    pub fn command_name(&self) -> &str {
+        use UnityCatalogStatement::*;
+
+        match &self {
+            CreateCatalog(_) => "CreateCatalog",
+            DropCatalog(_) => "DropCatalog",
+            CreateSchema(_) => "CreateSchema",
+            DropSchema(_) => "DropSchema",
+            CreateManagedTable(_) => "CreateManagedTable",
+        }
+    }
+
+    pub fn fmt_for_explain_params(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use UnityCatalogStatement::*;
+
+        match self {
+            CreateCatalog(cmd) => write!(f, "CreateCatalog: name={}", cmd.name),
+            DropCatalog(cmd) => write!(
+                f,
+                "DropCatalog: name={} if_exists={} cascade={}",
+                cmd.name, cmd.if_exists, cmd.cascade
+            ),
+            CreateSchema(cmd) => write!(f, "CreateSchema: name={}", cmd.name),
+            DropSchema(cmd) => write!(
+                f,
+                "DropSchema: name={} if_exists={} cascade={}",
+                cmd.name, cmd.if_exists, cmd.cascade
+            ),
+            CreateManagedTable(cmd) => write!(
+                f,
+                "CreateManagedTable: name={} columns={} if_not_exists={}",
+                cmd.name,
+                cmd.columns.len(),
+                cmd.if_not_exists
+            ),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Hash, Debug, Clone)]
+pub struct ExecuteUnityCatalogPlanNode {
+    pub statement: UnityCatalogStatement,
+}
+
+impl UserDefinedLogicalNodeCore for ExecuteUnityCatalogPlanNode {
+    fn name(&self) -> &str {
+        self.statement.command_name()
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        self.statement.return_schema()
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.statement.fmt_for_explain_params(f)
+    }
+
+    fn with_exprs_and_inputs(&self, exprs: Vec<Expr>, inputs: Vec<LogicalPlan>) -> Result<Self> {
+        if !exprs.is_empty() || !inputs.is_empty() {
+            internal_err!("CreateCatalogPlanNode does not support exprs and inputs")
+        } else {
+            Ok(self.clone())
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ExecutableUnityCatalogStatement for UnityCatalogStatement {
+    fn return_schema(&self) -> &DFSchemaRef {
+        use UnityCatalogStatement::*;
+
+        match &self {
+            CreateCatalog(_) | CreateSchema(_) | CreateManagedTable(_) => &CREATE_UC_RETURN_SCHEMA,
+            DropCatalog(_) | DropSchema(_) => &DROP_UC_RETURN_SCHEMA,
+        }
+    }
+
+    async fn execute(&self, client: UnityCatalogClient) -> Result<RecordBatch> {
+        use UnityCatalogStatement::*;
+
+        match &self {
+            CreateCatalog(cmd) => cmd.execute(client).await,
+            DropCatalog(cmd) => cmd.execute(client).await,
+            CreateSchema(cmd) => cmd.execute(client).await,
+            DropSchema(cmd) => cmd.execute(client).await,
+            CreateManagedTable(cmd) => cmd.execute(client).await,
+        }
+    }
+}
+
+pub(crate) fn create_response_to_batch(
+    name: impl ToString,
+    type_name: impl ToString,
+    object: impl Serialize,
+) -> Result<RecordBatch> {
+    let names = vec![name.to_string()];
+    let types = vec![type_name.to_string()];
+    let values = vec![serde_json::to_string(&object).unwrap()];
+    let schema = Arc::new(CREATE_UC_RETURN_SCHEMA.as_arrow().clone());
+    Ok(RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(StringArray::from(names)),
+            Arc::new(StringArray::from(types)),
+            Arc::new(StringArray::from(values)),
+        ],
+    )?)
+}
+
+pub(crate) fn drop_response_to_batch(
+    name: impl ToString,
+    type_name: impl ToString,
+    status: impl ToString,
+) -> Result<RecordBatch> {
+    let names = vec![name.to_string()];
+    let types = vec![type_name.to_string()];
+    let status = vec![status.to_string()];
+    let schema = Arc::new(DROP_UC_RETURN_SCHEMA.as_arrow().clone());
+    Ok(RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(StringArray::from(names)),
+            Arc::new(StringArray::from(types)),
+            Arc::new(StringArray::from(status)),
+        ],
+    )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::sql::sqlparser::ast::Ident;
+
+    use super::*;
+    use crate::sql::{CreateCatalogStatement, DropCatalogStatement, DropSchemaStatement};
+
+    fn name(parts: &[&str]) -> datafusion::sql::sqlparser::ast::ObjectName {
+        parts
+            .iter()
+            .map(|p| Ident::new(*p))
+            .collect::<Vec<_>>()
+            .into()
+    }
+
+    #[test]
+    fn create_statements_use_create_return_schema() {
+        let create_catalog: UnityCatalogStatement = CreateCatalogStatement {
+            name: name(&["c"]),
+            if_not_exists: false,
+            using_share: None,
+            managed_location: None,
+            default_collation: None,
+            comment: None,
+            options: None,
+        }
+        .into();
+        let create_schema: UnityCatalogStatement = CreateSchemaStatement {
+            name: name(&["c", "s"]),
+            if_not_exists: false,
+            managed_location: None,
+            comment: None,
+            properties: None,
+        }
+        .into();
+        for stmt in [create_catalog, create_schema] {
+            assert_eq!(stmt.return_schema(), &*CREATE_UC_RETURN_SCHEMA);
+            // The logical node mirrors the statement's return schema.
+            let node = ExecuteUnityCatalogPlanNode { statement: stmt };
+            assert_eq!(node.schema(), &*CREATE_UC_RETURN_SCHEMA);
+        }
+    }
+
+    #[test]
+    fn drop_statements_use_drop_return_schema() {
+        let drop_catalog: UnityCatalogStatement = DropCatalogStatement {
+            name: name(&["c"]),
+            if_exists: false,
+            cascade: false,
+        }
+        .into();
+        let drop_schema: UnityCatalogStatement = DropSchemaStatement {
+            name: name(&["c", "s"]),
+            if_exists: false,
+            cascade: false,
+        }
+        .into();
+        for stmt in [drop_catalog, drop_schema] {
+            assert_eq!(stmt.return_schema(), &*DROP_UC_RETURN_SCHEMA);
+        }
+    }
+
+    #[test]
+    fn command_names_are_stable() {
+        // These names are the contract the Cedar visitor matches on.
+        let cases: [(UnityCatalogStatement, &str); 2] = [
+            (
+                CreateCatalogStatement {
+                    name: name(&["c"]),
+                    if_not_exists: false,
+                    using_share: None,
+                    managed_location: None,
+                    default_collation: None,
+                    comment: None,
+                    options: None,
+                }
+                .into(),
+                "CreateCatalog",
+            ),
+            (
+                DropSchemaStatement {
+                    name: name(&["c", "s"]),
+                    if_exists: false,
+                    cascade: false,
+                }
+                .into(),
+                "DropSchema",
+            ),
+        ];
+        for (stmt, expected) in cases {
+            assert_eq!(stmt.command_name(), expected);
+        }
+    }
+
+    #[test]
+    fn explain_display_carries_securable_name() {
+        // Cedar reads the securable from the `name=<...>` token in the node's
+        // `Display`/`fmt_for_explain` output — this contract must hold across the
+        // cross-repo boundary.
+        let cases: [(UnityCatalogStatement, &str, &str); 4] = [
+            (
+                CreateCatalogStatement {
+                    name: name(&["my_catalog"]),
+                    if_not_exists: false,
+                    using_share: None,
+                    managed_location: None,
+                    default_collation: None,
+                    comment: None,
+                    options: None,
+                }
+                .into(),
+                "CreateCatalog",
+                "my_catalog",
+            ),
+            (
+                DropCatalogStatement {
+                    name: name(&["my_catalog"]),
+                    if_exists: false,
+                    cascade: false,
+                }
+                .into(),
+                "DropCatalog",
+                "my_catalog",
+            ),
+            (
+                CreateSchemaStatement {
+                    name: name(&["c", "s"]),
+                    if_not_exists: false,
+                    managed_location: None,
+                    comment: None,
+                    properties: None,
+                }
+                .into(),
+                "CreateSchema",
+                "c.s",
+            ),
+            (
+                DropSchemaStatement {
+                    name: name(&["c", "s"]),
+                    if_exists: false,
+                    cascade: false,
+                }
+                .into(),
+                "DropSchema",
+                "c.s",
+            ),
+        ];
+        for (stmt, expected_name, expected_securable) in cases {
+            let node = ExecuteUnityCatalogPlanNode { statement: stmt };
+            assert_eq!(node.name(), expected_name);
+            let rendered = format!("{}", DisplayNode(&node));
+            let securable = rendered
+                .split("name=")
+                .nth(1)
+                .and_then(|rest| rest.split_whitespace().next())
+                .unwrap_or("");
+            assert_eq!(securable, expected_securable, "rendered: {rendered}");
+        }
+    }
+
+    /// Mirror the Cedar visitor's `DisplayNode` wrapper so the contract test
+    /// exercises the same `fmt_for_explain` path Cedar relies on.
+    struct DisplayNode<'a>(&'a ExecuteUnityCatalogPlanNode);
+
+    impl fmt::Display for DisplayNode<'_> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            self.0.fmt_for_explain(f)
+        }
+    }
+}

--- a/crates/datafusion/src/sql/unity/schemas.rs
+++ b/crates/datafusion/src/sql/unity/schemas.rs
@@ -1,0 +1,94 @@
+use datafusion::arrow::array::RecordBatch;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::sql::sqlparser::ast::{ObjectName, Value};
+use unitycatalog_client::UnityCatalogClient;
+use url::Url;
+
+use crate::sql::unity::{create_response_to_batch, drop_response_to_batch};
+
+/// Split a schema [`ObjectName`] into `(catalog, schema)`.
+///
+/// Unity Catalog schemas are always two-part (`catalog.schema`); unlike a
+/// Databricks SQL session, hydrofoil has no notion of a "current catalog" to
+/// resolve a bare schema name against, so a one-part name is rejected with a
+/// clear error directing the caller to qualify it.
+fn split_schema_name(name: &ObjectName) -> Result<(String, String)> {
+    match name.0.as_slice() {
+        [catalog, schema] => Ok((catalog.to_string(), schema.to_string())),
+        [_] => Err(DataFusionError::Execution(format!(
+            "Schema name '{name}' must be qualified with a catalog (<catalog>.<schema>)"
+        ))),
+        _ => Err(DataFusionError::Execution(format!(
+            "Expected schema name to be a two-part identifier (<catalog>.<schema>), got '{name}'"
+        ))),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+pub struct CreateSchemaStatement {
+    pub name: ObjectName,
+    pub if_not_exists: bool,
+    pub managed_location: Option<Url>,
+    pub comment: Option<String>,
+    pub properties: Option<Vec<(String, Value)>>,
+}
+
+impl CreateSchemaStatement {
+    pub(crate) async fn execute(&self, client: UnityCatalogClient) -> Result<RecordBatch> {
+        let (catalog, schema) = split_schema_name(&self.name)?;
+
+        // The UC `CreateSchema` API has no managed-location field (unlike
+        // catalogs), so `MANAGED LOCATION` is not supported for schemas yet.
+        if self.managed_location.is_some() {
+            return Err(DataFusionError::NotImplemented(
+                "MANAGED LOCATION is not supported for CREATE SCHEMA".to_string(),
+            ));
+        }
+
+        let mut request = client
+            .create_schema(&catalog, &schema)
+            .with_comment(self.comment.clone());
+        if let Some(properties) = self.properties.as_ref() {
+            request = request.with_properties(
+                properties
+                    .iter()
+                    .map(|(k, v)| (k.clone(), value_to_string(v))),
+            );
+        }
+        let schema_info = request
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        create_response_to_batch(self.name.to_string(), "Schema", schema_info)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+pub struct DropSchemaStatement {
+    pub name: ObjectName,
+    pub if_exists: bool,
+    pub cascade: bool,
+}
+
+impl DropSchemaStatement {
+    pub(crate) async fn execute(&self, client: UnityCatalogClient) -> Result<RecordBatch> {
+        let (catalog, schema) = split_schema_name(&self.name)?;
+        client
+            .schema(&catalog, &schema)
+            .delete()
+            .with_force(self.cascade)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        drop_response_to_batch(self.name.to_string(), "Schema", "success")
+    }
+}
+
+/// Render a parsed option [`Value`] as the plain string UC properties expect.
+fn value_to_string(value: &Value) -> String {
+    match value {
+        Value::SingleQuotedString(s)
+        | Value::DoubleQuotedString(s)
+        | Value::EscapedStringLiteral(s) => s.clone(),
+        Value::Number(n, _) => n.clone(),
+        other => other.to_string(),
+    }
+}

--- a/crates/datafusion/src/sql/unity/tables.rs
+++ b/crates/datafusion/src/sql/unity/tables.rs
@@ -1,0 +1,214 @@
+use std::sync::Arc;
+
+use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use datafusion::common::{DataFusionError, Result};
+use datafusion::sql::sqlparser::ast::{ColumnDef, DataType as SqlDataType, ObjectName};
+use unitycatalog_client::UnityCatalogClient;
+
+use crate::managed::create_managed_table;
+use crate::sql::unity::create_response_to_batch;
+
+/// `CREATE TABLE <catalog>.<schema>.<table> (<cols>) USING DELTA` — a Unity
+/// Catalog **managed** Delta table (no `LOCATION`; UC allocates the storage
+/// location). Lowered to an `Extension` node like the other UC DDL so it rides
+/// through the `allow_ddl=false` SQL gate and is authorized by Cedar instead.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+pub struct CreateManagedTableStatement {
+    pub name: ObjectName,
+    pub columns: Vec<ColumnDef>,
+    pub if_not_exists: bool,
+}
+
+/// Engine identifier recorded in the v0 `commitInfo` for tables created through
+/// this SQL path.
+const ENGINE_INFO: &str = concat!("datafusion-unitycatalog/", env!("CARGO_PKG_VERSION"));
+
+impl CreateManagedTableStatement {
+    pub(crate) async fn execute(&self, client: UnityCatalogClient) -> Result<RecordBatch> {
+        let (catalog, schema, table) = split_table_name(&self.name)?;
+        let delta = Arc::new(client.delta_v1());
+
+        // Honor `IF NOT EXISTS`: a successful load means the table already
+        // exists, so this is a no-op rather than a hard 409 from createTable.
+        if self.if_not_exists && delta.load_table(&catalog, &schema, &table).await.is_ok() {
+            return create_response_to_batch(self.name.to_string(), "Table", "exists");
+        }
+
+        let arrow_schema = sql_columns_to_arrow_schema(&self.columns)?;
+
+        let created = create_managed_table(
+            delta,
+            &catalog,
+            &schema,
+            &table,
+            arrow_schema,
+            // Partitioned managed tables are out of scope for this path (the
+            // append path is unpartitioned-only); always create unpartitioned.
+            Vec::new(),
+            ENGINE_INFO,
+        )
+        .await
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        create_response_to_batch(
+            self.name.to_string(),
+            "Table",
+            serde_json::json!({
+                "table_id": created.table_id,
+                "location": created.location,
+            }),
+        )
+    }
+}
+
+/// Split a table [`ObjectName`] into `(catalog, schema, table)`.
+///
+/// Managed tables must be fully qualified — hydrofoil has no "current catalog"
+/// to resolve a shorter name against (matching [`super::schemas`]' two-part
+/// requirement for schemas).
+fn split_table_name(name: &ObjectName) -> Result<(String, String, String)> {
+    match name.0.as_slice() {
+        [catalog, schema, table] => {
+            Ok((catalog.to_string(), schema.to_string(), table.to_string()))
+        }
+        _ => Err(DataFusionError::Execution(format!(
+            "Managed table name '{name}' must be a three-part identifier (<catalog>.<schema>.<table>)"
+        ))),
+    }
+}
+
+/// Map parsed SQL column definitions to an Arrow [`SchemaRef`].
+///
+/// Only the primitive types the managed connector supports are accepted (see
+/// `arrow_primitive_to_delta` in the connector); nested / decimal / unsupported
+/// types are rejected here with a clear error rather than failing deeper in the
+/// create path. Recognizes both standard SQL names and the Spark aliases
+/// `LONG` / `STRING` (which the generic dialect surfaces as `Custom`).
+pub(crate) fn sql_columns_to_arrow_schema(columns: &[ColumnDef]) -> Result<SchemaRef> {
+    if columns.is_empty() {
+        return Err(DataFusionError::Execution(
+            "managed CREATE TABLE requires at least one column".to_string(),
+        ));
+    }
+    let fields = columns
+        .iter()
+        .map(|col| {
+            let data_type = sql_type_to_arrow(&col.data_type, &col.name.value)?;
+            // Columns are nullable unless an explicit NOT NULL option is present;
+            // matching Spark/Delta defaults keeps the create schema permissive.
+            let nullable = !col
+                .options
+                .iter()
+                .any(|o| matches!(o.option, datafusion::sql::sqlparser::ast::ColumnOption::NotNull));
+            Ok(Field::new(&col.name.value, data_type, nullable))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(Arc::new(Schema::new(fields)))
+}
+
+fn sql_type_to_arrow(dt: &SqlDataType, col: &str) -> Result<DataType> {
+    let unsupported = |dt: &SqlDataType| {
+        DataFusionError::NotImplemented(format!(
+            "column '{col}' has unsupported type '{dt}' for a managed Delta table \
+             (supported: boolean, tinyint/byte, smallint/short, int, bigint/long, \
+             real/float, double, string/varchar/char/text, binary, date, timestamp)"
+        ))
+    };
+    let mapped = match dt {
+        SqlDataType::Boolean | SqlDataType::Bool => DataType::Boolean,
+        SqlDataType::TinyInt(_) => DataType::Int8,
+        SqlDataType::SmallInt(_) => DataType::Int16,
+        SqlDataType::Int(_) | SqlDataType::Integer(_) => DataType::Int32,
+        SqlDataType::BigInt(_) => DataType::Int64,
+        SqlDataType::Real | SqlDataType::Float4 | SqlDataType::Float(_) => DataType::Float32,
+        SqlDataType::Double(_)
+        | SqlDataType::DoublePrecision
+        | SqlDataType::Float8
+        | SqlDataType::Float64 => DataType::Float64,
+        SqlDataType::Char(_)
+        | SqlDataType::Varchar(_)
+        | SqlDataType::Text
+        | SqlDataType::String(_) => DataType::Utf8,
+        SqlDataType::Binary(_) | SqlDataType::Bytea => DataType::Binary,
+        SqlDataType::Date => DataType::Date32,
+        SqlDataType::Timestamp(_, _) | SqlDataType::TimestampNtz(_) => {
+            DataType::Timestamp(TimeUnit::Microsecond, None)
+        }
+        // Spark spells some types (`LONG`, `STRING`, `BYTE`, `SHORT`) as bare
+        // identifiers the generic dialect parses as `Custom`. Match on the name.
+        SqlDataType::Custom(name, _) => match name.to_string().to_ascii_lowercase().as_str() {
+            "long" => DataType::Int64,
+            "string" => DataType::Utf8,
+            "byte" => DataType::Int8,
+            "short" => DataType::Int16,
+            _ => return Err(unsupported(dt)),
+        },
+        _ => return Err(unsupported(dt)),
+    };
+    Ok(mapped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::sql::sqlparser::ast::Ident;
+
+    fn col(name: &str, dt: SqlDataType) -> ColumnDef {
+        ColumnDef {
+            name: Ident::new(name),
+            data_type: dt,
+            options: vec![],
+        }
+    }
+
+    #[test]
+    fn maps_supported_primitives() {
+        let cols = vec![
+            col("a", SqlDataType::BigInt(None)),
+            col("b", SqlDataType::Varchar(None)),
+            col("c", SqlDataType::Boolean),
+            col(
+                "d",
+                SqlDataType::Custom(vec![Ident::new("LONG")].into(), vec![]),
+            ),
+            col(
+                "e",
+                SqlDataType::Custom(vec![Ident::new("string")].into(), vec![]),
+            ),
+        ];
+        let schema = sql_columns_to_arrow_schema(&cols).unwrap();
+        assert_eq!(schema.field(0).data_type(), &DataType::Int64);
+        assert_eq!(schema.field(1).data_type(), &DataType::Utf8);
+        assert_eq!(schema.field(2).data_type(), &DataType::Boolean);
+        assert_eq!(schema.field(3).data_type(), &DataType::Int64);
+        assert_eq!(schema.field(4).data_type(), &DataType::Utf8);
+    }
+
+    #[test]
+    fn rejects_unsupported_type() {
+        let cols = vec![col(
+            "amount",
+            SqlDataType::Decimal(datafusion::sql::sqlparser::ast::ExactNumberInfo::None),
+        )];
+        let err = sql_columns_to_arrow_schema(&cols).unwrap_err();
+        assert!(err.to_string().contains("unsupported type"));
+    }
+
+    #[test]
+    fn rejects_empty_columns() {
+        let err = sql_columns_to_arrow_schema(&[]).unwrap_err();
+        assert!(err.to_string().contains("at least one column"));
+    }
+
+    #[test]
+    fn requires_three_part_name() {
+        let two: ObjectName = vec![Ident::new("s"), Ident::new("t")].into();
+        assert!(split_table_name(&two).is_err());
+        let three: ObjectName = vec![Ident::new("c"), Ident::new("s"), Ident::new("t")].into();
+        assert_eq!(
+            split_table_name(&three).unwrap(),
+            ("c".to_string(), "s".to_string(), "t".to_string())
+        );
+    }
+}


### PR DESCRIPTION
Add a `sql` module to `datafusion-unitycatalog` owning the Unity Catalog DDL surface that runs inside a DataFusion plan: the statement types (CREATE/DROP CATALOG, CREATE/DROP SCHEMA, managed CREATE TABLE), their execution against a live UnityCatalogClient, the ExecuteUnityCatalogPlanNode extension node, and the UnityCatalogPlanner that lowers it to a physical plan.

This code previously lived in open-lakehouse's `deltalake-datafusion` crate, where it already depended inward on `datafusion_unitycatalog::managed` and `unitycatalog-client`. Co-locating it with the managed-write and catalog- resolution primitives it calls makes `datafusion-unitycatalog` the single home for the UC<->DataFusion integration; the managed CREATE TABLE path is now an intra-crate `crate::managed::create_managed_table` call.

The SQL parser front end stays in the host application: it also owns Delta-table maintenance commands (VACUUM, and OPTIMIZE in future) that are not Unity Catalog concerns. The host parses SQL into a UnityCatalogStatement and wraps it in an ExecuteUnityCatalogPlanNode; everything from there is owned here.

The module rides the existing `delta` feature (the managed CREATE TABLE path calls into `managed`), which now also pulls in serde/serde_json for serializing DDL responses into result batches. arrow and sqlparser are accessed via DataFusion's re-exports, so no new workspace dependencies are introduced.

Authorization for the DDL is the host's Cedar policy layer, which matches the extension node purely by its name() string and reads the securable from the `name=<...>` token in fmt_for_explain. A unit test pins both, so that cross-repo string contract cannot silently regress.

AI assisted by Isaac

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->