### PR TITLE
feat: default the CLI server to SQLite :memory: backend

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -100,10 +100,10 @@ impl Default for Config {
         Self {
             host: None,
             port: None,
-            backend: Backend::InMemory,
-            // No config file: fall back to a dev KEK so the in-memory server
-            // runs out of the box. Real deployments supply their own
-            // `encryption` config (see `EncryptionConfig::dev_default`).
+            backend: Backend::default(),
+            // No config file: fall back to a dev KEK so the default ephemeral
+            // SQLite server runs out of the box. Real deployments supply their
+            // own `encryption` config (see `EncryptionConfig::dev_default`).
             encryption: Some(EncryptionConfig::dev_default()),
             upstream: None,
             routing: RoutingConfig::default(),
@@ -215,7 +215,7 @@ impl RoutingConfig {
 }
 
 /// Backend configuration for the unity catalog server.
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case", tag = "engine")]
 pub enum Backend {
     /// Postgres backend configuration.
@@ -224,17 +224,26 @@ pub enum Backend {
     /// Embedded SQLite backend configuration.
     ///
     /// Durable, file-based storage that runs in-process — no external database
-    /// to operate. Suitable for a capable local single-binary server. Delta
-    /// catalog-managed commits are not durably coordinated by this backend (see
-    /// the `unitycatalog-sqlite` crate docs).
+    /// to operate. Suitable for a capable local single-binary server. The
+    /// special path `:memory:` opens an ephemeral in-process database, which is
+    /// the default when no config file is supplied — a feature-complete,
+    /// non-persistent dev backend (it coordinates Delta commits like the
+    /// file/Postgres backends, unlike the former bespoke in-memory store).
     Sqlite(SqliteBackendConfig),
+}
 
-    /// In-memory backend configuration.
+impl Default for Backend {
+    /// Default to an ephemeral in-process SQLite database (`:memory:`).
     ///
-    /// This is useful for testing and development purposes
-    /// but should not be used in production.
-    #[default]
-    InMemory,
+    /// This replaces the former bespoke in-memory store: it exercises the same
+    /// store and commit-coordinator code paths as the file and Postgres
+    /// backends, so a config-less `uc server` behaves like a real deployment
+    /// minus persistence.
+    fn default() -> Self {
+        Backend::Sqlite(SqliteBackendConfig {
+            path: ConfigValue::Value(":memory:".to_string()),
+        })
+    }
 }
 
 /// SQLite backend configuration.
@@ -308,8 +317,9 @@ impl EncryptionConfig {
     /// A fixed, well-known KEK for local development only.
     ///
     /// Used by [`Config::default`] so `uc server` runs without a config file
-    /// against the in-memory backend, where secrets do not survive a restart.
-    /// **Never use this in production** — supply a real KEK via a config file.
+    /// against the default ephemeral SQLite backend, where secrets do not
+    /// survive a restart. **Never use this in production** — supply a real KEK
+    /// via a config file.
     pub fn dev_default() -> Self {
         // 32 zero-derived bytes (`0..32`), base64-encoded. Deliberately not secret.
         const DEV_KEK: &str = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=";
@@ -427,7 +437,12 @@ mod tests {
         let config = Config::default();
         assert!(config.host.is_none());
         assert!(config.port.is_none());
-        assert!(matches!(config.backend, Backend::InMemory));
+        // The config-less default is an ephemeral in-process SQLite database.
+        let backend = match config.backend {
+            Backend::Sqlite(ref b) => b,
+            ref other => panic!("expected sqlite backend, got {other:?}"),
+        };
+        assert_eq!(backend.database_path().as_deref(), Some(":memory:"));
         assert!(config.upstream.is_none());
         assert_eq!(config.routing, RoutingConfig::default());
         assert!(!config.routing.any_upstream());
@@ -441,7 +456,8 @@ mod tests {
     fn test_minimal_config() {
         let config = r#"{}"#;
         let config: Config = serde_json::from_str(config).unwrap();
-        assert!(matches!(config.backend, Backend::InMemory));
+        // An empty config gets the default ephemeral SQLite backend.
+        assert!(matches!(config.backend, Backend::Sqlite(_)));
         assert!(!config.routing.any_upstream());
     }
 
@@ -453,7 +469,8 @@ mod tests {
         let yaml = format!(
             r#"
             backend:
-              engine: in-memory
+              engine: sqlite
+              path: ":memory:"
             encryption:
               active:
                 id: v2
@@ -492,7 +509,8 @@ mod tests {
     fn test_managed_storage_root_roundtrips() {
         let yaml = r#"
             backend:
-              engine: in-memory
+              engine: sqlite
+              path: ":memory:"
             managed_storage_root: "s3://bucket/meta"
         "#;
         let config: Config = serde_yml::from_str(yaml).unwrap();
@@ -507,7 +525,8 @@ mod tests {
         assert_eq!(reparsed.managed_storage_root, config.managed_storage_root);
 
         // Absent ⇒ None (default).
-        let bare: Config = serde_yml::from_str("backend:\n  engine: in-memory\n").unwrap();
+        let bare: Config =
+            serde_yml::from_str("backend:\n  engine: sqlite\n  path: \":memory:\"\n").unwrap();
         assert!(bare.managed_storage_root.is_none());
     }
 
@@ -523,7 +542,8 @@ mod tests {
     fn test_hybrid_config_roundtrip() {
         let yaml = r#"
             backend:
-              engine: in-memory
+              engine: sqlite
+              path: ":memory:"
             upstream:
               url: "http://uc-java:8080/api/2.1/unity-catalog"
             routing:

--- a/crates/cli/src/server/mod.rs
+++ b/crates/cli/src/server/mod.rs
@@ -7,7 +7,6 @@ use unitycatalog_client::UnityCatalogClient;
 use unitycatalog_common::store::ObjectStoreAdapter;
 use unitycatalog_postgres::GraphStore;
 use unitycatalog_server::api::RequestContext;
-use unitycatalog_server::memory::InMemoryResourceStore;
 use unitycatalog_server::policy::{ConstantPolicy, Policy};
 use unitycatalog_server::{
     rest::AnonymousAuthenticator,
@@ -138,7 +137,6 @@ async fn handle_rest(args: &ServerArgs) -> Result<()> {
     }
 
     let (handler, policy) = match &config.backend {
-        Backend::InMemory => get_memory_handler(encryptor).await?,
         Backend::Postgres(pg) => get_db_handler(pg, encryptor).await?,
         Backend::Sqlite(cfg) => get_sqlite_handler(cfg, encryptor).await?,
     };
@@ -196,9 +194,11 @@ fn print_startup_summary(host: &str, port: u16, config: &Config) {
     let base = format!("http://{host}:{port}");
 
     let backend = match &config.backend {
-        Backend::InMemory => "in-memory".to_string(),
         Backend::Postgres(_) => "postgres".to_string(),
-        Backend::Sqlite(_) => "sqlite".to_string(),
+        Backend::Sqlite(cfg) => match cfg.database_path().as_deref() {
+            Some(":memory:") => "sqlite (:memory:)".to_string(),
+            _ => "sqlite".to_string(),
+        },
     };
 
     let routing = if config.routing.any_upstream() {
@@ -257,13 +257,6 @@ async fn get_db_handler(
         store.clone(),
         store,
     )?;
-    Ok((handler, policy))
-}
-
-async fn get_memory_handler(encryptor: EnvelopeEncryptor) -> Result<LocalHandler> {
-    let store = Arc::new(InMemoryResourceStore::new(encryptor));
-    let policy: Arc<dyn Policy<RequestContext>> = Arc::new(ConstantPolicy::default());
-    let handler = ServerHandler::try_new_tokio(policy.clone(), store.clone(), store)?;
     Ok((handler, policy))
 }
 


### PR DESCRIPTION
## Summary

Defaults the CLI server to an **ephemeral in-process SQLite (`:memory:`) backend** and removes the bespoke in-memory production backend.

The old `InMemoryResourceStore` does not implement `CommitCoordinator`, so a config-less `uc server` silently used the fallback in-memory coordinator and diverged from the file/Postgres backends on catalog-managed Delta commits. SQLite `:memory:` exercises the *same* store and commit-coordinator code paths as the file/Postgres backends — just without persistence — so the default dev server now behaves like a real deployment minus durability.

## Changes
- Remove the `Backend::InMemory` config variant; add `Default for Backend` returning `Sqlite { path: ":memory:" }`, so `Config::default()` (no config file) and `just rest` boot an ephemeral SQLite server.
- Drop the `Backend::InMemory` dispatch arm and `get_memory_handler`; remove the now-unused `InMemoryResourceStore` import. Startup banner shows `sqlite (:memory:)` distinctly.
- Migrate config tests from `engine: in-memory` to `engine: sqlite` + `:memory:`.

`InMemoryResourceStore` stays in `crates/server` as a **test-only fixture** — the per-module `handler()` helpers rely on it (no migration/async init needed). It is no longer reachable as a server/CLI backend.

## Test plan
- [x] `cargo test -p unitycatalog-cli` — 10/10 pass (config defaults now assert SQLite `:memory:`)
- [x] `cargo clippy -p unitycatalog-cli` — clean
- [x] Booted `uc server --rest` with no config file: banner reports `sqlite (:memory:)`, migrations run, `GET /catalogs` → 200

## Notes
- Backend is purely config-driven (`config.yaml` `backend.engine`); there is no `--use-db`-style flag.
- Unrelated pre-existing breakage spotted: the `just rest-db` target passes a `--use-db` flag that `ServerArgs` does not define. Left untouched here — worth a separate fix.

This pull request and its description were written by Isaac.
