### PR TITLE
feat(datafusion): add CREATE/DROP FUNCTION DDL (scalar SQL UDFs)

### DIFF
--- a/crates/datafusion/src/sql/unity/functions.rs
+++ b/crates/datafusion/src/sql/unity/functions.rs
@@ -1,0 +1,299 @@
+use datafusion::arrow::array::RecordBatch;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::sql::sqlparser::ast::{DataType as SqlDataType, ObjectName};
+use unitycatalog_client::UnityCatalogClient;
+use unitycatalog_common::models::functions::v1::{
+    FunctionParameterInfo, FunctionParameterInfos, ParameterMode, ParameterStyle, RoutineBody,
+    SecurityType, SqlDataAccess,
+};
+
+use crate::sql::unity::{create_response_to_batch, drop_response_to_batch};
+
+/// The language a Unity Catalog function body is written in.
+///
+/// Only [`FunctionLanguage::Sql`] is executable today; the other variants exist
+/// so the host parser can faithfully carry what the user wrote and this crate
+/// can reject it with a precise error rather than silently mis-creating it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
+pub enum FunctionLanguage {
+    Sql,
+    Python,
+    External,
+}
+
+/// The SQL data-access characteristic of a function (`CONTAINS SQL` /
+/// `READS SQL DATA` / `NO SQL`). Defaults to `CONTAINS SQL` for SQL UDFs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
+pub enum SqlDataAccessKind {
+    ContainsSql,
+    ReadsSqlData,
+    NoSql,
+}
+
+impl From<SqlDataAccessKind> for SqlDataAccess {
+    fn from(value: SqlDataAccessKind) -> Self {
+        match value {
+            SqlDataAccessKind::ContainsSql => SqlDataAccess::ContainsSql,
+            SqlDataAccessKind::ReadsSqlData => SqlDataAccess::ReadsSqlData,
+            SqlDataAccessKind::NoSql => SqlDataAccess::NoSql,
+        }
+    }
+}
+
+/// A single `CREATE FUNCTION` parameter: `name data_type [DEFAULT expr] [COMMENT str]`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+pub struct FunctionParam {
+    pub name: String,
+    pub data_type: SqlDataType,
+    pub default: Option<String>,
+    pub comment: Option<String>,
+}
+
+/// `CREATE [OR REPLACE] FUNCTION [IF NOT EXISTS] <catalog>.<schema>.<fn>(<params>)
+/// RETURNS <type> [characteristics] RETURN <expr>` — a Unity Catalog scalar SQL
+/// UDF. Lowered to an `Extension` node like the other UC DDL so it rides through
+/// the SQL DDL gate and is authorized by Cedar.
+///
+/// Only scalar SQL UDFs are supported: `RETURNS TABLE` (UDTFs) and non-SQL
+/// languages are rejected at execution with a clear `NotImplemented` error.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+pub struct CreateFunctionStatement {
+    pub name: ObjectName,
+    /// `OR REPLACE` — carried for the Cedar/explain contract; the UC
+    /// `CreateFunction` API has no replace flag, so it has no effect yet.
+    pub or_replace: bool,
+    /// `IF NOT EXISTS` — carried for the contract; no API field yet.
+    pub if_not_exists: bool,
+    pub params: Vec<FunctionParam>,
+    /// Scalar return type from the `RETURNS` clause.
+    pub returns: SqlDataType,
+    pub language: FunctionLanguage,
+    /// `DETERMINISTIC` (true) / `NOT DETERMINISTIC` (false); SQL UDFs default true.
+    pub deterministic: bool,
+    pub data_access: SqlDataAccessKind,
+    /// The raw `RETURN <expr>` body text.
+    pub routine_definition: String,
+    pub comment: Option<String>,
+}
+
+impl CreateFunctionStatement {
+    pub(crate) async fn execute(&self, client: UnityCatalogClient) -> Result<RecordBatch> {
+        let (catalog, schema, func) = split_function_name(&self.name)?;
+
+        if self.language != FunctionLanguage::Sql {
+            return Err(DataFusionError::NotImplemented(
+                "only LANGUAGE SQL functions are supported; \
+                 Python and external functions are not yet implemented"
+                    .to_string(),
+            ));
+        }
+
+        // We keep the parsed SQL type text for both `data_type` and
+        // `full_data_type`; `type_name` (the ColumnTypeName enum) is left
+        // unspecified, mirroring a minimal create payload.
+        let data_type_text = self.returns.to_string();
+
+        let params = FunctionParameterInfos {
+            parameters: self
+                .params
+                .iter()
+                .enumerate()
+                .map(|(i, p)| FunctionParameterInfo {
+                    name: p.name.clone(),
+                    type_text: p.data_type.to_string(),
+                    position: Some(i as i32),
+                    parameter_mode: ParameterMode::In as i32,
+                    parameter_type:
+                        unitycatalog_common::models::functions::v1::FunctionParameterType::Param
+                            as i32,
+                    parameter_default: p.default.clone(),
+                    comment: p.comment.clone(),
+                    ..Default::default()
+                })
+                .collect(),
+        };
+
+        let info = client
+            .create_function(
+                func,
+                catalog,
+                schema,
+                data_type_text.clone(),
+                data_type_text,
+                ParameterStyle::S,
+                self.deterministic,
+                self.data_access.into(),
+                // Null-calling is not a writable DDL clause; default to false.
+                false,
+                SecurityType::Definer,
+                RoutineBody::Sql,
+            )
+            .with_input_params(Some(params))
+            .with_routine_definition(Some(self.routine_definition.clone()))
+            .with_routine_body_language(Some("SQL".to_string()))
+            .with_comment(self.comment.clone())
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        create_response_to_batch(self.name.to_string(), "Function", info)
+    }
+}
+
+/// `DROP FUNCTION [IF EXISTS] <catalog>.<schema>.<fn>`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+pub struct DropFunctionStatement {
+    pub name: ObjectName,
+    pub if_exists: bool,
+}
+
+impl DropFunctionStatement {
+    pub(crate) async fn execute(&self, client: UnityCatalogClient) -> Result<RecordBatch> {
+        let (catalog, schema, func) = split_function_name(&self.name)?;
+        // Functions have no cascade concept; always a plain delete.
+        client
+            .function(catalog, schema, func)
+            .delete()
+            .with_force(false)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        drop_response_to_batch(self.name.to_string(), "Function", "success")
+    }
+}
+
+/// Split a function [`ObjectName`] into `(catalog, schema, function)`.
+///
+/// Functions must be fully qualified — hydrofoil has no "current catalog" to
+/// resolve a shorter name against (matching [`super::tables`]' three-part
+/// requirement for managed tables).
+fn split_function_name(name: &ObjectName) -> Result<(String, String, String)> {
+    match name.0.as_slice() {
+        [catalog, schema, function] => Ok((
+            catalog.to_string(),
+            schema.to_string(),
+            function.to_string(),
+        )),
+        _ => Err(DataFusionError::Execution(format!(
+            "Function name '{name}' must be a three-part identifier (<catalog>.<schema>.<function>)"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::sql::sqlparser::ast::Ident;
+
+    use super::*;
+
+    fn name(parts: &[&str]) -> ObjectName {
+        parts
+            .iter()
+            .map(|p| Ident::new(*p))
+            .collect::<Vec<_>>()
+            .into()
+    }
+
+    #[test]
+    fn split_function_name_requires_three_parts() {
+        assert!(split_function_name(&name(&["c", "s", "f"])).is_ok());
+        let (catalog, schema, func) = split_function_name(&name(&["c", "s", "f"])).unwrap();
+        assert_eq!(
+            (catalog.as_str(), schema.as_str(), func.as_str()),
+            ("c", "s", "f")
+        );
+
+        for bad in [name(&["f"]), name(&["s", "f"]), name(&["a", "b", "c", "d"])] {
+            assert!(
+                split_function_name(&bad).is_err(),
+                "{bad} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn sql_data_access_maps_to_proto_enum() {
+        assert_eq!(
+            SqlDataAccess::from(SqlDataAccessKind::ContainsSql),
+            SqlDataAccess::ContainsSql
+        );
+        assert_eq!(
+            SqlDataAccess::from(SqlDataAccessKind::ReadsSqlData),
+            SqlDataAccess::ReadsSqlData
+        );
+        assert_eq!(
+            SqlDataAccess::from(SqlDataAccessKind::NoSql),
+            SqlDataAccess::NoSql
+        );
+    }
+
+    /// A scalar SQL UDF statement we can reuse across mapping assertions.
+    fn sample_create() -> CreateFunctionStatement {
+        CreateFunctionStatement {
+            name: name(&["c", "s", "add"]),
+            or_replace: false,
+            if_not_exists: false,
+            params: vec![
+                FunctionParam {
+                    name: "x".to_string(),
+                    data_type: SqlDataType::Int(None),
+                    default: None,
+                    comment: Some("first".to_string()),
+                },
+                FunctionParam {
+                    name: "y".to_string(),
+                    data_type: SqlDataType::Int(None),
+                    default: Some("1".to_string()),
+                    comment: None,
+                },
+            ],
+            returns: SqlDataType::Int(None),
+            language: FunctionLanguage::Sql,
+            deterministic: true,
+            data_access: SqlDataAccessKind::ContainsSql,
+            routine_definition: "x + y".to_string(),
+            comment: None,
+        }
+    }
+
+    /// Reproduce the `input_params` construction from `execute` so we can assert
+    /// the SQL-clause → `FunctionParameterInfo` mapping without a live client.
+    fn build_params(stmt: &CreateFunctionStatement) -> FunctionParameterInfos {
+        use unitycatalog_common::models::functions::v1::FunctionParameterType;
+        FunctionParameterInfos {
+            parameters: stmt
+                .params
+                .iter()
+                .enumerate()
+                .map(|(i, p)| FunctionParameterInfo {
+                    name: p.name.clone(),
+                    type_text: p.data_type.to_string(),
+                    position: Some(i as i32),
+                    parameter_mode: ParameterMode::In as i32,
+                    parameter_type: FunctionParameterType::Param as i32,
+                    parameter_default: p.default.clone(),
+                    comment: p.comment.clone(),
+                    ..Default::default()
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn params_map_with_zero_based_positions_and_metadata() {
+        use unitycatalog_common::models::functions::v1::FunctionParameterType;
+        let params = build_params(&sample_create());
+        assert_eq!(params.parameters.len(), 2);
+
+        let x = &params.parameters[0];
+        assert_eq!(x.name, "x");
+        assert_eq!(x.position, Some(0));
+        assert_eq!(x.parameter_mode, ParameterMode::In as i32);
+        assert_eq!(x.parameter_type, FunctionParameterType::Param as i32);
+        assert_eq!(x.parameter_default, None);
+        assert_eq!(x.comment.as_deref(), Some("first"));
+
+        let y = &params.parameters[1];
+        assert_eq!(y.position, Some(1));
+        assert_eq!(y.parameter_default.as_deref(), Some("1"));
+        assert_eq!(y.comment, None);
+    }
+}

--- a/crates/datafusion/src/sql/unity/functions.rs
+++ b/crates/datafusion/src/sql/unity/functions.rs
@@ -13,7 +13,7 @@ use crate::sql::unity::{create_response_to_batch, drop_response_to_batch};
 ///
 /// Only [`FunctionLanguage::Sql`] is executable today; the other variants exist
 /// so the host parser can faithfully carry what the user wrote and this crate
-/// can reject it with a precise error rather than silently mis-creating it.
+/// can reject it with a precise error rather than creating it incorrectly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
 pub enum FunctionLanguage {
     Sql,

--- a/crates/datafusion/src/sql/unity/mod.rs
+++ b/crates/datafusion/src/sql/unity/mod.rs
@@ -18,11 +18,13 @@ use unitycatalog_client::UnityCatalogClient;
 
 pub use self::catalogs::*;
 pub use self::exec::*;
+pub use self::functions::*;
 pub use self::schemas::*;
 pub use self::tables::*;
 
 mod catalogs;
 mod exec;
+mod functions;
 mod schemas;
 mod tables;
 
@@ -62,6 +64,8 @@ pub enum UnityCatalogStatement {
     CreateSchema(CreateSchemaStatement),
     DropSchema(DropSchemaStatement),
     CreateManagedTable(CreateManagedTableStatement),
+    CreateFunction(CreateFunctionStatement),
+    DropFunction(DropFunctionStatement),
 }
 
 impl From<CreateCatalogStatement> for UnityCatalogStatement {
@@ -94,6 +98,18 @@ impl From<CreateManagedTableStatement> for UnityCatalogStatement {
     }
 }
 
+impl From<CreateFunctionStatement> for UnityCatalogStatement {
+    fn from(value: CreateFunctionStatement) -> Self {
+        UnityCatalogStatement::CreateFunction(value)
+    }
+}
+
+impl From<DropFunctionStatement> for UnityCatalogStatement {
+    fn from(value: DropFunctionStatement) -> Self {
+        UnityCatalogStatement::DropFunction(value)
+    }
+}
+
 impl UnityCatalogStatement {
     pub fn command_name(&self) -> &str {
         use UnityCatalogStatement::*;
@@ -104,6 +120,8 @@ impl UnityCatalogStatement {
             CreateSchema(_) => "CreateSchema",
             DropSchema(_) => "DropSchema",
             CreateManagedTable(_) => "CreateManagedTable",
+            CreateFunction(_) => "CreateFunction",
+            DropFunction(_) => "DropFunction",
         }
     }
 
@@ -129,6 +147,12 @@ impl UnityCatalogStatement {
                 cmd.name,
                 cmd.columns.len(),
                 cmd.if_not_exists
+            ),
+            CreateFunction(cmd) => write!(f, "CreateFunction: name={}", cmd.name),
+            DropFunction(cmd) => write!(
+                f,
+                "DropFunction: name={} if_exists={}",
+                cmd.name, cmd.if_exists
             ),
         }
     }
@@ -175,8 +199,10 @@ impl ExecutableUnityCatalogStatement for UnityCatalogStatement {
         use UnityCatalogStatement::*;
 
         match &self {
-            CreateCatalog(_) | CreateSchema(_) | CreateManagedTable(_) => &CREATE_UC_RETURN_SCHEMA,
-            DropCatalog(_) | DropSchema(_) => &DROP_UC_RETURN_SCHEMA,
+            CreateCatalog(_) | CreateSchema(_) | CreateManagedTable(_) | CreateFunction(_) => {
+                &CREATE_UC_RETURN_SCHEMA
+            }
+            DropCatalog(_) | DropSchema(_) | DropFunction(_) => &DROP_UC_RETURN_SCHEMA,
         }
     }
 
@@ -189,6 +215,8 @@ impl ExecutableUnityCatalogStatement for UnityCatalogStatement {
             CreateSchema(cmd) => cmd.execute(client).await,
             DropSchema(cmd) => cmd.execute(client).await,
             CreateManagedTable(cmd) => cmd.execute(client).await,
+            CreateFunction(cmd) => cmd.execute(client).await,
+            DropFunction(cmd) => cmd.execute(client).await,
         }
     }
 }
@@ -236,7 +264,27 @@ mod tests {
     use datafusion::sql::sqlparser::ast::Ident;
 
     use super::*;
-    use crate::sql::{CreateCatalogStatement, DropCatalogStatement, DropSchemaStatement};
+    use crate::sql::{
+        CreateCatalogStatement, CreateFunctionStatement, DropCatalogStatement,
+        DropFunctionStatement, DropSchemaStatement, FunctionLanguage, SqlDataAccessKind,
+    };
+    use datafusion::sql::sqlparser::ast::DataType as SqlDataType;
+
+    /// A minimal scalar SQL UDF statement for the contract tests.
+    fn sample_function() -> CreateFunctionStatement {
+        CreateFunctionStatement {
+            name: name(&["c", "s", "f"]),
+            or_replace: false,
+            if_not_exists: false,
+            params: vec![],
+            returns: SqlDataType::Int(None),
+            language: FunctionLanguage::Sql,
+            deterministic: true,
+            data_access: SqlDataAccessKind::ContainsSql,
+            routine_definition: "1".to_string(),
+            comment: None,
+        }
+    }
 
     fn name(parts: &[&str]) -> datafusion::sql::sqlparser::ast::ObjectName {
         parts
@@ -266,7 +314,8 @@ mod tests {
             properties: None,
         }
         .into();
-        for stmt in [create_catalog, create_schema] {
+        let create_function: UnityCatalogStatement = sample_function().into();
+        for stmt in [create_catalog, create_schema, create_function] {
             assert_eq!(stmt.return_schema(), &*CREATE_UC_RETURN_SCHEMA);
             // The logical node mirrors the statement's return schema.
             let node = ExecuteUnityCatalogPlanNode { statement: stmt };
@@ -288,7 +337,12 @@ mod tests {
             cascade: false,
         }
         .into();
-        for stmt in [drop_catalog, drop_schema] {
+        let drop_function: UnityCatalogStatement = DropFunctionStatement {
+            name: name(&["c", "s", "f"]),
+            if_exists: false,
+        }
+        .into();
+        for stmt in [drop_catalog, drop_schema, drop_function] {
             assert_eq!(stmt.return_schema(), &*DROP_UC_RETURN_SCHEMA);
         }
     }
@@ -296,7 +350,7 @@ mod tests {
     #[test]
     fn command_names_are_stable() {
         // These names are the contract the Cedar visitor matches on.
-        let cases: [(UnityCatalogStatement, &str); 2] = [
+        let cases: [(UnityCatalogStatement, &str); 4] = [
             (
                 CreateCatalogStatement {
                     name: name(&["c"]),
@@ -319,6 +373,15 @@ mod tests {
                 .into(),
                 "DropSchema",
             ),
+            (sample_function().into(), "CreateFunction"),
+            (
+                DropFunctionStatement {
+                    name: name(&["c", "s", "f"]),
+                    if_exists: false,
+                }
+                .into(),
+                "DropFunction",
+            ),
         ];
         for (stmt, expected) in cases {
             assert_eq!(stmt.command_name(), expected);
@@ -330,7 +393,7 @@ mod tests {
         // Cedar reads the securable from the `name=<...>` token in the node's
         // `Display`/`fmt_for_explain` output — this contract must hold across the
         // cross-repo boundary.
-        let cases: [(UnityCatalogStatement, &str, &str); 4] = [
+        let cases: [(UnityCatalogStatement, &str, &str); 6] = [
             (
                 CreateCatalogStatement {
                     name: name(&["my_catalog"]),
@@ -376,6 +439,16 @@ mod tests {
                 .into(),
                 "DropSchema",
                 "c.s",
+            ),
+            (sample_function().into(), "CreateFunction", "c.s.f"),
+            (
+                DropFunctionStatement {
+                    name: name(&["c", "s", "f"]),
+                    if_exists: false,
+                }
+                .into(),
+                "DropFunction",
+                "c.s.f",
             ),
         ];
         for (stmt, expected_name, expected_securable) in cases {


### PR DESCRIPTION
## Summary

Extends the Unity Catalog DDL surface in the `datafusion` crate (which already supports `CREATE`/`DROP CATALOG`, `CREATE`/`DROP SCHEMA`, and managed `CREATE TABLE`) with **`CREATE FUNCTION` / `DROP FUNCTION` for scalar SQL UDFs**, following the exact statement → execute → enum-wiring pattern set by `schemas.rs` and `tables.rs`.

- **New `crates/datafusion/src/sql/unity/functions.rs`**
  - `CreateFunctionStatement` / `DropFunctionStatement` + `FunctionParam`, with in-crate `FunctionLanguage` and `SqlDataAccessKind` enums so the host parser carries intent without leaking generated proto enums into the statement API.
  - `execute()` maps SQL clauses to `CreateFunctionRequest` via `client.create_function(...)`: params → `FunctionParameterInfos` (0-based `position`, `mode=IN`, `type=PARAM`, `DEFAULT`/`COMMENT`); `RETURN` body → `routine_definition`; fixed `routine_body=SQL`, `parameter_style=S`, `security_type=DEFINER`. `DROP` maps to `client.function(c,s,f).delete()`.
- **`crates/datafusion/src/sql/unity/mod.rs`** — wires both variants into `UnityCatalogStatement` (`From`, `command_name`, `fmt_for_explain_params` preserving the `name=<...>` Cedar securable contract, `return_schema`, `execute`) and extends the existing contract tests.

### Clause → `FunctionInfo` mapping

| SQL | UC field |
|---|---|
| 3-part name | `name` / `catalog_name` / `schema_name` |
| `RETURNS <type>` | `data_type` + `full_data_type` (SQL text) |
| params | `input_params: FunctionParameterInfos` (pos, `type_text`, default, comment) |
| `RETURN <expr>` | `routine_definition` |
| `LANGUAGE SQL` | `routine_body = SQL` |
| `[NOT] DETERMINISTIC` | `is_deterministic` |
| `CONTAINS SQL` / `READS SQL DATA` | `sql_data_access` |
| `COMMENT` | `comment` |

## Scope / deferred

- **Scalar SQL UDFs only.** `RETURNS TABLE` (UDTFs) and non-SQL languages are rejected with `NotImplemented`.
- `OR REPLACE` / `IF NOT EXISTS` are carried on the struct for the explain/Cedar contract but have no API effect yet (no such fields on the UC `CreateFunction` request).
- **SQL string parsing remains the host application's responsibility**, per the design in `sql/mod.rs`. The host builds these statement structs and wraps them in `ExecuteUnityCatalogPlanNode`, enforces parser edge cases (`OR REPLACE` XOR `IF NOT EXISTS`, trailing-defaults, dollar-quoted bodies), and adds Cedar entries for the new `CreateFunction`/`DropFunction` command names.

## Test plan

- [x] `cargo test -p datafusion-unitycatalog --lib` — 42 passed (new unit + extended contract tests).
- [x] `cargo clippy -p datafusion-unitycatalog` — no warnings in new code.
- [x] `cargo fmt` — new files conformant.
- [ ] Manual end-to-end against a running server (`just rest`): create `cat.sch.add_one(x INT) RETURNS INT RETURN x + 1`, assert `securable_type="Function"` + round-tripped `routine_definition`; then drop and assert `status="success"`.

## Follow-ups

- #200 — support `RETURNS TABLE` (SQL UDTFs)
- #201 — support `LANGUAGE PYTHON` / external functions

AI-assisted by Isaac