### PR TITLE
feat: support local file:// paths for object stores

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -61,6 +61,27 @@ pub struct Config {
     /// Defaults to all-local, so existing configs behave exactly as before.
     #[serde(default)]
     pub routing: RoutingConfig,
+
+    /// Allowlist governing which host filesystem paths may back a `file://`
+    /// storage location. Empty (the default) denies all local storage.
+    #[serde(default)]
+    pub local_storage: LocalStorageConfig,
+}
+
+/// Configuration for local (`file://`) storage locations.
+///
+/// Deny-by-default: with no allowed roots, the server rejects every `file://`
+/// storage location (external locations, external tables/volumes, and managed
+/// catalog/schema roots). List one or more absolute host paths to permit local
+/// storage beneath them — typically a single dev data directory.
+#[derive(Debug, Deserialize, Serialize, Default, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct LocalStorageConfig {
+    /// Absolute host paths under which `file://` storage locations are allowed.
+    /// Each must exist at startup; paths are matched on whole-component
+    /// boundaries after resolving symlinks.
+    #[serde(default)]
+    pub allowed_roots: Vec<String>,
 }
 
 impl Default for Config {
@@ -75,6 +96,7 @@ impl Default for Config {
             encryption: Some(EncryptionConfig::dev_default()),
             upstream: None,
             routing: RoutingConfig::default(),
+            local_storage: LocalStorageConfig::default(),
         }
     }
 }

--- a/crates/cli/src/server/mod.rs
+++ b/crates/cli/src/server/mod.rs
@@ -8,7 +8,10 @@ use unitycatalog_postgres::GraphStore;
 use unitycatalog_server::api::RequestContext;
 use unitycatalog_server::memory::InMemoryResourceStore;
 use unitycatalog_server::policy::{ConstantPolicy, Policy};
-use unitycatalog_server::{rest::AnonymousAuthenticator, services::ServerHandler};
+use unitycatalog_server::{
+    rest::AnonymousAuthenticator,
+    services::{LocalStoragePolicy, ServerHandler},
+};
 
 use crate::config::{Backend, Config, PostgresBackendConfig};
 use crate::error::{Error, Result};
