### PR TITLE
feat: use GUID-based storage paths for managed volumes

### DIFF
--- a/.sqlx/query-9433cc7ff2120bea048fb896d5ea0dcfd47a78727876ccbd0d38c533d32cd9b6.json
+++ b/.sqlx/query-9433cc7ff2120bea048fb896d5ea0dcfd47a78727876ccbd0d38c533d32cd9b6.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                INSERT INTO objects ( label, name, properties )\n                VALUES ( $1, $2, $3 )\n                RETURNING\n                    id,\n                    label AS \"label: ObjectLabel\",\n                    name,\n                    properties,\n                    created_at,\n                    updated_at\n                ",
+  "query": "\n                INSERT INTO objects ( id, label, name, properties )\n                VALUES ( COALESCE($1, uuidv7()), $2, $3, $4 )\n                RETURNING\n                    id,\n                    label AS \"label: ObjectLabel\",\n                    name,\n                    properties,\n                    created_at,\n                    updated_at\n                ",
   "describe": {
     "columns": [
       {
@@ -56,6 +56,7 @@
     ],
     "parameters": {
       "Left": [
+        "Uuid",
         {
           "Custom": {
             "name": "object_label",
@@ -90,5 +91,5 @@
       true
     ]
   },
-  "hash": "3fcb48e93412b7446220d1e6f6c61169cd0ca49e8d4da96b35d0ee90fe830baf"
+  "hash": "9433cc7ff2120bea048fb896d5ea0dcfd47a78727876ccbd0d38c533d32cd9b6"
 }

--- a/crates/acceptance/src/execution/mod.rs
+++ b/crates/acceptance/src/execution/mod.rs
@@ -173,10 +173,10 @@ impl JourneyFilter {
             return false;
         }
 
-        if let Some(ref max_tier) = self.max_tier {
-            if meta.tier > *max_tier {
-                return false;
-            }
+        if let Some(ref max_tier) = self.max_tier
+            && meta.tier > *max_tier
+        {
+            return false;
         }
 
         if let Some(ref impl_tag) = self.implementation {

--- a/crates/acceptance/src/journeys/tier1/catalog_simple.rs
+++ b/crates/acceptance/src/journeys/tier1/catalog_simple.rs
@@ -172,20 +172,20 @@ impl UserJourney for CatalogSimpleJourney {
                 }
 
                 // Validate storage root if provided
-                if let Some(storage_root) = &catalog_info.storage_root {
-                    if storage_root != &ctx.storage_root {
-                        logger.warn(&format!(
-                            "Storage root mismatch: expected '{}', got '{}'",
-                            ctx.storage_root, storage_root
-                        ))?;
-                    }
+                if let Some(storage_root) = &catalog_info.storage_root
+                    && storage_root != &ctx.storage_root
+                {
+                    logger.warn(&format!(
+                        "Storage root mismatch: expected '{}', got '{}'",
+                        ctx.storage_root, storage_root
+                    ))?;
                 }
 
                 // Validate comment
-                if let Some(comment) = &catalog_info.comment {
-                    if !comment.contains("Enhanced test catalog") {
-                        logger.warn("Catalog comment doesn't match expected content")?;
-                    }
+                if let Some(comment) = &catalog_info.comment
+                    && !comment.contains("Enhanced test catalog")
+                {
+                    logger.warn("Catalog comment doesn't match expected content")?;
                 }
 
                 // Log detailed information

--- a/crates/acceptance/src/reporting.rs
+++ b/crates/acceptance/src/reporting.rs
@@ -233,10 +233,10 @@ impl JourneyReporter {
                 };
                 self.term.write_line(&msg)?;
 
-                if let Some(details) = &step.details {
-                    if self.config.verbosity > 1 {
-                        self.term.write_line(&format!("    └─ {}", details))?;
-                    }
+                if let Some(details) = &step.details
+                    && self.config.verbosity > 1
+                {
+                    self.term.write_line(&format!("    └─ {}", details))?;
                 }
             }
         }

--- a/crates/common/src/services/commit_coordinator.rs
+++ b/crates/common/src/services/commit_coordinator.rs
@@ -292,12 +292,12 @@ impl CommitCoordinator for InMemoryCommitCoordinator {
                         "commit version must be the next version after {last}, but got {version}"
                     )));
                 }
-                if let Some(lbv) = latest_backfilled_version {
-                    if lbv > last {
-                        return Err(CommitError::InvalidArgument(format!(
-                            "latest_backfilled_version {lbv} is greater than the latest commit {last}"
-                        )));
-                    }
+                if let Some(lbv) = latest_backfilled_version
+                    && lbv > last
+                {
+                    return Err(CommitError::InvalidArgument(format!(
+                        "latest_backfilled_version {lbv} is greater than the latest commit {last}"
+                    )));
                 }
 
                 // Enforce the unbackfilled-commit cap. The effective backfilled
@@ -337,12 +337,12 @@ impl CommitCoordinator for InMemoryCommitCoordinator {
                 "start_version must be non-negative".to_string(),
             ));
         }
-        if let Some(end) = end_version {
-            if end < start_version {
-                return Err(CommitError::InvalidArgument(format!(
-                    "end_version {end} must be >= start_version {start_version}"
-                )));
-            }
+        if let Some(end) = end_version
+            && end < start_version
+        {
+            return Err(CommitError::InvalidArgument(format!(
+                "end_version {end} must be >= start_version {start_version}"
+            )));
         }
 
         let Some(entry) = self
@@ -404,10 +404,10 @@ fn backfill(state: &mut TableCommitState, up_to: i64) {
     for v in to_remove {
         state.commits.remove(&v);
     }
-    if up_to >= last {
-        if let Some(c) = state.commits.get_mut(&last) {
-            c.is_backfilled_latest = true;
-        }
+    if up_to >= last
+        && let Some(c) = state.commits.get_mut(&last)
+    {
+        c.is_backfilled_latest = true;
     }
 }
 

--- a/crates/datafusion/src/catalog/kernel.rs
+++ b/crates/datafusion/src/catalog/kernel.rs
@@ -156,13 +156,13 @@ pub fn build_catalog_managed_snapshot(
         ))
     })?;
 
-    if let Some(version) = at_version {
-        if version > latest_table_version {
-            return Err(DataFusionError::Plan(format!(
-                "requested version {version} for '{location}' exceeds latest ratified \
+    if let Some(version) = at_version
+        && version > latest_table_version
+    {
+        return Err(DataFusionError::Plan(format!(
+            "requested version {version} for '{location}' exceeds latest ratified \
                  version {latest_table_version}"
-            )));
-        }
+        )));
     }
 
     // The kernel joins log paths onto the table root via `Url::join`, which drops the

--- a/crates/object-store/src/lib.rs
+++ b/crates/object-store/src/lib.rs
@@ -338,18 +338,16 @@ impl UnityObjectStoreFactory {
         // This resolution is only possible for name references; a caller that
         // holds only the table UUID still vends (and a local-fs table addressed
         // by UUID is an unsupported edge case — use the three-level name).
-        if let TableReference::Name(name) = &table {
-            if let Some(location) = self.table_storage_location(name).await? {
-                if let Ok(url) = Url::parse(&location) {
-                    if url.scheme() == "file" {
-                        let path_op = match operation {
-                            TableOperation::Read => PathOperation::Read,
-                            TableOperation::ReadWrite => PathOperation::ReadWrite,
-                        };
-                        return local_store(&url, path_op);
-                    }
-                }
-            }
+        if let TableReference::Name(name) = &table
+            && let Some(location) = self.table_storage_location(name).await?
+            && let Ok(url) = Url::parse(&location)
+            && url.scheme() == "file"
+        {
+            let path_op = match operation {
+                TableOperation::Read => PathOperation::Read,
+                TableOperation::ReadWrite => PathOperation::ReadWrite,
+            };
+            return local_store(&url, path_op);
         }
         let (credential, table_id) = self
             .creds
@@ -400,18 +398,16 @@ impl UnityObjectStoreFactory {
         // Only possible for name references; a caller holding only the volume
         // UUID still vends (a local-fs volume addressed by UUID is unsupported —
         // use the three-level name).
-        if let VolumeReference::Name(name) = &volume {
-            if let Some(location) = self.volume_storage_location(name).await? {
-                if let Ok(url) = Url::parse(&location) {
-                    if url.scheme() == "file" {
-                        let path_op = match operation {
-                            VolumeOperation::Read => PathOperation::Read,
-                            VolumeOperation::ReadWrite => PathOperation::ReadWrite,
-                        };
-                        return local_store(&url, path_op);
-                    }
-                }
-            }
+        if let VolumeReference::Name(name) = &volume
+            && let Some(location) = self.volume_storage_location(name).await?
+            && let Ok(url) = Url::parse(&location)
+            && url.scheme() == "file"
+        {
+            let path_op = match operation {
+                VolumeOperation::Read => PathOperation::Read,
+                VolumeOperation::ReadWrite => PathOperation::ReadWrite,
+            };
+            return local_store(&url, path_op);
         }
         let (credential, volume_id) = self
             .creds

--- a/crates/postgres/src/commit_coordinator.rs
+++ b/crates/postgres/src/commit_coordinator.rs
@@ -39,15 +39,14 @@ fn parse_table_id(table_id: &str) -> CommitResult<Uuid> {
 /// Map a sqlx error to a [`CommitError`], translating a unique violation on the
 /// `(table_id, commit_version)` constraint into a version conflict.
 fn map_sqlx_err(e: sqlx::Error) -> CommitError {
-    if let sqlx::Error::Database(db_err) = &e {
-        if db_err
+    if let sqlx::Error::Database(db_err) = &e
+        && db_err
             .try_downcast_ref::<sqlx::postgres::PgDatabaseError>()
             .is_some_and(|pg| pg.code() == "23505")
-        {
-            return CommitError::VersionConflict(
-                "commit version was already accepted by another writer".to_string(),
-            );
-        }
+    {
+        return CommitError::VersionConflict(
+            "commit version was already accepted by another writer".to_string(),
+        );
     }
     CommitError::Backend(e.to_string())
 }
@@ -201,13 +200,13 @@ impl CommitCoordinator for GraphStore {
                         b.last
                     )));
                 }
-                if let Some(lbv) = latest_backfilled_version {
-                    if lbv > b.last {
-                        return Err(CommitError::InvalidArgument(format!(
-                            "latest_backfilled_version {lbv} is greater than the latest commit {}",
-                            b.last
-                        )));
-                    }
+                if let Some(lbv) = latest_backfilled_version
+                    && lbv > b.last
+                {
+                    return Err(CommitError::InvalidArgument(format!(
+                        "latest_backfilled_version {lbv} is greater than the latest commit {}",
+                        b.last
+                    )));
                 }
 
                 // Enforce the unbackfilled-commit cap. The effective backfilled
@@ -247,12 +246,12 @@ impl CommitCoordinator for GraphStore {
                 "start_version must be non-negative".to_string(),
             ));
         }
-        if let Some(end) = end_version {
-            if end < start_version {
-                return Err(CommitError::InvalidArgument(format!(
-                    "end_version {end} must be >= start_version {start_version}"
-                )));
-            }
+        if let Some(end) = end_version
+            && end < start_version
+        {
+            return Err(CommitError::InvalidArgument(format!(
+                "end_version {end} must be >= start_version {start_version}"
+            )));
         }
         let table_id = parse_table_id(table_id)?;
 

--- a/crates/postgres/src/graph/store.rs
+++ b/crates/postgres/src/graph/store.rs
@@ -87,9 +87,10 @@ impl Store {
         label: &ObjectLabel,
         name: &[String],
         properties: Option<serde_json::Value>,
+        id: Option<Uuid>,
     ) -> Result<Object> {
         let mut txn = self.pool.begin().await?;
-        let obj = add_object(label, name, properties, &mut txn).await?;
+        let obj = add_object(label, name, properties, id, &mut txn).await?;
         txn.commit().await?;
         Ok(obj)
     }
@@ -345,7 +346,7 @@ impl olai_store::ObjectStore<ObjectLabel> for Store {
         name: &ResourceName,
         properties: Option<serde_json::Value>,
     ) -> olai_store::Result<olai_store::Object<ObjectLabel>> {
-        Ok(self.add_object(&label, name, properties).await?)
+        Ok(self.add_object(&label, name, properties, None).await?)
     }
 
     async fn update(
@@ -488,13 +489,17 @@ async fn add_object(
     label: &ObjectLabel,
     name: &[String],
     properties: Option<serde_json::Value>,
+    id: Option<Uuid>,
     txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
 ) -> Result<Object, crate::Error> {
+    // A caller that pre-allocates an id (e.g. a managed volume or staging table
+    // embedding the id in its storage path) passes it here; `COALESCE` falls back
+    // to the column's `uuidv7()` default for the common id-less create.
     let obj = sqlx::query_as!(
         Object,
         r#"
-                INSERT INTO objects ( label, name, properties )
-                VALUES ( $1, $2, $3 )
+                INSERT INTO objects ( id, label, name, properties )
+                VALUES ( COALESCE($1, uuidv7()), $2, $3, $4 )
                 RETURNING
                     id,
                     label AS "label: ObjectLabel",
@@ -503,6 +508,7 @@ async fn add_object(
                     created_at,
                     updated_at
                 "#,
+        id,
         label as &ObjectLabel,
         name,
         properties

--- a/crates/postgres/src/resources.rs
+++ b/crates/postgres/src/resources.rs
@@ -83,8 +83,13 @@ impl ResourceStore for GraphStore {
     /// The created resource.
     async fn create(&self, resource: Resource) -> Result<(Resource, ResourceRef)> {
         let object: Object = resource.try_into()?;
+        // A non-nil id means the caller pre-allocated it (e.g. a managed volume or
+        // staging table that embeds the id in its storage path); a nil id lets the
+        // store mint a fresh v7. API request types carry no id field, so callers
+        // cannot force an id through this path.
+        let supplied_id = (!object.id.is_nil()).then_some(object.id);
         let object = self
-            .add_object(&object.label, &object.name, object.properties)
+            .add_object(&object.label, &object.name, object.properties, supplied_id)
             .await?;
         let id = ResourceRef::Uuid(object.id);
         Ok((object.try_into()?, id))

--- a/crates/server/src/api/entity_tag_assignments.rs
+++ b/crates/server/src/api/entity_tag_assignments.rs
@@ -203,10 +203,10 @@ impl<T: ResourceStore + Policy<RequestContext>> EntityTagAssignmentHandler<Reque
 /// looks the TagPolicy up in the store and returns its `tag_key`.
 async fn tag_key_for<S: ResourceStore>(store: &S, tag_ref: &ResourceIdent) -> Result<String> {
     // Fast path: the ident already carries the single-segment name.
-    if let ResourceRef::Name(name) = tag_ref.as_ref() {
-        if let Some(last) = name.iter().last() {
-            return Ok(last.clone());
-        }
+    if let ResourceRef::Name(name) = tag_ref.as_ref()
+        && let Some(last) = name.iter().last()
+    {
+        return Ok(last.clone());
     }
     let (resource, _) = store.get(tag_ref).await?;
     let policy: TagPolicy = resource.try_into()?;

--- a/crates/server/src/api/volumes.rs
+++ b/crates/server/src/api/volumes.rs
@@ -34,6 +34,11 @@ impl<
         let volume_type =
             VolumeType::try_from(request.volume_type).unwrap_or(VolumeType::Unspecified);
 
+        // Empty unless a managed volume allocates its id below. An empty
+        // `volume_id` leaves id assignment to the store (UUID v7), matching every
+        // other resource; a managed volume sets it so the storage path can embed
+        // it and the store persists the row under that same id.
+        let mut volume_id = String::new();
         let storage_location = match volume_type {
             VolumeType::External => {
                 // External volumes MUST have an explicit storage location that
@@ -53,14 +58,17 @@ impl<
                 // Managed volumes derive their storage location from the managed
                 // storage root resolved for the parent schema/catalog (schema →
                 // catalog → metastore), exactly like managed tables. The resolved
-                // root already carries the `__unitystorage` prefix; we append the
-                // standard `volumes/{name}` segment, paralleling the
-                // `tables/{uuid}` convention in `create_staging_table`. A caller
-                // cannot supply its own location for a managed volume.
+                // root already carries the `__unitystorage` prefix; we append a
+                // `volumes/{volume_id}` segment, mirroring the `tables/{uuid}`
+                // convention in `create_staging_table`. The id is allocated here
+                // and persisted as `volume_id` (the store honors a pre-set id), so
+                // the path segment equals the volume's id and survives renames. A
+                // caller cannot supply its own location for a managed volume.
                 let root =
                     resolve_managed_storage_root(self, &request.catalog_name, &request.schema_name)
                         .await?;
-                format!("{}/volumes/{}", root.trim_end_matches('/'), request.name)
+                volume_id = uuid::Uuid::now_v7().hyphenated().to_string();
+                format!("{}/volumes/{}", root.trim_end_matches('/'), volume_id)
             }
             VolumeType::Unspecified => {
                 return Err(Error::invalid_argument(
@@ -80,6 +88,7 @@ impl<
             schema_name: request.schema_name,
             volume_type: request.volume_type,
             storage_location,
+            volume_id,
             comment: request.comment,
             ..Default::default()
         };
@@ -220,14 +229,16 @@ impl SecuredAction for DeleteVolumeRequest {
 mod tests {
     use std::sync::Arc;
 
+    use unitycatalog_common::models::catalogs::v1::CreateCatalogRequest;
     use unitycatalog_common::models::credentials::v1::{
         AwsIamRoleConfig, CreateCredentialRequest, Purpose,
     };
     use unitycatalog_common::models::external_locations::v1::CreateExternalLocationRequest;
+    use unitycatalog_common::models::schemas::v1::CreateSchemaRequest;
     use unitycatalog_common::services::encryption::{EnvelopeEncryptor, LocalKeyProvider};
 
     use super::*;
-    use crate::api::{CredentialHandler, ExternalLocationHandler};
+    use crate::api::{CatalogHandler, CredentialHandler, ExternalLocationHandler, SchemaHandler};
     use crate::memory::InMemoryResourceStore;
     use crate::policy::ConstantPolicy;
     use crate::services::ServerHandler;
@@ -285,6 +296,163 @@ mod tests {
             storage_location: location.map(str::to_string),
             comment: None,
         }
+    }
+
+    /// Create catalog `cat` (rooted at `storage_root`) and schema `sch` so a
+    /// managed volume can resolve a managed storage root.
+    async fn setup_managed_namespace(h: &ServerHandler<RequestContext>, storage_root: &str) {
+        h.create_catalog(
+            CreateCatalogRequest {
+                name: "cat".to_string(),
+                storage_root: Some(storage_root.to_string()),
+                ..Default::default()
+            },
+            ctx(),
+        )
+        .await
+        .unwrap();
+        h.create_schema(
+            CreateSchemaRequest {
+                name: "sch".to_string(),
+                catalog_name: "cat".to_string(),
+                ..Default::default()
+            },
+            ctx(),
+        )
+        .await
+        .unwrap();
+    }
+
+    fn create_managed_volume(name: &str) -> CreateVolumeRequest {
+        CreateVolumeRequest {
+            catalog_name: "cat".to_string(),
+            schema_name: "sch".to_string(),
+            name: name.to_string(),
+            volume_type: VolumeType::Managed as i32,
+            storage_location: None,
+            comment: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn managed_volume_location_uses_volume_id() {
+        let h = handler();
+        setup_managed_namespace(&h, "s3://bucket/cat").await;
+
+        let v = h
+            .create_volume(create_managed_volume("vol"), ctx())
+            .await
+            .unwrap();
+
+        // The path segment equals the persisted volume id, not the name.
+        assert!(
+            uuid::Uuid::parse_str(&v.volume_id).is_ok(),
+            "volume_id should be a uuid, got {}",
+            v.volume_id
+        );
+        assert_eq!(
+            v.storage_location,
+            format!("s3://bucket/cat/__unitystorage/volumes/{}", v.volume_id),
+        );
+        assert!(
+            !v.storage_location.ends_with("/volumes/vol"),
+            "managed volume should not use its name in the path: {}",
+            v.storage_location
+        );
+
+        // The id round-trips: a get returns the same id and location.
+        let got = h
+            .get_volume(
+                GetVolumeRequest {
+                    name: "cat.sch.vol".to_string(),
+                    ..Default::default()
+                },
+                ctx(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(got.volume_id, v.volume_id);
+        assert_eq!(got.storage_location, v.storage_location);
+    }
+
+    #[tokio::test]
+    async fn managed_volume_schema_location_takes_precedence() {
+        let h = handler();
+        h.create_catalog(
+            CreateCatalogRequest {
+                name: "cat".to_string(),
+                storage_root: Some("s3://bucket/cat".to_string()),
+                ..Default::default()
+            },
+            ctx(),
+        )
+        .await
+        .unwrap();
+        h.create_schema(
+            CreateSchemaRequest {
+                name: "sch".to_string(),
+                catalog_name: "cat".to_string(),
+                storage_location: Some("s3://other/sch".to_string()),
+                ..Default::default()
+            },
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+        let v = h
+            .create_volume(create_managed_volume("vol"), ctx())
+            .await
+            .unwrap();
+        assert_eq!(
+            v.storage_location,
+            format!("s3://other/sch/__unitystorage/volumes/{}", v.volume_id),
+        );
+    }
+
+    #[tokio::test]
+    async fn managed_volume_recreate_yields_new_path() {
+        // Dropping and recreating a managed volume with the same name yields a
+        // fresh id and therefore a distinct path — name-based collisions are gone.
+        let h = handler();
+        setup_managed_namespace(&h, "s3://bucket/cat").await;
+
+        let first = h
+            .create_volume(create_managed_volume("vol"), ctx())
+            .await
+            .unwrap();
+        h.delete_volume(
+            DeleteVolumeRequest {
+                name: "cat.sch.vol".to_string(),
+            },
+            ctx(),
+        )
+        .await
+        .unwrap();
+        let second = h
+            .create_volume(create_managed_volume("vol"), ctx())
+            .await
+            .unwrap();
+
+        assert_ne!(first.volume_id, second.volume_id);
+        assert_ne!(first.storage_location, second.storage_location);
+    }
+
+    #[tokio::test]
+    async fn managed_volume_duplicate_name_is_rejected() {
+        // Uniqueness on the catalog.schema.name triplet is preserved even though
+        // the store now honors a pre-allocated id.
+        let h = handler();
+        setup_managed_namespace(&h, "s3://bucket/cat").await;
+
+        h.create_volume(create_managed_volume("vol"), ctx())
+            .await
+            .unwrap();
+        let err = h
+            .create_volume(create_managed_volume("vol"), ctx())
+            .await
+            .expect_err("duplicate triplet must be rejected");
+        assert_eq!(err.error_code(), "RESOURCE_ALREADY_EXISTS", "{err:?}");
     }
 
     #[tokio::test]

--- a/crates/server/src/memory.rs
+++ b/crates/server/src/memory.rs
@@ -15,17 +15,30 @@ use crate::store::{ResourceStore, ResourceStoreReader};
 
 const MAX_PAGE_SIZE: usize = 10000;
 
+/// Resource rows keyed by `(label, uuid)`. The label is part of the key so two
+/// resources of different types can share one logical id — the managed-table flow
+/// does exactly this (a `Table` adopts its `StagingTable`'s id, so
+/// `table_uuid == staging.id`). A bare-uuid key would let the second create
+/// overwrite the first.
+type ResourceMap = Arc<DashMap<(ObjectLabel, Uuid), Resource>>;
+
+/// Association edges keyed by label, then by `(from_uuid, to_uuid)` so a single
+/// source resource can hold many edges of the same label (e.g. an entity with
+/// multiple tags). The value carries the target's [`ObjectLabel`] (so the row can
+/// be located in [`ResourceMap`], which is keyed by `(label, uuid)`) and the
+/// edge's optional properties (e.g. a tag assignment's value). Mirrors Postgres's
+/// `to_label`.
+type AssociationMap =
+    Arc<DashMap<AssociationLabel, DashMap<(Uuid, Uuid), (ObjectLabel, Option<PropertyMap>)>>>;
+
 /// An in-memory implementation of a resource store.
 ///
 /// This store is not intended for production use, but is useful for testing and development.
 #[derive(Debug, Clone)]
 pub struct InMemoryResourceStore {
-    resources: Arc<DashMap<Uuid, Resource>>,
+    resources: ResourceMap,
     id_map: Arc<DashMap<ObjectLabel, DashMap<ResourceName, Uuid>>>,
-    /// Association edges keyed by label, then by `(from_uuid, to_uuid)` so a single source
-    /// resource can hold many edges of the same label (e.g. an entity with multiple tags).
-    /// The value is the edge's optional properties (e.g. a tag assignment's value).
-    associations: Arc<DashMap<AssociationLabel, DashMap<(Uuid, Uuid), Option<PropertyMap>>>>,
+    associations: AssociationMap,
     /// Sealed secret blobs keyed by name. Encryption matches the production path so dev/test
     /// behaviour (and the on-disk format) is exercised here too.
     secrets: Arc<DashMap<String, bytes::Bytes>>,
@@ -56,11 +69,19 @@ impl InMemoryResourceStore {
     }
 
     fn new_uuid(&self, label: &ObjectLabel, name: &ResourceName) -> Result<Uuid> {
+        self.insert_uuid(label, name, Uuid::now_v7())
+    }
+
+    /// Register `uuid` for `(label, name)`, failing if the name is already taken.
+    ///
+    /// `new_uuid` generates a fresh v7 id; callers that pre-allocate an id (e.g.
+    /// managed volumes and staging tables, which embed the id in their storage
+    /// path) reserve that exact id here so the persisted row id matches the path.
+    fn insert_uuid(&self, label: &ObjectLabel, name: &ResourceName, uuid: Uuid) -> Result<Uuid> {
         if self.get_uuid(label, name).is_some() {
             return Err(Error::AlreadyExists);
         }
         let map = self.id_map.entry(*label).or_default();
-        let uuid = Uuid::now_v7();
         map.insert(name.clone(), uuid);
         Ok(uuid)
     }
@@ -70,15 +91,18 @@ impl InMemoryResourceStore {
 impl ResourceStoreReader for InMemoryResourceStore {
     async fn get(&self, id: &ResourceIdent) -> Result<(Resource, ResourceRef)> {
         let resource = match id.as_ref() {
-            ResourceRef::Uuid(uuid) => self.resources.get(uuid),
+            ResourceRef::Uuid(uuid) => self.resources.get(&(*id.label(), *uuid)),
             ResourceRef::Name(name) => {
                 let uuid = self.get_uuid(id.label(), name).ok_or(Error::NotFound)?;
-                self.resources.get(&uuid)
+                self.resources.get(&(*id.label(), uuid))
             }
             ResourceRef::Undefined => return Err(Error::NotFound),
         };
         match resource {
-            Some(resource) => Ok((resource.value().clone(), resource.key().into())),
+            Some(resource) => Ok((
+                resource.value().clone(),
+                ResourceRef::Uuid(resource.key().1),
+            )),
             None => Err(Error::NotFound),
         }
     }
@@ -114,7 +138,11 @@ impl ResourceStoreReader for InMemoryResourceStore {
         let mut resources = Vec::new();
         let mut last_id = &Uuid::nil();
         for uuid in resource_ids.iter().rev().take(max_page_size) {
-            let resource = self.resources.get(uuid).ok_or(Error::NotFound)?.clone();
+            let resource = self
+                .resources
+                .get(&(*label, *uuid))
+                .ok_or(Error::NotFound)?
+                .clone();
             last_id = uuid;
             resources.push(resource);
         }
@@ -126,14 +154,27 @@ impl ResourceStoreReader for InMemoryResourceStore {
 #[async_trait::async_trait]
 impl ResourceStore for InMemoryResourceStore {
     async fn create(&self, resource: Resource) -> Result<(Resource, ResourceRef)> {
-        if self
-            .get_uuid(resource.resource_label(), &resource.resource_name())
-            .is_some()
-        {
-            return Err(Error::AlreadyExists);
-        }
-        let uuid = self.new_uuid(resource.resource_label(), &resource.resource_name())?;
-        self.resources.insert(uuid, resource.clone());
+        // Honor an id the caller pre-allocated (a resource whose id field is set
+        // resolves to `ResourceRef::Uuid`); otherwise mint a fresh v7 id. This
+        // lets managed volumes and staging tables persist under the same id they
+        // embed in their storage path. API callers cannot reach this — request
+        // types carry no id field.
+        let label = resource.resource_label();
+        let name = resource.resource_name();
+        let uuid = match resource.resource_ref() {
+            ResourceRef::Uuid(id) => {
+                // Guard the id's uniqueness within this label too; otherwise a
+                // colliding pre-set id would silently overwrite an existing row of
+                // the same type. (A different label sharing the id is allowed — see
+                // the `resources` keying.)
+                if self.resources.contains_key(&(*label, id)) {
+                    return Err(Error::AlreadyExists);
+                }
+                self.insert_uuid(label, &name, id)?
+            }
+            _ => self.new_uuid(label, &name)?,
+        };
+        self.resources.insert((*label, uuid), resource.clone());
         Ok((resource, ResourceRef::Uuid(uuid)))
     }
 
@@ -143,7 +184,7 @@ impl ResourceStore for InMemoryResourceStore {
             ResourceRef::Name(name) => self.get_uuid(id.label(), name).ok_or(Error::NotFound)?,
             ResourceRef::Undefined => return Err(Error::NotFound),
         };
-        match self.resources.remove(&uuid) {
+        match self.resources.remove(&(*id.label(), uuid)) {
             Some((_, resource)) => self.remove_uuid(id.label(), &resource.resource_name()),
             None => None,
         };
@@ -163,7 +204,7 @@ impl ResourceStore for InMemoryResourceStore {
         // Need to clone to avoid locking the map while holding a reference to the value
         let existing = self
             .resources
-            .get(&uuid)
+            .get(&(*id.label(), uuid))
             .ok_or(Error::NotFound)?
             .value()
             .clone();
@@ -183,7 +224,12 @@ impl ResourceStore for InMemoryResourceStore {
                 .get(existing.resource_label())
                 .and_then(|map| map.value().insert(resource.resource_name(), uuid));
         }
-        self.resources.insert(uuid, resource.clone());
+        // The label may have changed; drop the row at the old key and write it
+        // under the new one. When the label is unchanged these are the same key,
+        // collapsing to a plain overwrite.
+        self.resources.remove(&(*existing.resource_label(), uuid));
+        self.resources
+            .insert((*resource.resource_label(), uuid), resource.clone());
         Ok((resource, ResourceRef::Uuid(uuid)))
     }
 
@@ -204,11 +250,14 @@ impl ResourceStore for InMemoryResourceStore {
             ResourceRef::Name(name) => self.get_uuid(to.label(), name).ok_or(Error::NotFound)?,
             ResourceRef::Undefined => return Err(Error::NotFound),
         };
+        // Each edge stores the label of *its* target so the row can be located in
+        // `resources` (keyed by `(label, uuid)`). The forward edge targets `to`;
+        // the inverse edge targets `from`.
         let map = self.associations.entry(label.clone()).or_default();
-        map.insert((from_uuid, to_uuid), properties.clone());
+        map.insert((from_uuid, to_uuid), (*to.label(), properties.clone()));
         if let Some(inverse) = label.inverse() {
             let inverse_map = self.associations.entry(inverse).or_default();
-            inverse_map.insert((to_uuid, from_uuid), properties.clone());
+            inverse_map.insert((to_uuid, from_uuid), (*from.label(), properties.clone()));
         }
         Ok(())
     }
@@ -297,8 +346,10 @@ impl InMemoryResourceStore {
             })
             .transpose()?;
         let page_token = page_token.map(|t| Uuid::parse_str(&t)).transpose()?;
-        // Collect (to_uuid, properties) for every edge whose source is `resource_uuid`,
-        // applying the optional target filter and the pagination cursor.
+        // Collect (to_uuid, to_label, properties) for every edge whose source is
+        // `resource_uuid`, applying the optional target filter and the pagination
+        // cursor. The edge carries the target's label, so we can build the target
+        // ident directly without a `resources` lookup.
         let mut edges = self
             .associations
             .get(label)
@@ -307,9 +358,10 @@ impl InMemoryResourceStore {
                     .iter()
                     .filter_map(|entry| {
                         let (from, to) = *entry.key();
-                        (from == resource_uuid).then(|| (to, entry.value().clone()))
+                        let (to_label, props) = entry.value().clone();
+                        (from == resource_uuid).then_some((to, to_label, props))
                     })
-                    .filter(|(to, _)| {
+                    .filter(|(to, _, _)| {
                         target_uuid.is_none_or(|uuid| *to == uuid)
                             && page_token.is_none_or(|t| t > *to)
                     })
@@ -319,15 +371,14 @@ impl InMemoryResourceStore {
         if edges.is_empty() {
             return Ok((Vec::new(), None));
         }
-        edges.sort_unstable_by_key(|(to, _)| *to);
+        edges.sort_unstable_by_key(|(to, _, _)| *to);
 
         let max_page_size = usize::min(max_results.unwrap_or(MAX_PAGE_SIZE), MAX_PAGE_SIZE);
         let mut results = Vec::new();
         let mut last_id = Uuid::nil();
-        for (to_uuid, props) in edges.into_iter().rev().take(max_page_size) {
-            let resource = self.resources.get(&to_uuid).ok_or(Error::NotFound)?;
+        for (to_uuid, to_label, props) in edges.into_iter().rev().take(max_page_size) {
             last_id = to_uuid;
-            results.push((resource.resource_ident(), props));
+            results.push((to_label.to_ident(ResourceRef::Uuid(to_uuid)), props));
         }
         let next_page_token = (results.len() == max_page_size).then(|| last_id.to_string());
         Ok((results, next_page_token))
@@ -460,6 +511,119 @@ mod tests {
         let result = store.get(&ident).await;
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), Error::NotFound));
+    }
+
+    #[tokio::test]
+    async fn create_honors_pre_allocated_id() {
+        use unitycatalog_common::models::volumes::v1::Volume;
+
+        let store = test_store();
+        let id = Uuid::new_v4();
+        let resource: Resource = Volume {
+            name: "vol".into(),
+            catalog_name: "cat".into(),
+            schema_name: "sch".into(),
+            volume_id: id.hyphenated().to_string(),
+            ..Default::default()
+        }
+        .into();
+
+        let (_, reference) = store.create(resource).await.unwrap();
+        // The store persists under the supplied id rather than minting a new one.
+        assert_eq!(reference, ResourceRef::Uuid(id));
+    }
+
+    #[tokio::test]
+    async fn create_generates_id_when_absent() {
+        // A resource with no id set (the common case) still gets a fresh v7 id.
+        let store = test_store();
+        let resource: Resource = Catalog {
+            name: "cat".into(),
+            ..Default::default()
+        }
+        .into();
+        let (_, reference) = store.create(resource).await.unwrap();
+        let ResourceRef::Uuid(id) = reference else {
+            panic!("expected a uuid reference, got {reference:?}");
+        };
+        assert_eq!(id.get_version_num(), 7, "store should mint a v7 id");
+    }
+
+    #[tokio::test]
+    async fn staging_table_and_table_share_one_id() {
+        use unitycatalog_common::models::staging_tables::v1::StagingTable;
+        use unitycatalog_common::models::tables::v1::Table;
+
+        // The managed-table flow has a Table adopt its StagingTable's id, so both
+        // rows live at the same uuid under different labels. They must coexist.
+        let store = test_store();
+        let id = Uuid::new_v4();
+        let id_str = id.hyphenated().to_string();
+
+        store
+            .create(
+                StagingTable {
+                    name: "t".into(),
+                    catalog_name: "cat".into(),
+                    schema_name: "sch".into(),
+                    id: id_str.clone(),
+                    ..Default::default()
+                }
+                .into(),
+            )
+            .await
+            .unwrap();
+        store
+            .create(
+                Table {
+                    name: "t".into(),
+                    catalog_name: "cat".into(),
+                    schema_name: "sch".into(),
+                    table_id: Some(id_str.clone()),
+                    ..Default::default()
+                }
+                .into(),
+            )
+            .await
+            .unwrap();
+
+        // Both are retrievable by their own label-scoped uuid; neither clobbered
+        // the other.
+        let staging_ident = ObjectLabel::StagingTable.to_ident(ResourceRef::Uuid(id));
+        let table_ident = ObjectLabel::Table.to_ident(ResourceRef::Uuid(id));
+        let staging: StagingTable = store
+            .get(&staging_ident)
+            .await
+            .unwrap()
+            .0
+            .try_into()
+            .unwrap();
+        let table: Table = store.get(&table_ident).await.unwrap().0.try_into().unwrap();
+        assert_eq!(staging.id, id_str);
+        assert_eq!(table.table_id.as_deref(), Some(id_str.as_str()));
+    }
+
+    #[tokio::test]
+    async fn create_rejects_duplicate_pre_allocated_id() {
+        use unitycatalog_common::models::volumes::v1::Volume;
+
+        let store = test_store();
+        let id = Uuid::new_v4();
+        let volume = |name: &str| -> Resource {
+            Volume {
+                name: name.into(),
+                catalog_name: "cat".into(),
+                schema_name: "sch".into(),
+                volume_id: id.hyphenated().to_string(),
+                ..Default::default()
+            }
+            .into()
+        };
+        store.create(volume("a")).await.unwrap();
+        // A different name but the same pre-allocated id must not overwrite the
+        // existing row (Postgres relies on the id primary key for this).
+        let res = store.create(volume("b")).await;
+        assert!(matches!(res, Err(Error::AlreadyExists)), "{res:?}");
     }
 
     #[tokio::test]

--- a/crates/server/src/rest/validation.rs
+++ b/crates/server/src/rest/validation.rs
@@ -75,18 +75,17 @@ where
             .get(axum::http::header::CONTENT_LENGTH)
             .and_then(|v| v.to_str().ok())
             .and_then(|s| s.parse::<usize>().ok())
+            && content_length > MAX_BODY_SIZE
         {
-            if content_length > MAX_BODY_SIZE {
-                let response = (
-                    StatusCode::PAYLOAD_TOO_LARGE,
-                    format!(
-                        "Request body too large: {} bytes (limit: {} bytes)",
-                        content_length, MAX_BODY_SIZE
-                    ),
-                )
-                    .into_response();
-                return async { Ok(response) }.boxed();
-            }
+            let response = (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                format!(
+                    "Request body too large: {} bytes (limit: {} bytes)",
+                    content_length, MAX_BODY_SIZE
+                ),
+            )
+                .into_response();
+            return async { Ok(response) }.boxed();
         }
 
         self.inner.call(req).boxed()

--- a/crates/server/src/services/object_store.rs
+++ b/crates/server/src/services/object_store.rs
@@ -113,10 +113,10 @@ pub(crate) async fn list_table_volume_locations(
         .await?;
     for resource in tables {
         let table: Table = resource.try_into()?;
-        if let Some(loc) = table.storage_location.filter(|s| !s.is_empty()) {
-            if let Ok(url) = StorageLocationUrl::parse(&loc) {
-                out.push(url);
-            }
+        if let Some(loc) = table.storage_location.filter(|s| !s.is_empty())
+            && let Ok(url) = StorageLocationUrl::parse(&loc)
+        {
+            out.push(url);
         }
     }
 
@@ -125,10 +125,10 @@ pub(crate) async fn list_table_volume_locations(
         .await?;
     for resource in volumes {
         let volume: Volume = resource.try_into()?;
-        if !volume.storage_location.is_empty() {
-            if let Ok(url) = StorageLocationUrl::parse(&volume.storage_location) {
-                out.push(url);
-            }
+        if !volume.storage_location.is_empty()
+            && let Ok(url) = StorageLocationUrl::parse(&volume.storage_location)
+        {
+            out.push(url);
         }
     }
 


### PR DESCRIPTION
## Summary

Managed volumes now get a **GUID-based storage path** —
`{root}/__unitystorage/volumes/{volume_id}` — instead of the old name-based
`volumes/{name}`, mirroring the `tables/{uuid}` convention used by managed
tables.

- The path segment equals the volume's persisted `volume_id`, so it **survives
  renames** and **avoids collisions** when a name is reused after drop/recreate.
- The id is a **server-generated UUID v7**. API request types carry no id field,
  so callers cannot set it; only the server handler allocates one.
- External volumes are unchanged (they keep their caller-supplied location).

### Store contract change

To make the persisted `volume_id` equal the path segment, the resource stores
now **honor a caller pre-allocated id on create** (falling back to a fresh v7
when absent):

- **In-memory** (`memory.rs`): `create()` honors a pre-set id. `resources` is
  re-keyed from `Uuid` to `(ObjectLabel, Uuid)` so a `Table` can adopt its
  `StagingTable`'s id (`table_uuid == staging.id`) without the two rows
  colliding at the same key. In-memory association edges now carry the target
  label (mirroring Postgres's `to_label`), so the target ident is built without
  a `resources` lookup.
- **Postgres** (`graph/store.rs`, `resources.rs`): `add_object` gains an optional
  id, inserted via `INSERT INTO objects (id, ...) VALUES (COALESCE($1, uuidv7()), ...)`
  so the column default still fires for id-less creates. Regenerated `.sqlx`
  offline cache.

Namespace uniqueness on the `catalog.schema.name` triplet is preserved.

> Note: the Postgres `object_label` enum has no `staging_table` value, so
> staging tables are in-memory-only today — the StagingTable/Table id reuse only
> occurs in the in-memory store. The Postgres id-honoring path is exercised by
> managed volumes (single-row, no collision).

## Test plan

- [x] `cargo test -p unitycatalog-server` (111 tests) — incl. new volume tests:
      path equals `volume_id`, schema-location precedence, external unchanged,
      recreate-yields-new-path, duplicate-name rejected.
- [x] New store tests: pre-set id honored, v7 minted when absent, per-label
      duplicate-id rejection, and StagingTable+Table coexist at one id.
- [x] `cargo test -p unitycatalog-acceptance` (managed volume + cross-resource
      lifecycle journeys).
- [x] `cargo clippy` clean on changed files; `cargo fmt --check` clean.
- [x] `just build-sqlx` to refresh the offline query cache.

AI-assisted by Isaac