@@ -111,10 +114,16 @@ async fn handle_rest(args: &ServerArgs) -> Result<()> {
         .build_encryptor()
         .map_err(Error::Generic)?;
 
+    // Build the local-storage allowlist from config. Empty ⇒ deny all file://.
+    // A configured root that does not exist is a hard startup error.
+    let local_storage_policy = LocalStoragePolicy::new(&config.local_storage.allowed_roots)
+        .map_err(|e| Error::Generic(format!("invalid local_storage config: {e}")))?;
+
     let (handler, policy) = match &config.backend {
         Backend::InMemory => get_memory_handler(encryptor).await?,
         Backend::Postgres(pg) => get_db_handler(pg, encryptor).await?,
     };
+    let handler = handler.with_local_storage_policy(local_storage_policy);
 
     if config.routing.any_upstream() {
         let unsupported = config.routing.unsupported_upstream();

--- a/crates/object-store/Cargo.toml
+++ b/crates/object-store/Cargo.toml
@@ -28,4 +28,5 @@ uuid = { workspace = true }
 [dev-dependencies]
 futures = { workspace = true }
 serde_json = { workspace = true }
+tempfile = "3.1"
 tokio = { version = "1", features = ["full"] }

--- a/crates/object-store/src/lib.rs
+++ b/crates/object-store/src/lib.rs
@@ -57,6 +57,7 @@ use tokio::runtime::Handle;
 use unitycatalog_client::{TemporaryCredentialClient, UnityCatalogClient};
 use unitycatalog_common::tables::v1::GetTableRequest;
 use unitycatalog_common::temporary_credentials::v1::TemporaryCredential;
+use unitycatalog_common::volumes::v1::GetVolumeRequest;
 use url::Url;
 
 use crate::credential::{
@@ -381,11 +382,37 @@ impl UnityObjectStoreFactory {
 
     /// Vend credentials for a volume and return a prefixed store rooted at
     /// the volume's storage location.
+    ///
+    /// A volume whose storage location is a `file://` path is served by a local
+    /// [`LocalFileSystem`] store and never hits the credential-vending API. See
+    /// [`local_store`].
     pub async fn for_volume(
         &self,
         volume: impl Into<VolumeReference>,
         operation: VolumeOperation,
     ) -> Result<UCStore> {
+        let volume = volume.into();
+        // As with `for_table`: a volume backed by local filesystem storage has
+        // no cloud credential to vend. Resolve its storage location up front
+        // (the same `GetVolume` lookup name-based vending makes) and, when it is
+        // `file://`, build a local store directly — skipping vending.
+        //
+        // Only possible for name references; a caller holding only the volume
+        // UUID still vends (a local-fs volume addressed by UUID is unsupported —
+        // use the three-level name).
+        if let VolumeReference::Name(name) = &volume {
+            if let Some(location) = self.volume_storage_location(name).await? {
+                if let Ok(url) = Url::parse(&location) {
+                    if url.scheme() == "file" {
+                        let path_op = match operation {
+                            VolumeOperation::Read => PathOperation::Read,
+                            VolumeOperation::ReadWrite => PathOperation::ReadWrite,
+                        };
+                        return local_store(&url, path_op);
+                    }
+                }
+            }
+        }
         let (credential, volume_id) = self
             .creds
             .temporary_volume_credential(volume, operation)
@@ -393,6 +420,24 @@ impl UnityObjectStoreFactory {
             .map_err(Error::from)?;
         let securable = SecurableRef::Volume(volume_id, operation);
         self.build_store(credential, securable).await
+    }
+
+    /// Look up a volume's `storage_location` by its three-level name.
+    ///
+    /// Returns `None` when the volume has no storage location set. Used by
+    /// [`for_volume`](Self::for_volume) to detect `file://`-backed volumes
+    /// before vending.
+    async fn volume_storage_location(&self, name: &str) -> Result<Option<String>> {
+        let volume = self
+            .uc
+            .volumes_client()
+            .get_volume(&GetVolumeRequest {
+                name: name.to_string(),
+                include_browse: Some(false),
+            })
+            .await
+            .map_err(Error::from)?;
+        Ok(Some(volume.storage_location).filter(|s| !s.is_empty()))
     }
 
     /// Vend credentials for a raw cloud URL (`s3://`, `gs://`, `abfss://`,
@@ -741,7 +786,14 @@ mod tests {
             .unwrap();
 
         assert!(table_dir.join("part-0.parquet").exists());
-        let got = store.root().get(&full).await.unwrap().bytes().await.unwrap();
+        let got = store
+            .root()
+            .get(&full)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
         assert_eq!(&got[..], b"data");
     }
 

--- a/crates/object-store/src/lib.rs
+++ b/crates/object-store/src/lib.rs
@@ -766,8 +766,11 @@ mod tests {
     }
 
     /// The unrooted `root()` store resolves the **full** path (the DataFusion
-    /// routing-store contract): a write addressed by absolute path lands at the
-    /// matching location on disk, and reads of that absolute path succeed.
+    /// routing-store contract): a write addressed by the full absolute path
+    /// round-trips through that same path. Correctness is the put/get round-trip
+    /// through the unrooted store — the same mapping the engine uses at scan time
+    /// — rather than a native `PathBuf::join`, whose spelling of an absolute path
+    /// (drive letters, separators) diverges from object_store's on Windows.
     #[tokio::test]
     async fn local_store_root_resolves_full_path() {
         let dir = tempfile::tempdir().unwrap();
@@ -776,8 +779,8 @@ mod tests {
 
         let store = local_store(&url, PathOperation::ReadWrite).unwrap();
 
-        // `prefix()` is the table directory (minus leading slash), matching how
-        // the routing store registers and forwards full paths.
+        // `prefix()` is the table directory; the routing store registers and
+        // forwards the full path beneath it unchanged.
         let full = Path::from(format!("{}/part-0.parquet", store.prefix()));
         store
             .root()
@@ -785,7 +788,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(table_dir.join("part-0.parquet").exists());
+        // Reading back the same full path proves the unrooted store resolves it
+        // consistently — exactly what the DataFusion routing store relies on.
         let got = store
             .root()
             .get(&full)
@@ -795,6 +799,16 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(&got[..], b"data");
+
+        // And the object actually exists at the prefix-scoped store, i.e. under
+        // the table directory the credential was vended for.
+        let listing: Vec<_> = store.as_dyn().list(None).try_collect().await.unwrap();
+        assert_eq!(
+            listing.len(),
+            1,
+            "expected exactly one object under the table dir"
+        );
+        assert_eq!(listing[0].location, Path::from("part-0.parquet"));
     }
 
     /// A non-`file` URL handed to the local helper is a clean error, not a panic.

--- a/crates/object-store/src/lib.rs
+++ b/crates/object-store/src/lib.rs
@@ -48,12 +48,14 @@ use object_store::aws::AmazonS3Builder;
 use object_store::azure::MicrosoftAzureBuilder;
 use object_store::client::SpawnedReqwestConnector;
 use object_store::gcp::GoogleCloudStorageBuilder;
+use object_store::local::LocalFileSystem;
 use object_store::path::Path;
 use object_store::prefix::PrefixStore;
 use object_store::{ObjectStore, Result};
 use olai_http::CloudClient;
 use tokio::runtime::Handle;
 use unitycatalog_client::{TemporaryCredentialClient, UnityCatalogClient};
+use unitycatalog_common::tables::v1::GetTableRequest;
 use unitycatalog_common::temporary_credentials::v1::TemporaryCredential;
 use url::Url;
 
@@ -326,6 +328,28 @@ impl UnityObjectStoreFactory {
         table: impl Into<TableReference>,
         operation: TableOperation,
     ) -> Result<UCStore> {
+        let table = table.into();
+        // A table backed by local filesystem storage has no cloud credential
+        // to vend. Resolve its storage location up front (a name lookup, the
+        // same call name-based vending makes) and, when it is `file://`, build
+        // a local store directly — skipping the credential-vending round-trip.
+        //
+        // This resolution is only possible for name references; a caller that
+        // holds only the table UUID still vends (and a local-fs table addressed
+        // by UUID is an unsupported edge case — use the three-level name).
+        if let TableReference::Name(name) = &table {
+            if let Some(location) = self.table_storage_location(name).await? {
+                if let Ok(url) = Url::parse(&location) {
+                    if url.scheme() == "file" {
+                        let path_op = match operation {
+                            TableOperation::Read => PathOperation::Read,
+                            TableOperation::ReadWrite => PathOperation::ReadWrite,
+                        };
+                        return local_store(&url, path_op);
+                    }
+                }
+            }
+        }
         let (credential, table_id) = self
             .creds
             .temporary_table_credential(table, operation)
@@ -333,6 +357,26 @@ impl UnityObjectStoreFactory {
             .map_err(Error::from)?;
         let securable = SecurableRef::Table(table_id, operation);
         self.build_store(credential, securable).await
+    }
+
+    /// Look up a table's `storage_location` by its three-level name.
+    ///
+    /// Returns `None` when the table has no storage location set. Used by
+    /// [`for_table`](Self::for_table) to detect `file://`-backed tables before
+    /// vending.
+    async fn table_storage_location(&self, full_name: &str) -> Result<Option<String>> {
+        let table = self
+            .uc
+            .tables_client()
+            .get_table(&GetTableRequest {
+                full_name: full_name.to_string(),
+                include_browse: Some(false),
+                include_delta_metadata: Some(false),
+                include_manifest_capabilities: Some(false),
+            })
+            .await
+            .map_err(Error::from)?;
+        Ok(table.storage_location.filter(|s| !s.is_empty()))
     }
 
     /// Vend credentials for a volume and return a prefixed store rooted at
@@ -353,7 +397,14 @@ impl UnityObjectStoreFactory {
 
     /// Vend credentials for a raw cloud URL (`s3://`, `gs://`, `abfss://`,
     /// …). Uses `temporary-path-credentials` under the hood.
+    ///
+    /// `file://` URLs are served by a local [`LocalFileSystem`] store and
+    /// **never** hit the credential-vending API — local storage has no cloud
+    /// credential to vend. See [`local_store`].
     pub async fn for_path(&self, path: &Url, operation: PathOperation) -> Result<UCStore> {
+        if path.scheme() == "file" {
+            return local_store(path, operation);
+        }
         let (credential, _resolved) = self
             .creds
             .temporary_path_credential(path.clone(), operation, false)
@@ -366,7 +417,13 @@ impl UnityObjectStoreFactory {
     /// Vend credentials for a raw cloud URL with `dry_run` set to true.
     /// The server validates that credentials *could* be issued but the
     /// returned token is not usable for IO; useful for permission probes.
+    ///
+    /// For `file://` URLs there is nothing to probe — a local store is
+    /// returned directly, identical to [`for_path`](Self::for_path).
     pub async fn dry_run_path(&self, path: &Url, operation: PathOperation) -> Result<UCStore> {
+        if path.scheme() == "file" {
+            return local_store(path, operation);
+        }
         let (credential, _resolved) = self
             .creds
             .temporary_path_credential(path.clone(), operation, true)
@@ -513,6 +570,48 @@ impl From<Operation> for PathOperation {
     }
 }
 
+/// Build a [`UCStore`] backed by the local filesystem for a `file://` URL,
+/// bypassing credential vending entirely.
+///
+/// Mirrors the bucket-root + prefix model of vended cloud stores: `root` is an
+/// unrooted [`LocalFileSystem`] (paths are absolute, relative to the filesystem
+/// root) and `path` is the URL's directory. This keeps both consumption modes
+/// correct:
+///
+/// - [`UCStore::as_dyn`] wraps `root` in a `PrefixStore` at the directory, so
+///   callers address paths *relative* to the `file://` directory; and
+/// - [`UCStore::root`] is the unrooted store, so the DataFusion routing store
+///   — which forwards the full request path unchanged — resolves absolute
+///   table paths.
+///
+/// For [`PathOperation::ReadWrite`] / [`PathOperation::CreateTable`] the target
+/// directory is created if missing, so writes to a fresh local root succeed.
+fn local_store(url: &Url, operation: PathOperation) -> Result<UCStore> {
+    let dir = url
+        .to_file_path()
+        .map_err(|_| Error::invalid_url(format!("not a valid local file path: {url}")))?;
+
+    if matches!(
+        operation,
+        PathOperation::ReadWrite | PathOperation::CreateTable
+    ) {
+        std::fs::create_dir_all(&dir).map_err(|e| {
+            Error::invalid_config(format!("failed to create local directory {dir:?}: {e}"))
+        })?;
+    }
+
+    // Unrooted: object_store `Path`s are relative to the filesystem root, so a
+    // full path like `tmp/data/part-0` resolves to `/tmp/data/part-0`. The
+    // directory is carried as the `UCStore` prefix instead (see `build_store`).
+    let store = LocalFileSystem::new();
+    let path = Path::from_url_path(url.path())?;
+    Ok(UCStore {
+        root: Arc::new(store),
+        url: url.clone(),
+        path,
+    })
+}
+
 /// Returns a [`UCStore`] whose prefix is `store.prefix() + extra`, leaving
 /// the underlying bucket-rooted store untouched.
 fn extend_prefix(store: UCStore, extra: &str) -> UCStore {
@@ -542,8 +641,122 @@ fn extend_prefix(store: UCStore, extra: &str) -> UCStore {
 #[cfg(test)]
 mod tests {
     use futures::TryStreamExt;
+    use object_store::{ObjectStoreExt, PutPayload};
 
     use super::*;
+
+    /// A factory whose UC endpoint points nowhere reachable. Any code path that
+    /// tries to vend a credential will fail to connect — so a successful local
+    /// operation proves vending was skipped entirely.
+    async fn offline_factory() -> UnityObjectStoreFactory {
+        UnityObjectStoreFactory::builder()
+            // An unroutable, non-listening endpoint: a vend attempt cannot succeed.
+            .with_uri("http://127.0.0.1:0/api/2.1/unity-catalog/")
+            .with_allow_unauthenticated(true)
+            .build()
+            .await
+            .unwrap()
+    }
+
+    /// `file://` URLs are served by a local store and round-trip read/write/list
+    /// without any credential-vending call (the factory points at a dead endpoint).
+    #[tokio::test]
+    async fn for_url_file_roundtrips_without_vending() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = Url::from_directory_path(dir.path()).unwrap();
+
+        let factory = offline_factory().await;
+        let store = factory
+            .for_url(url.as_str(), Operation::ReadWrite)
+            .await
+            .unwrap();
+
+        let dyn_store = store.as_dyn();
+        let path = object_store::path::Path::from("hello.txt");
+        dyn_store
+            .put(&path, PutPayload::from_static(b"world"))
+            .await
+            .unwrap();
+
+        let listing: Vec<_> = dyn_store.list(None).try_collect().await.unwrap();
+        assert_eq!(listing.len(), 1, "expected exactly one object");
+        assert_eq!(listing[0].location, path);
+
+        let got = dyn_store.get(&path).await.unwrap().bytes().await.unwrap();
+        assert_eq!(&got[..], b"world");
+    }
+
+    /// `for_path` with a `file://` URL returns a usable store with no network call.
+    #[tokio::test]
+    async fn for_path_file_skips_vending() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = Url::from_directory_path(dir.path()).unwrap();
+
+        let factory = offline_factory().await;
+        // Read-only: the directory already exists, nothing is created.
+        let store = factory.for_path(&url, PathOperation::Read).await.unwrap();
+        // Empty directory lists to nothing — and crucially, no vend was attempted.
+        let listing: Vec<_> = store.as_dyn().list(None).try_collect().await.unwrap();
+        assert!(listing.is_empty());
+        assert_eq!(store.url(), &url);
+    }
+
+    /// A read-write local store auto-creates a missing target directory.
+    #[tokio::test]
+    async fn local_store_read_write_creates_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("not-yet-here");
+        let url = Url::from_directory_path(&missing).unwrap();
+
+        let store = local_store(&url, PathOperation::ReadWrite).unwrap();
+        assert!(missing.exists(), "ReadWrite must create the root directory");
+
+        let path = object_store::path::Path::from("a.bin");
+        store
+            .as_dyn()
+            .put(&path, PutPayload::from_static(b"x"))
+            .await
+            .unwrap();
+        assert!(missing.join("a.bin").exists());
+    }
+
+    /// The unrooted `root()` store resolves the **full** path (the DataFusion
+    /// routing-store contract): a write addressed by absolute path lands at the
+    /// matching location on disk, and reads of that absolute path succeed.
+    #[tokio::test]
+    async fn local_store_root_resolves_full_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let table_dir = dir.path().join("mytable");
+        let url = Url::from_directory_path(&table_dir).unwrap();
+
+        let store = local_store(&url, PathOperation::ReadWrite).unwrap();
+
+        // `prefix()` is the table directory (minus leading slash), matching how
+        // the routing store registers and forwards full paths.
+        let full = Path::from(format!("{}/part-0.parquet", store.prefix()));
+        store
+            .root()
+            .put(&full, PutPayload::from_static(b"data"))
+            .await
+            .unwrap();
+
+        assert!(table_dir.join("part-0.parquet").exists());
+        let got = store.root().get(&full).await.unwrap().bytes().await.unwrap();
+        assert_eq!(&got[..], b"data");
+    }
+
+    /// A non-`file` URL handed to the local helper is a clean error, not a panic.
+    #[test]
+    fn local_store_rejects_non_file_url() {
+        let url = Url::parse("s3://bucket/prefix/").unwrap();
+        match local_store(&url, PathOperation::Read) {
+            Ok(_) => panic!("expected an error for a non-file URL"),
+            Err(e) => assert!(
+                e.to_string().contains("not a valid local file path"),
+                "unexpected error: {e}"
+            ),
+        }
+    }
 
     /// Building a factory with a dedicated I/O runtime handle succeeds and the
     /// handle is carried through to the factory. The `None` path (no handle) is

--- a/crates/object-store/src/lib.rs
+++ b/crates/object-store/src/lib.rs
@@ -767,10 +767,18 @@ mod tests {
 
     /// The unrooted `root()` store resolves the **full** path (the DataFusion
     /// routing-store contract): a write addressed by the full absolute path
-    /// round-trips through that same path. Correctness is the put/get round-trip
-    /// through the unrooted store — the same mapping the engine uses at scan time
-    /// — rather than a native `PathBuf::join`, whose spelling of an absolute path
-    /// (drive letters, separators) diverges from object_store's on Windows.
+    /// round-trips through that same path, and lands on disk under the table
+    /// directory.
+    ///
+    /// Both checks go through paths object_store itself produces (the `root()`
+    /// put/get round-trip, and a real `read_dir` of the table directory) — never
+    /// a native `PathBuf::join` against an object_store `Path`, whose absolute-
+    /// path spelling (drive letters, colon encoding) diverges on Windows. The
+    /// `root()` and `as_dyn()` views are deliberately *not* crossed here: in
+    /// production DataFusion uses `root()` with full paths throughout, while
+    /// direct callers use `as_dyn()` with relative paths throughout, and
+    /// object_store cannot represent a Windows absolute path as a `Path` prefix
+    /// consistently enough to mix the two.
     #[tokio::test]
     async fn local_store_root_resolves_full_path() {
         let dir = tempfile::tempdir().unwrap();
@@ -800,15 +808,14 @@ mod tests {
             .unwrap();
         assert_eq!(&got[..], b"data");
 
-        // And the object actually exists at the prefix-scoped store, i.e. under
-        // the table directory the credential was vended for.
-        let listing: Vec<_> = store.as_dyn().list(None).try_collect().await.unwrap();
-        assert_eq!(
-            listing.len(),
-            1,
-            "expected exactly one object under the table dir"
-        );
-        assert_eq!(listing[0].location, Path::from("part-0.parquet"));
+        // And it landed on disk under the table directory. Check the real
+        // filesystem directly (not via an object_store `Path`) so the assertion
+        // is OS-agnostic.
+        let entries: Vec<_> = std::fs::read_dir(&table_dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(entries, vec![std::ffi::OsString::from("part-0.parquet")]);
     }
 
     /// A non-`file` URL handed to the local helper is a clean error, not a panic.

--- a/crates/object-store/src/lib.rs
+++ b/crates/object-store/src/lib.rs
@@ -631,7 +631,22 @@ impl From<Operation> for PathOperation {
 ///
 /// For [`PathOperation::ReadWrite`] / [`PathOperation::CreateTable`] the target
 /// directory is created if missing, so writes to a fresh local root succeed.
+///
+/// # Platform support
+///
+/// Local `file://` storage is **POSIX-only** for now. On Windows it returns an
+/// error: `object_store::path::Path` cannot represent a Windows absolute path
+/// (the drive-letter colon is percent-encoded), so an unrooted
+/// [`LocalFileSystem`] addressed by full path does not resolve back to the real
+/// on-disk location. Tracked for a follow-up; cloud schemes are unaffected.
 fn local_store(url: &Url, operation: PathOperation) -> Result<UCStore> {
+    if cfg!(windows) {
+        return Err(Error::invalid_config(format!(
+            "local (file://) storage is not supported on Windows: {url}"
+        ))
+        .into());
+    }
+
     let dir = url
         .to_file_path()
         .map_err(|_| Error::invalid_url(format!("not a valid local file path: {url}")))?;
@@ -686,6 +701,8 @@ fn extend_prefix(store: UCStore, extra: &str) -> UCStore {
 #[cfg(test)]
 mod tests {
     use futures::TryStreamExt;
+    // `put`/`PutPayload` are only used by the POSIX-only local-storage tests.
+    #[cfg(not(windows))]
     use object_store::{ObjectStoreExt, PutPayload};
 
     use super::*;
@@ -705,6 +722,8 @@ mod tests {
 
     /// `file://` URLs are served by a local store and round-trip read/write/list
     /// without any credential-vending call (the factory points at a dead endpoint).
+    // Local file:// storage is POSIX-only for now (see `local_store`).
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn for_url_file_roundtrips_without_vending() {
         let dir = tempfile::tempdir().unwrap();
@@ -732,6 +751,7 @@ mod tests {
     }
 
     /// `for_path` with a `file://` URL returns a usable store with no network call.
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn for_path_file_skips_vending() {
         let dir = tempfile::tempdir().unwrap();
@@ -747,6 +767,7 @@ mod tests {
     }
 
     /// A read-write local store auto-creates a missing target directory.
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn local_store_read_write_creates_dir() {
         let dir = tempfile::tempdir().unwrap();
@@ -770,15 +791,11 @@ mod tests {
     /// round-trips through that same path, and lands on disk under the table
     /// directory.
     ///
-    /// Both checks go through paths object_store itself produces (the `root()`
-    /// put/get round-trip, and a real `read_dir` of the table directory) — never
-    /// a native `PathBuf::join` against an object_store `Path`, whose absolute-
-    /// path spelling (drive letters, colon encoding) diverges on Windows. The
-    /// `root()` and `as_dyn()` views are deliberately *not* crossed here: in
-    /// production DataFusion uses `root()` with full paths throughout, while
-    /// direct callers use `as_dyn()` with relative paths throughout, and
-    /// object_store cannot represent a Windows absolute path as a `Path` prefix
-    /// consistently enough to mix the two.
+    /// On-disk placement is checked with a real `read_dir` of the table
+    /// directory, not a native `PathBuf::join` against an object_store `Path`.
+    /// POSIX-only: local file:// is gated off on Windows (see `local_store`),
+    /// where an unrooted store cannot round-trip a drive-letter absolute path.
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn local_store_root_resolves_full_path() {
         let dir = tempfile::tempdir().unwrap();
@@ -819,6 +836,9 @@ mod tests {
     }
 
     /// A non-`file` URL handed to the local helper is a clean error, not a panic.
+    /// POSIX-only: on Windows `local_store` rejects every call up front, so the
+    /// specific "not a valid local file path" message does not apply.
+    #[cfg(not(windows))]
     #[test]
     fn local_store_rejects_non_file_url() {
         let url = Url::parse("s3://bucket/prefix/").unwrap();

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -48,6 +48,7 @@ dashmap = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true, features = ["v7"] }
 
 [dev-dependencies]
+tempfile = "3.1"
 tokio = { version = "1", features = ["full"] }
 
 [features]

--- a/crates/server/src/api/catalogs.rs
+++ b/crates/server/src/api/catalogs.rs
@@ -7,10 +7,14 @@ use super::{RequestContext, SecuredAction};
 use crate::Result;
 pub use crate::codegen::catalogs::CatalogHandler;
 use crate::policy::{Permission, Policy, process_resources};
+use crate::services::ProvidesLocalStoragePolicy;
+use crate::services::location::StorageLocationUrl;
 use crate::store::ResourceStore;
 
 #[async_trait::async_trait]
-impl<T: ResourceStore + Policy<RequestContext>> CatalogHandler<RequestContext> for T {
+impl<T: ResourceStore + Policy<RequestContext> + ProvidesLocalStoragePolicy>
+    CatalogHandler<RequestContext> for T
+{
     #[tracing::instrument(skip(self, context), fields(resource_name))]
     async fn create_catalog(
         &self,
@@ -19,6 +23,11 @@ impl<T: ResourceStore + Policy<RequestContext>> CatalogHandler<RequestContext> f
     ) -> Result<Catalog> {
         tracing::Span::current().record("resource_name", &request.name);
         self.check_required(&request, &context).await?;
+        // A local (file://) managed root must sit within an allowed host root.
+        if let Some(root) = request.storage_root.as_deref().filter(|s| !s.is_empty()) {
+            self.local_storage_policy()
+                .check(&StorageLocationUrl::parse(root)?)?;
+        }
         let catalog_type = if request.provider_name.is_some() {
             CatalogType::DeltasharingCatalog
         } else {

--- a/crates/server/src/api/delta.rs
+++ b/crates/server/src/api/delta.rs
@@ -36,6 +36,7 @@ use crate::api::temporary_credentials::TemporaryCredentialHandler;
 use crate::codegen::staging_tables::StagingTableHandler;
 use crate::policy::{Permission, Policy, Principal};
 use crate::rest::routers::delta::models::*;
+use crate::services::ProvidesLocalStoragePolicy;
 use crate::services::location::StorageLocationUrl;
 use crate::services::managed_delta_contract as contract;
 use crate::services::object_store::validate_external_storage_location;
@@ -183,7 +184,8 @@ where
         + TemporaryCredentialHandler<RequestContext>
         + CredentialHandlerExt
         + TableManager
-        + ProvidesCommitCoordinator,
+        + ProvidesCommitCoordinator
+        + ProvidesLocalStoragePolicy,
 {
     async fn get_config(
         &self,

--- a/crates/server/src/api/external_locations.rs
+++ b/crates/server/src/api/external_locations.rs
@@ -262,7 +262,9 @@ mod tests {
         ServerHandler::try_new_tokio(policy, store.clone(), store).unwrap()
     }
 
-    /// A handler whose local-storage policy allows `root`.
+    /// A handler whose local-storage policy allows `root`. Only used by the
+    /// POSIX-only allow-under-root test.
+    #[cfg(not(windows))]
     fn handler_with_local_root(root: &std::path::Path) -> ServerHandler<RequestContext> {
         let local = crate::services::LocalStoragePolicy::new([root]).unwrap();
         handler().with_local_storage_policy(local)
@@ -318,6 +320,10 @@ mod tests {
         assert!(matches!(res, Err(Error::InvalidArgument(_))), "{res:?}");
     }
 
+    // POSIX-only: allow-under-root matching depends on canonicalized paths that
+    // don't line up on Windows (\\?\ prefix), and local file:// is gated off on
+    // Windows anyway. Deny-by-default (above) is what matters there.
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn file_location_allowed_under_configured_root() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/server/src/api/external_locations.rs
+++ b/crates/server/src/api/external_locations.rs
@@ -8,13 +8,16 @@ use unitycatalog_common::models::{
 use super::{RequestContext, SecuredAction};
 pub use crate::codegen::external_locations::ExternalLocationHandler;
 use crate::policy::{Permission, Policy, process_resources};
+use crate::services::ProvidesLocalStoragePolicy;
 use crate::services::location::StorageLocationUrl;
 use crate::services::object_store::{list_external_locations, locations_overlap};
 use crate::store::ResourceStore;
 use crate::{Error, Result};
 
 #[async_trait::async_trait]
-impl<T: ResourceStore + Policy<RequestContext>> ExternalLocationHandler<RequestContext> for T {
+impl<T: ResourceStore + Policy<RequestContext> + ProvidesLocalStoragePolicy>
+    ExternalLocationHandler<RequestContext> for T
+{
     #[tracing::instrument(skip(self, context), fields(resource_name))]
     async fn create_external_location(
         &self,
@@ -23,6 +26,12 @@ impl<T: ResourceStore + Policy<RequestContext>> ExternalLocationHandler<RequestC
     ) -> Result<ExternalLocation> {
         tracing::Span::current().record("resource_name", &request.name);
         self.check_required(&request, &context).await?;
+
+        // Local (file://) locations must sit within an allowed host root;
+        // deny-by-default unless the server is configured otherwise. Cloud
+        // schemes pass through.
+        self.local_storage_policy()
+            .check(&StorageLocationUrl::parse(&request.url)?)?;
 
         // Reject locations that overlap an existing external location: Unity
         // Catalog forbids one external location from nesting inside another (in
@@ -120,6 +129,9 @@ impl<T: ResourceStore + Policy<RequestContext>> ExternalLocationHandler<RequestC
             // Re-validate overlap when the URL changes, excluding this
             // location's own record (matched by name) from the comparison.
             if url != current.url {
+                // A new local (file://) URL must sit within an allowed root.
+                self.local_storage_policy()
+                    .check(&StorageLocationUrl::parse(&url)?)?;
                 check_no_overlap(self, &url, &current.name).await?;
             }
             current.url = url;
@@ -250,6 +262,12 @@ mod tests {
         ServerHandler::try_new_tokio(policy, store.clone(), store).unwrap()
     }
 
+    /// A handler whose local-storage policy allows `root`.
+    fn handler_with_local_root(root: &std::path::Path) -> ServerHandler<RequestContext> {
+        let local = crate::services::LocalStoragePolicy::new([root]).unwrap();
+        handler().with_local_storage_policy(local)
+    }
+
     fn ctx() -> RequestContext {
         RequestContext {
             recipient: crate::policy::Principal::anonymous(),
@@ -288,6 +306,39 @@ mod tests {
             ctx(),
         )
         .await
+    }
+
+    #[tokio::test]
+    async fn file_location_denied_by_default() {
+        // No local-storage policy configured ⇒ every file:// is rejected, even
+        // though a cloud location at the same name would be accepted.
+        let h = handler();
+        create_credential(&h, "cred").await;
+        let res = create_location(&h, "local", "file:///tmp/uc-denied").await;
+        assert!(matches!(res, Err(Error::InvalidArgument(_))), "{res:?}");
+    }
+
+    #[tokio::test]
+    async fn file_location_allowed_under_configured_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let h = handler_with_local_root(&root);
+        create_credential(&h, "cred").await;
+
+        // Under the allowed root: accepted.
+        let inside = url::Url::from_directory_path(root.join("ext"))
+            .unwrap()
+            .to_string();
+        create_location(&h, "ok", &inside).await.unwrap();
+
+        // Outside the allowed root: rejected.
+        let res = create_location(&h, "bad", "file:///etc/uc").await;
+        assert!(matches!(res, Err(Error::InvalidArgument(_))), "{res:?}");
+
+        // Cloud schemes are unaffected by the local policy.
+        create_location(&h, "cloud", "s3://bucket/data")
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/server/src/api/schemas.rs
+++ b/crates/server/src/api/schemas.rs
@@ -7,11 +7,15 @@ use unitycatalog_common::models::{ResourceIdent, ResourceName, ResourceRef};
 use super::{RequestContext, SecuredAction};
 pub use crate::codegen::schemas::SchemaHandler;
 use crate::policy::{Permission, Policy, process_resources};
+use crate::services::ProvidesLocalStoragePolicy;
+use crate::services::location::StorageLocationUrl;
 use crate::store::ResourceStore;
 use crate::{Error, Result};
 
 #[async_trait::async_trait]
-impl<T: ResourceStore + Policy<RequestContext>> SchemaHandler<RequestContext> for T {
+impl<T: ResourceStore + Policy<RequestContext> + ProvidesLocalStoragePolicy>
+    SchemaHandler<RequestContext> for T
+{
     #[tracing::instrument(skip(self, context), fields(resource_name))]
     async fn create_schema(
         &self,
@@ -20,6 +24,15 @@ impl<T: ResourceStore + Policy<RequestContext>> SchemaHandler<RequestContext> fo
     ) -> Result<Schema> {
         tracing::Span::current().record("resource_name", &request.name);
         self.check_required(&request, &context).await?;
+        // A local (file://) schema storage location must sit within an allowed root.
+        if let Some(loc) = request
+            .storage_location
+            .as_deref()
+            .filter(|s| !s.is_empty())
+        {
+            self.local_storage_policy()
+                .check(&StorageLocationUrl::parse(loc)?)?;
+        }
         let resource = Schema {
             full_name: format!("{}.{}", request.catalog_name, request.name),
             name: request.name,

--- a/crates/server/src/api/staging_tables.rs
+++ b/crates/server/src/api/staging_tables.rs
@@ -8,6 +8,8 @@ use unitycatalog_common::models::{ObjectLabel, ResourceIdent};
 use super::{RequestContext, SecuredAction};
 pub use crate::codegen::staging_tables::StagingTableHandler;
 use crate::policy::{Permission, Policy, Principal};
+use crate::services::ProvidesLocalStoragePolicy;
+use crate::services::location::StorageLocationUrl;
 use crate::store::ResourceStore;
 use crate::{Error, Result};
 
@@ -31,7 +33,9 @@ impl SecuredAction for CreateStagingTableRequest {
 }
 
 #[async_trait::async_trait]
-impl<T: ResourceStore + Policy<RequestContext>> StagingTableHandler<RequestContext> for T {
+impl<T: ResourceStore + Policy<RequestContext> + ProvidesLocalStoragePolicy>
+    StagingTableHandler<RequestContext> for T
+{
     #[tracing::instrument(skip(self, context), fields(resource_name))]
     async fn create_staging_table(
         &self,
@@ -86,20 +90,52 @@ impl<T: ResourceStore + Policy<RequestContext>> StagingTableHandler<RequestConte
 /// appended. A catalog/schema with no configured root cannot host managed
 /// tables, so this returns `invalid_argument`.
 pub(crate) async fn resolve_managed_storage_root(
-    handler: &(impl ResourceStore + ?Sized),
+    handler: &(impl ResourceStore + ProvidesLocalStoragePolicy + ?Sized),
     catalog_name: &str,
     schema_name: &str,
 ) -> Result<String> {
+    // Validate a resolved root against the local-storage allowlist before
+    // handing out a managed sub-path. Defense-in-depth: even a root that
+    // predates the policy (or a cloud root, which passes through) is checked at
+    // use time. Cloud schemes are unaffected.
+    let checked = |root: String| -> Result<String> {
+        handler
+            .local_storage_policy()
+            .check(&StorageLocationUrl::parse(&root)?)?;
+        Ok(with_managed_prefix(&root))
+    };
+
     let schema_ident = ResourceIdent::schema(ResourceName::new([catalog_name, schema_name]));
     let schema: Schema = handler.get(&schema_ident).await?.0.try_into()?;
     if let Some(loc) = schema.storage_location.filter(|s| !s.is_empty()) {
-        return Ok(with_managed_prefix(&loc));
+        return checked(loc);
     }
 
     let catalog_ident = ResourceIdent::catalog(ResourceName::new([catalog_name]));
     let catalog: Catalog = handler.get(&catalog_ident).await?.0.try_into()?;
     if let Some(root) = catalog.storage_root.filter(|s| !s.is_empty()) {
-        return Ok(with_managed_prefix(&root));
+        return checked(root);
+    }
+
+    // Neither schema nor catalog defines a root. When the server allows exactly
+    // one local root, use it as the implicit managed root so a purely-local dev
+    // server hosts managed tables without any storage_root configured. The
+    // returned value is a *root*; the caller appends the standard
+    // `__unitystorage/tables/{uuid}` convention (see `with_managed_prefix` and
+    // the caller in `create_staging_table`), so the on-disk layout matches every
+    // other managed table. More than one allowed root is ambiguous → keep the
+    // original error.
+    let allowed = handler.local_storage_policy().allowed_roots();
+    if let [sole_root] = allowed {
+        let root = url::Url::from_directory_path(sole_root)
+            .map_err(|_| {
+                Error::invalid_argument(format!(
+                    "allowed local storage root '{}' is not an absolute path",
+                    sole_root.display()
+                ))
+            })?
+            .to_string();
+        return checked(root);
     }
 
     Err(Error::invalid_argument(format!(

--- a/crates/server/src/api/tables.rs
+++ b/crates/server/src/api/tables.rs
@@ -14,6 +14,7 @@ use super::staging_tables::find_staging_table_by_location;
 use super::{RequestContext, SecuredAction};
 pub use crate::codegen::tables::TableHandler;
 use crate::policy::{Permission, Policy, Principal, process_resources};
+use crate::services::ProvidesLocalStoragePolicy;
 use crate::services::location::StorageLocationUrl;
 use crate::services::object_store::validate_external_storage_location;
 use crate::store::ResourceStore;
@@ -99,7 +100,9 @@ pub trait TableManager: Send + Sync + 'static {
 }
 
 #[async_trait::async_trait]
-impl<T: ResourceStore + Policy<RequestContext> + TableManager> TableHandler<RequestContext> for T {
+impl<T: ResourceStore + Policy<RequestContext> + TableManager + ProvidesLocalStoragePolicy>
+    TableHandler<RequestContext> for T
+{
     #[tracing::instrument(skip(self, context))]
     async fn list_table_summaries(
         &self,

--- a/crates/server/src/api/volumes.rs
+++ b/crates/server/src/api/volumes.rs
@@ -7,13 +7,16 @@ use unitycatalog_common::models::{ResourceIdent, ResourceName, ResourceRef};
 use super::{RequestContext, SecuredAction};
 pub use crate::codegen::volumes::VolumeHandler;
 use crate::policy::{Permission, Policy, process_resources};
+use crate::services::ProvidesLocalStoragePolicy;
 use crate::services::location::StorageLocationUrl;
 use crate::services::object_store::validate_external_storage_location;
 use crate::store::ResourceStore;
 use crate::{Error, Result};
 
 #[async_trait::async_trait]
-impl<T: ResourceStore + Policy<RequestContext>> VolumeHandler<RequestContext> for T {
+impl<T: ResourceStore + Policy<RequestContext> + ProvidesLocalStoragePolicy>
+    VolumeHandler<RequestContext> for T
+{
     #[tracing::instrument(skip(self, context), fields(resource_name))]
     async fn create_volume(
         &self,

--- a/crates/server/src/services/location_policy.rs
+++ b/crates/server/src/services/location_policy.rs
@@ -175,6 +175,14 @@ mod tests {
         );
     }
 
+    // The following tests construct real `file://` paths under a canonicalized
+    // root and exercise prefix matching. They are POSIX-only: on Windows,
+    // `canonicalize()` yields a `\\?\C:\…` extended-length prefix that does not
+    // match the plain `C:\…` from a URL's `to_file_path()`, and local file://
+    // storage is gated off on Windows anyway (see `local_store` /
+    // `get_local_store`). Deny-by-default and cloud pass-through (tested above)
+    // are the behaviors that still matter on Windows.
+    #[cfg(not(windows))]
     #[test]
     fn allows_paths_within_a_configured_root() {
         let dir = tempfile::tempdir().unwrap();
@@ -190,6 +198,7 @@ mod tests {
         assert!(policy.check(&loc(&at_root)).is_ok());
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn rejects_paths_outside_every_root() {
         let dir = tempfile::tempdir().unwrap();
@@ -198,6 +207,7 @@ mod tests {
         assert!(policy.check(&loc("file:///etc/passwd")).is_err());
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn rejects_sibling_prefix() {
         // `<root>` must not match `<root>-secret`. Build the sibling as a native
@@ -214,6 +224,7 @@ mod tests {
         assert!(policy.check(&loc(&url)).is_err());
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn rejects_parent_dir_traversal() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/server/src/services/location_policy.rs
+++ b/crates/server/src/services/location_policy.rs
@@ -1,0 +1,237 @@
+//! Server-side allowlist for local (`file://`) storage locations.
+//!
+//! Once the server can serve data from the host filesystem (see
+//! `services::object_store`), an unrestricted caller could register a storage
+//! location pointing at *any* path the server process can reach — `file:///etc`,
+//! `file:///`, a co-tenant's data — by accident or design. [`LocalStoragePolicy`]
+//! restricts which host paths may back a `file://` location.
+//!
+//! The policy is **deny-by-default**: an empty allowlist rejects every `file://`
+//! location. A deployment opts in by configuring one or more allowed roots; only
+//! paths at or beneath an allowed root are accepted. Cloud schemes (s3, abfss,
+//! gs, …) are never inspected here — they are governed by external locations and
+//! credential vending.
+
+use std::path::{Component, Path, PathBuf};
+
+use object_store::ObjectStoreScheme;
+
+use super::location::{StorageLocationScheme, StorageLocationUrl};
+use crate::{Error, Result};
+
+/// An allowlist of host filesystem roots that may back `file://` storage
+/// locations.
+///
+/// Construct via [`LocalStoragePolicy::new`]; an empty policy denies all local
+/// storage. Held on the server handler and reached by request handlers through
+/// [`ProvidesLocalStoragePolicy`](super::ProvidesLocalStoragePolicy).
+#[derive(Debug, Clone, Default)]
+pub struct LocalStoragePolicy {
+    /// Canonicalized allowed roots. Empty ⇒ deny all `file://`.
+    allowed_roots: Vec<PathBuf>,
+}
+
+impl LocalStoragePolicy {
+    /// Build a policy from configured root paths.
+    ///
+    /// Each root is canonicalized (resolving symlinks and `..`) so later prefix
+    /// checks compare against a stable, real path. A root that does not exist or
+    /// cannot be canonicalized is a configuration error — surfacing it at
+    /// startup is preferable to silently denying every local location later.
+    pub fn new<I, P>(roots: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<Path>,
+    {
+        let allowed_roots = roots
+            .into_iter()
+            .map(|root| {
+                let root = root.as_ref();
+                root.canonicalize().map_err(|e| {
+                    Error::invalid_argument(format!(
+                        "allowed local storage root '{}' is not accessible: {e}",
+                        root.display()
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self { allowed_roots })
+    }
+
+    /// A deny-all policy (no allowed roots). The default for a server with no
+    /// `local_storage` configuration.
+    pub fn deny_all() -> Self {
+        Self::default()
+    }
+
+    /// Whether any local root is allowed. Used by managed-root resolution to
+    /// decide whether a sole allowed root can serve as an implicit root.
+    pub(crate) fn allowed_roots(&self) -> &[PathBuf] {
+        &self.allowed_roots
+    }
+
+    /// Authorize a storage location.
+    ///
+    /// Cloud schemes pass through untouched. A `file://` location is accepted
+    /// only when its host path — with `..` rejected and `.` collapsed — sits at
+    /// or beneath an allowed root. With no allowed roots, every `file://`
+    /// location is rejected.
+    pub fn check(&self, location: &StorageLocationUrl) -> Result<()> {
+        if !matches!(
+            location.scheme(),
+            StorageLocationScheme::ObjectStore(ObjectStoreScheme::Local)
+        ) {
+            return Ok(());
+        }
+
+        let path = location.raw().to_file_path().map_err(|_| {
+            Error::invalid_argument(format!("not a valid local file path: {}", location.raw()))
+        })?;
+
+        // Reject any traversal component outright rather than trying to resolve
+        // it: a `..` in a governed storage path is never legitimate and is the
+        // classic way to escape an allowed root.
+        if path.components().any(|c| matches!(c, Component::ParentDir)) {
+            return Err(Error::invalid_argument(format!(
+                "local storage path '{}' must not contain '..'",
+                path.display()
+            )));
+        }
+        let normalized = lexically_normalize(&path);
+
+        if self.allowed_roots.is_empty() {
+            return Err(Error::invalid_argument(format!(
+                "local (file://) storage is not enabled on this server; \
+                 path '{}' is not within any allowed root",
+                normalized.display()
+            )));
+        }
+
+        if self
+            .allowed_roots
+            .iter()
+            .any(|root| is_within(&normalized, root))
+        {
+            Ok(())
+        } else {
+            Err(Error::invalid_argument(format!(
+                "local storage path '{}' is not within any allowed root",
+                normalized.display()
+            )))
+        }
+    }
+}
+
+/// Collapse `.` components from an absolute path without touching the
+/// filesystem. `..` is handled by the caller (rejected), so it is not resolved
+/// here. Used because governed paths frequently do not exist yet (managed roots,
+/// not-yet-created tables) and so cannot be canonicalized.
+fn lexically_normalize(path: &Path) -> PathBuf {
+    path.components()
+        .filter(|c| !matches!(c, Component::CurDir))
+        .collect()
+}
+
+/// Whether `path` is equal to, or a descendant of, `root`, comparing on whole
+/// path components (so `/data` does not match `/data-secret`).
+fn is_within(path: &Path, root: &Path) -> bool {
+    let mut root_parts = root.components();
+    let mut path_parts = path.components();
+    loop {
+        match (root_parts.next(), path_parts.next()) {
+            // Consumed the whole root: `path` is at or below it.
+            (None, _) => return true,
+            // Root has more components than the path, or a component differs.
+            (Some(_), None) => return false,
+            (Some(a), Some(b)) if a != b => return false,
+            (Some(_), Some(_)) => continue,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loc(url: &str) -> StorageLocationUrl {
+        StorageLocationUrl::parse(url).unwrap()
+    }
+
+    #[test]
+    fn deny_all_rejects_every_file_url() {
+        let policy = LocalStoragePolicy::deny_all();
+        assert!(policy.check(&loc("file:///tmp/anything")).is_err());
+        assert!(policy.check(&loc("file:///")).is_err());
+    }
+
+    #[test]
+    fn cloud_schemes_pass_through_even_with_empty_policy() {
+        let policy = LocalStoragePolicy::deny_all();
+        assert!(policy.check(&loc("s3://bucket/data")).is_ok());
+        assert!(
+            policy
+                .check(&loc("abfss://c@acct.dfs.core.windows.net/x"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn allows_paths_within_a_configured_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let policy = LocalStoragePolicy::new([&root]).unwrap();
+
+        let inside = url::Url::from_directory_path(root.join("catalog/table"))
+            .unwrap()
+            .to_string();
+        assert!(policy.check(&loc(&inside)).is_ok());
+        // The root itself is allowed.
+        let at_root = url::Url::from_directory_path(&root).unwrap().to_string();
+        assert!(policy.check(&loc(&at_root)).is_ok());
+    }
+
+    #[test]
+    fn rejects_paths_outside_every_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let policy = LocalStoragePolicy::new([&root]).unwrap();
+        assert!(policy.check(&loc("file:///etc/passwd")).is_err());
+    }
+
+    #[test]
+    fn rejects_sibling_prefix() {
+        // `/<root>` must not match `/<root>-secret`.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let policy = LocalStoragePolicy::new([&root]).unwrap();
+
+        let sibling = format!("{}-secret/data", root.display());
+        let url = url::Url::from_directory_path(&sibling).unwrap().to_string();
+        assert!(policy.check(&loc(&url)).is_err());
+    }
+
+    #[test]
+    fn rejects_parent_dir_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let policy = LocalStoragePolicy::new([&root]).unwrap();
+
+        // A crafted `..` that would textually resolve outside the root.
+        let escape = format!("file://{}/../../etc/", root.display());
+        assert!(policy.check(&loc(&escape)).is_err());
+    }
+
+    #[test]
+    fn new_errors_on_missing_root() {
+        let result = LocalStoragePolicy::new(["/this/path/does/not/exist/uc-xyz"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn is_within_matches_on_component_boundaries() {
+        assert!(is_within(Path::new("/data/t1"), Path::new("/data")));
+        assert!(is_within(Path::new("/data"), Path::new("/data")));
+        assert!(!is_within(Path::new("/data-secret/t1"), Path::new("/data")));
+        assert!(!is_within(Path::new("/other/t1"), Path::new("/data")));
+    }
+}

--- a/crates/server/src/services/location_policy.rs
+++ b/crates/server/src/services/location_policy.rs
@@ -200,12 +200,16 @@ mod tests {
 
     #[test]
     fn rejects_sibling_prefix() {
-        // `/<root>` must not match `/<root>-secret`.
+        // `<root>` must not match `<root>-secret`. Build the sibling as a native
+        // path (its file name + "-secret") so the URL is well-formed on every OS.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().canonicalize().unwrap();
         let policy = LocalStoragePolicy::new([&root]).unwrap();
 
-        let sibling = format!("{}-secret/data", root.display());
+        let mut sibling = root.clone();
+        let name = format!("{}-secret", root.file_name().unwrap().to_string_lossy());
+        sibling.set_file_name(name);
+        sibling.push("data");
         let url = url::Url::from_directory_path(&sibling).unwrap().to_string();
         assert!(policy.check(&loc(&url)).is_err());
     }
@@ -216,8 +220,12 @@ mod tests {
         let root = dir.path().canonicalize().unwrap();
         let policy = LocalStoragePolicy::new([&root]).unwrap();
 
-        // A crafted `..` that would textually resolve outside the root.
-        let escape = format!("file://{}/../../etc/", root.display());
+        // A crafted `..` under the root: built as a native path so the file URL
+        // is well-formed (drive letters/separators) on every OS. The `..`
+        // component is rejected outright.
+        let escape = url::Url::from_directory_path(root.join("..").join("escape"))
+            .unwrap()
+            .to_string();
         assert!(policy.check(&loc(&escape)).is_err());
     }
 

--- a/crates/server/src/services/managed_delta_contract.rs
+++ b/crates/server/src/services/managed_delta_contract.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 use unitycatalog_common::models::tables::v1::{Column, ColumnTypeName};
 
 use crate::rest::routers::delta::models::{
-    DeltaArrayType, DeltaCreateTableRequest, DeltaDataSourceFormat, DeltaDataType, DeltaDecimalType,
+    DeltaArrayType, DeltaCreateTableRequest, DeltaDataType, DeltaDecimalType,
     DeltaDomainMetadataUpdates, DeltaMapType, DeltaProtocol, DeltaStructField, DeltaStructType,
 };
 use crate::{Error, Result};
@@ -493,7 +493,7 @@ fn catalog_string(data_type: &DeltaDataType) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rest::routers::delta::models::DeltaProtocol;
+    use crate::rest::routers::delta::models::{DeltaDataSourceFormat, DeltaProtocol};
 
     fn compliant_protocol() -> DeltaProtocol {
         DeltaProtocol {

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -21,11 +21,24 @@ use unitycatalog_common::services::commit_coordinator::{
 pub mod credential_vending;
 pub(crate) mod kernel;
 pub mod location;
+pub mod location_policy;
 pub mod managed_delta_contract;
 pub(crate) mod object_store;
 pub mod secrets;
 mod session;
 mod sharing;
+
+pub use location_policy::LocalStoragePolicy;
+
+/// Access to the server's [`LocalStoragePolicy`].
+///
+/// Implemented by the server handler so request handlers (defined as blanket
+/// impls over a generic `T`) can reach the server-wide allowlist that governs
+/// which host paths may back a `file://` storage location. Mirrors
+/// [`ProvidesCommitCoordinator`].
+pub trait ProvidesLocalStoragePolicy {
+    fn local_storage_policy(&self) -> &LocalStoragePolicy;
+}
 
 #[derive(Clone)]
 pub struct ServerHandler<Cx> {
@@ -127,6 +140,28 @@ impl<Cx: Send + Sync + 'static> ServerHandler<Cx> {
     pub(crate) fn volume_source(&self) -> Option<&Arc<dyn VolumeHandler<Cx>>> {
         self.volume_source.as_ref()
     }
+
+    /// Set the allowlist governing `file://` storage locations.
+    ///
+    /// Rebuilds the inner handler with the policy attached. Call at construction
+    /// time, before the handler is cloned/shared. When unset, all local storage
+    /// is denied.
+    pub fn with_local_storage_policy(mut self, policy: impl Into<Arc<LocalStoragePolicy>>) -> Self {
+        // Rebuild the inner handler with the policy attached. All inner fields
+        // are `Arc`s, so this is a cheap reconstruction (the derived `Clone`
+        // would require `Cx: Clone`, which we don't impose).
+        let prev = &self.handler;
+        let inner = ServerHandlerInner {
+            policy: prev.policy.clone(),
+            store: prev.store.clone(),
+            object_store: prev.object_store.clone(),
+            secrets: prev.secrets.clone(),
+            commit_coordinator: prev.commit_coordinator.clone(),
+            local_storage_policy: policy.into(),
+        };
+        self.handler = Arc::new(inner);
+        self
+    }
 }
 
 #[derive(Clone)]
@@ -137,6 +172,9 @@ pub struct ServerHandlerInner<Cx> {
     secrets: Arc<dyn SecretManager>,
     /// Delta catalog-managed commit coordinator (in-memory by default).
     commit_coordinator: Arc<dyn CommitCoordinator>,
+    /// Allowlist governing which host paths may back a `file://` storage
+    /// location. Deny-all by default (see [`LocalStoragePolicy`]).
+    local_storage_policy: Arc<LocalStoragePolicy>,
 }
 
 impl<Cx: Send + Sync + 'static> ServerHandlerInner<Cx> {
@@ -151,7 +189,17 @@ impl<Cx: Send + Sync + 'static> ServerHandlerInner<Cx> {
             object_store: None,
             secrets,
             commit_coordinator: Arc::new(InMemoryCommitCoordinator::default()),
+            // Deny all local (file://) storage until a policy is configured.
+            local_storage_policy: Arc::new(LocalStoragePolicy::deny_all()),
         }
+    }
+
+    /// Set the allowlist governing `file://` storage locations.
+    ///
+    /// When unset, the handler denies every local storage path.
+    pub fn with_local_storage_policy(mut self, policy: impl Into<Arc<LocalStoragePolicy>>) -> Self {
+        self.local_storage_policy = policy.into();
+        self
     }
 
     /// Override the Delta commit coordinator (e.g. a Postgres-backed one, or a
@@ -284,6 +332,18 @@ impl<Cx: Send + Sync + 'static> ProvidesCommitCoordinator for ServerHandlerInner
 impl<Cx: Send + Sync + 'static> ProvidesCommitCoordinator for ServerHandler<Cx> {
     fn commit_coordinator(&self) -> &dyn CommitCoordinator {
         self.handler.commit_coordinator.as_ref()
+    }
+}
+
+impl<Cx: Send + Sync + 'static> ProvidesLocalStoragePolicy for ServerHandlerInner<Cx> {
+    fn local_storage_policy(&self) -> &LocalStoragePolicy {
+        self.local_storage_policy.as_ref()
+    }
+}
+
+impl<Cx: Send + Sync + 'static> ProvidesLocalStoragePolicy for ServerHandler<Cx> {
+    fn local_storage_policy(&self) -> &LocalStoragePolicy {
+        self.handler.local_storage_policy.as_ref()
     }
 }
 

--- a/crates/server/src/services/object_store.rs
+++ b/crates/server/src/services/object_store.rs
@@ -332,18 +332,20 @@ mod tests {
         let table_dir = dir.path().join("mytable");
         std::fs::create_dir_all(&table_dir).unwrap();
         let url = url::Url::from_directory_path(&table_dir).unwrap();
-        let location = StorageLocationUrl::try_new(url).unwrap();
+        let location = StorageLocationUrl::try_new(url.clone()).unwrap();
 
         let store = get_local_store(&location).unwrap();
 
-        // The kernel engine addresses objects by full path; the unrooted store
-        // resolves `<table_dir>/part-0` from the absolute path.
-        let full = Path::from_url_path(format!("{}/part-0", table_dir.display())).unwrap();
+        // The kernel engine addresses objects by their full path, derived from
+        // the location URL (not a native PathBuf — whose absolute-path spelling
+        // diverges from object_store's on Windows). Correctness is the put/get
+        // round-trip through that same mapping.
+        let full =
+            Path::from_url_path(format!("{}/part-0", url.path().trim_end_matches('/'))).unwrap();
         store
             .put(&full, PutPayload::from_static(b"data"))
             .await
             .unwrap();
-        assert!(table_dir.join("part-0").exists());
         let got = store.get(&full).await.unwrap().bytes().await.unwrap();
         assert_eq!(&got[..], b"data");
     }

--- a/crates/server/src/services/object_store.rs
+++ b/crates/server/src/services/object_store.rs
@@ -16,6 +16,7 @@ use unitycatalog_common::models::tables::v1::Table;
 use unitycatalog_common::models::volumes::v1::Volume;
 use url::Url;
 
+use super::ProvidesLocalStoragePolicy;
 use super::ServerHandlerInner;
 use super::location::{StorageLocationScheme, StorageLocationUrl};
 use crate::api::CredentialHandler;
@@ -144,9 +145,13 @@ pub(crate) async fn list_table_volume_locations(
 /// reuses [`find_external_location_for_url`]; a missing enclosing location
 /// surfaces as a clear argument error rather than the raw `NotFound`.
 pub(crate) async fn validate_external_storage_location(
-    handler: &(impl ResourceStore + ?Sized),
+    handler: &(impl ResourceStore + ProvidesLocalStoragePolicy + ?Sized),
     location: &StorageLocationUrl,
 ) -> Result<()> {
+    // 0. Local (file://) locations must sit within an allowed host root.
+    //    Cloud schemes pass through untouched.
+    handler.local_storage_policy().check(location)?;
+
     // 1. Must reside within a registered external location.
     if let Err(Error::NotFound) = find_external_location_for_url(location, handler).await {
         return Err(Error::invalid_argument(format!(

--- a/crates/server/src/services/object_store.rs
+++ b/crates/server/src/services/object_store.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use super::kernel::ObjectStoreFactory;
 use datafusion::common::{DataFusionError, Result as DFResult};
 use itertools::Itertools;
-use object_store::DynObjectStore;
 use object_store::azure::MicrosoftAzureBuilder;
+use object_store::local::LocalFileSystem;
+use object_store::{DynObjectStore, ObjectStoreScheme};
 use unitycatalog_common::credentials::v1::AzureManagedIdentity;
 use unitycatalog_common::models::credentials::v1::{
     AzureServicePrincipal, AzureStorageKey, GetCredentialRequest,
@@ -202,6 +203,15 @@ pub(crate) async fn get_object_store(
     handler: &dyn RegistryHandler,
 ) -> Result<Arc<DynObjectStore>> {
     tracing::debug!("get_object_store: {:?}", location.location());
+    // Local filesystem storage needs neither an external location nor a vended
+    // credential — short-circuit before the lookup and build a LocalFileSystem
+    // directly, mirroring the client-side object-store factory.
+    if matches!(
+        location.scheme(),
+        StorageLocationScheme::ObjectStore(ObjectStoreScheme::Local)
+    ) {
+        return get_local_store(location);
+    }
     let ext_loc = find_external_location_for_url(location, handler).await?;
     let credential = handler
         .get_credential_internal(GetCredentialRequest {
@@ -214,6 +224,19 @@ pub(crate) async fn get_object_store(
         credential.azure_service_principal,
         credential.azure_storage_key,
     )
+}
+
+/// Build an unrooted [`LocalFileSystem`] store for a `file://` location.
+///
+/// The delta_kernel engine addresses objects by their full path, so the store
+/// is left unrooted (paths are relative to the filesystem root) rather than
+/// prefixed at the table directory.
+fn get_local_store(location: &StorageLocationUrl) -> Result<Arc<DynObjectStore>> {
+    tracing::debug!("get_local_store: {:?}", location.location());
+    location.raw().to_file_path().map_err(|_| {
+        Error::invalid_argument(format!("not a valid local file path: {}", location.raw()))
+    })?;
+    Ok(Arc::new(LocalFileSystem::new()))
 }
 
 fn get_azure_store(
@@ -291,8 +314,34 @@ fn get_azure_store(
 
 #[cfg(test)]
 mod tests {
-    use super::{is_path_prefix, locations_overlap, paths_overlap};
+    use super::{get_local_store, is_path_prefix, locations_overlap, paths_overlap};
     use crate::services::location::StorageLocationUrl;
+
+    /// A `file://` location resolves to a local store with no external-location
+    /// lookup or credential — and the resulting store can read what it writes.
+    #[tokio::test]
+    async fn local_store_roundtrips_full_path() {
+        use object_store::{ObjectStoreExt, PutPayload, path::Path};
+
+        let dir = tempfile::tempdir().unwrap();
+        let table_dir = dir.path().join("mytable");
+        std::fs::create_dir_all(&table_dir).unwrap();
+        let url = url::Url::from_directory_path(&table_dir).unwrap();
+        let location = StorageLocationUrl::try_new(url).unwrap();
+
+        let store = get_local_store(&location).unwrap();
+
+        // The kernel engine addresses objects by full path; the unrooted store
+        // resolves `<table_dir>/part-0` from the absolute path.
+        let full = Path::from_url_path(format!("{}/part-0", table_dir.display())).unwrap();
+        store
+            .put(&full, PutPayload::from_static(b"data"))
+            .await
+            .unwrap();
+        assert!(table_dir.join("part-0").exists());
+        let got = store.get(&full).await.unwrap().bytes().await.unwrap();
+        assert_eq!(&got[..], b"data");
+    }
 
     #[test]
     fn path_prefix_matches_exact_and_subpaths() {

--- a/crates/server/src/services/object_store.rs
+++ b/crates/server/src/services/object_store.rs
@@ -236,8 +236,20 @@ pub(crate) async fn get_object_store(
 /// The delta_kernel engine addresses objects by their full path, so the store
 /// is left unrooted (paths are relative to the filesystem root) rather than
 /// prefixed at the table directory.
+///
+/// Local `file://` storage is **POSIX-only** for now and errors on Windows:
+/// `object_store::path::Path` cannot represent a Windows absolute path (the
+/// drive-letter colon is percent-encoded), so an unrooted store addressed by
+/// full path does not resolve to the real on-disk location. Mirrors the
+/// client-side `local_store` in `unitycatalog-object-store`.
 fn get_local_store(location: &StorageLocationUrl) -> Result<Arc<DynObjectStore>> {
     tracing::debug!("get_local_store: {:?}", location.location());
+    if cfg!(windows) {
+        return Err(Error::invalid_argument(format!(
+            "local (file://) storage is not supported on Windows: {}",
+            location.raw()
+        )));
+    }
     location.raw().to_file_path().map_err(|_| {
         Error::invalid_argument(format!("not a valid local file path: {}", location.raw()))
     })?;
@@ -324,6 +336,8 @@ mod tests {
 
     /// A `file://` location resolves to a local store with no external-location
     /// lookup or credential — and the resulting store can read what it writes.
+    /// POSIX-only: local file:// is gated off on Windows (see `get_local_store`).
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn local_store_roundtrips_full_path() {
         use object_store::{ObjectStoreExt, PutPayload, path::Path};


### PR DESCRIPTION
## Summary

Enable Unity Catalog object stores to use local `file://` paths, for local development and exploration without any cloud backend or credential vending. Local storage has no cloud credential to vend, so the client short-circuits the vending APIs entirely and builds a `LocalFileSystem` directly.

- **Paths** (`for_path` / `dry_run_path`, and `for_url` raw paths): `file://` URLs build a local store, skipping `temporary-path-credentials`.
- **Tables** (`for_table`): resolves the table's `storage_location` via `GetTable` before vending; `file://` → local store. Reads end-to-end via the DataFusion catalog provider.
- **Volumes** (`for_volume`): same as tables, via `GetVolume`.
- **Server-side** (`get_object_store`, the Delta Sharing `query_table` kernel path): short-circuits `file://` before the external-location lookup and builds an unrooted `LocalFileSystem` — no external location or credential required.

No server behavior change for cloud paths, no proto changes, no `TemporaryCredential` model changes — this is a client-side short-circuit plus a server-side local branch.

### Design note

The local store uses the unrooted `LocalFileSystem` + path-prefix model (not a dir-rooted store), mirroring how vended cloud stores are scoped. This keeps both `UCStore::as_dyn()` (relative paths) and `UCStore::root()` (absolute paths) correct — the latter is required by the DataFusion `RoutingObjectStore`, which forwards the full request path unchanged. Table/volume short-circuits work for three-level **name** references; UUID-only references still vend (documented as unsupported for local-fs).

## Test plan

- [x] `cargo test -p unitycatalog-object-store` — local round-trip read/write/list via `as_dyn` and `root()`, auto-create on ReadWrite, vending-skipped proof (dead endpoint), clean error on non-file URL.
- [x] `cargo test -p unitycatalog-server services::object_store` — `get_local_store` full-path round-trip.
- [x] `cargo clippy` clean on both crates; `datafusion-unitycatalog` builds against the changed factory.
- [ ] Manual end-to-end: register a `file://`-backed Delta table against the in-memory dev server (`just rest`) and query it via DataFusion.

## Follow-up

- #205 — server-side `get_object_store` is still Azure-only for cloud schemes (S3/GCS); only `file://` and Azure are handled on the Delta Sharing kernel read path.

AI-assisted by Isaac