### PR TITLE
test: add credential-vending integration test against Azurite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -456,6 +456,10 @@ jobs:
     services:
       azurite:
         image: mcr.microsoft.com/azure-storage/azurite
+        # `--blobHost 0.0.0.0` makes the blob endpoint reachable through the
+        # mapped host port (the default 127.0.0.1 bind is container-local and
+        # the port mapping would not connect).
+        command: azurite-blob --blobHost 0.0.0.0
         ports:
           - 10000:10000
     steps:
@@ -481,6 +485,13 @@ jobs:
       # connection, then create the container the test expects (the vended SAS
       # is scoped to a blob prefix and cannot create containers itself). The
       # account/key are Azurite's published well-known emulator credentials.
+      #
+      # Use a pinned `azure-cli` image rather than the runner's preinstalled
+      # `az`: the latter defaults to a Storage API version no released Azurite
+      # supports (e.g. 2026-04-06 → "API version ... not supported by Azurite"),
+      # while 2.64.0's default version is one Azurite accepts. Our actual test
+      # path is unaffected — the vended SAS pins sv=2020-12-06 and object_store
+      # sends 2023-11-03, both supported.
       - name: Provision Azurite container
         env:
           AZURITE_CONN: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
@@ -491,7 +502,10 @@ jobs:
             fi
             echo "waiting for azurite ($i)"; sleep 1
           done
-          az storage container create --name lakehouse --connection-string "$AZURITE_CONN"
+          docker run --rm --network host \
+            -e AZURITE_CONN \
+            mcr.microsoft.com/azure-cli:2.64.0 \
+            az storage container create --name lakehouse --connection-string "$AZURITE_CONN"
 
       - name: Run credential-vending Azurite integration tests
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -441,3 +441,80 @@ jobs:
           name: nextest results (postgres)
           path: target/nextest/ci/junit.xml
           reporter: jest-junit
+
+  integration_azurite:
+    name: integration-azurite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      # dorny/test-reporter publishes the parsed JUnit results as a check run.
+      checks: write
+    # Azurite (Azure Blob emulator) matches dev/compose.yaml. The credential
+    # vending test signs a SAS from the well-known emulator account key and
+    # uses it to read/write blobs against this service container.
+    services:
+      azurite:
+        image: mcr.microsoft.com/azure-storage/azurite
+        ports:
+          - 10000:10000
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: "1.96"
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          shared-key: coverage
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - uses: taiki-e/install-action@8b3c737da4b541bf0fb5a3e0488ff20535badac9 # v2.82.1
+        with:
+          tool: cargo-llvm-cov,cargo-nextest
+
+      # Azurite has no health endpoint; wait for the blob port to accept a
+      # connection, then create the container the test expects (the vended SAS
+      # is scoped to a blob prefix and cannot create containers itself). The
+      # account/key are Azurite's published well-known emulator credentials.
+      - name: Provision Azurite container
+        env:
+          AZURITE_CONN: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+        run: |
+          for i in $(seq 1 30); do
+            if curl -s -o /dev/null "http://127.0.0.1:10000/devstoreaccount1?comp=list"; then
+              echo "azurite is up"; break
+            fi
+            echo "waiting for azurite ($i)"; sleep 1
+          done
+          az storage container create --name lakehouse --connection-string "$AZURITE_CONN"
+
+      - name: Run credential-vending Azurite integration tests
+        env:
+          UC_AZURITE_BLOB_ENDPOINT: "http://127.0.0.1:10000"
+          UC_AZURITE_CONTAINER: "lakehouse"
+          SQLX_OFFLINE: "true"
+        run: |
+          cargo llvm-cov --no-report nextest -p unitycatalog-server --features integration-azurite --profile ci --run-ignored all -E 'binary(credential_vending_azurite)'
+          cargo llvm-cov report --codecov --output-path codecov.json
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !cancelled() }}
+        with:
+          files: codecov.json
+          flags: integration-azurite
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Publish test report
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: ${{ !cancelled() }}
+        with:
+          name: nextest results (azurite)
+          path: target/nextest/ci/junit.xml
+          reporter: jest-junit

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,23 +13,24 @@ coverage:
 
 codecov:
   require_ci_to_pass: false
-  # Four flagged reports are uploaded per run (see comment below). Wait for all
+  # Five flagged reports are uploaded per run (see comment below). Wait for all
   # of them before computing status / posting the comment, so neither shows
   # partial numbers from whichever job uploaded first.
   notify:
-    after_n_builds: 4
+    after_n_builds: 5
 
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
   # Match notify.after_n_builds so the PR comment is posted once, complete.
-  after_n_builds: 4
+  after_n_builds: 5
 
 # Per-layer coverage is uploaded under distinct flags from separate CI jobs:
 #   unit                 — workspace nextest suite (coverage job)
 #   doctests             — doctest coverage (coverage_doc job)
 #   integration-oss-java — live journeys vs the Java UC server
 #   integration-pg       — postgres commit-coordinator #[sqlx::test]s
+#   integration-azurite  — credential-vending SAS path vs an Azurite emulator
 # carryforward keeps a flag's last known coverage when a given PR's run did not
 # produce it (e.g. an integration job that was skipped), so the merged project
 # view stays complete.

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -64,3 +64,8 @@ grpc = ["tonic"]
 # reusable handler patterns: proxy leaves + UC-client connector
 proxy = ["dep:unitycatalog-client"]
 federation = ["proxy"]
+
+# Gates the Azurite credential-vending integration test
+# (`tests/credential_vending_azurite.rs`). Requires a running Azurite blob
+# emulator; run with `just integration-azurite`.
+integration-azurite = ["memory"]

--- a/crates/server/tests/credential_vending_azurite.rs
+++ b/crates/server/tests/credential_vending_azurite.rs
@@ -1,0 +1,210 @@
+//! Integration test for the Azurite credential-vending path.
+//!
+//! Proves the full offline-SAS vend path end-to-end against a live Azurite
+//! (Azure Blob emulator): the server signs a SAS from a storage-account key
+//! (no STS / online token service), and that vended SAS actually authorizes
+//! blob I/O at the expected scope. This is the Rust analogue of
+//! `open-lakehouse/scripts/azurite-seed.sh`.
+//!
+//! Gated behind the `integration-azurite` feature and `#[ignore]` so it never
+//! runs in a normal `cargo test`. It needs a running Azurite blob emulator on
+//! `localhost:10000`. Run it with:
+//!
+//! ```sh
+//! just integration-azurite
+//! ```
+//!
+//! Environment knobs:
+//! | Variable                  | Default                  |
+//! |---------------------------|--------------------------|
+//! | `UC_AZURITE_BLOB_ENDPOINT`| `http://127.0.0.1:10000` |
+//! | `UC_AZURITE_CONTAINER`    | `lakehouse`              |
+#![cfg(feature = "integration-azurite")]
+
+use std::sync::Arc;
+
+use object_store::azure::{AzureConfigKey, MicrosoftAzureBuilder};
+use object_store::{ObjectStore, ObjectStoreExt, PutPayload, path::Path};
+use unitycatalog_common::models::credentials::v1::{
+    AzureStorageKey, CreateCredentialRequest, Purpose,
+};
+use unitycatalog_common::models::external_locations::v1::CreateExternalLocationRequest;
+use unitycatalog_common::models::temporary_credentials::v1::{
+    GenerateTemporaryPathCredentialsRequest,
+    generate_temporary_path_credentials_request::Operation, temporary_credential::Credentials,
+};
+use unitycatalog_common::services::encryption::{EnvelopeEncryptor, LocalKeyProvider};
+use unitycatalog_server::api::{
+    CredentialHandler, ExternalLocationHandler, RequestContext, TemporaryCredentialHandler,
+};
+use unitycatalog_server::memory::InMemoryResourceStore;
+use unitycatalog_server::policy::{ConstantPolicy, Policy, Principal};
+use unitycatalog_server::services::ServerHandler;
+
+/// The well-known Azurite account and key (local dev only — published by
+/// Microsoft, deliberately not secret).
+const ACCOUNT: &str = "devstoreaccount1";
+const ACCOUNT_KEY: &str =
+    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+fn container() -> String {
+    std::env::var("UC_AZURITE_CONTAINER").unwrap_or_else(|_| "lakehouse".to_string())
+}
+
+fn blob_endpoint() -> String {
+    std::env::var("UC_AZURITE_BLOB_ENDPOINT")
+        .unwrap_or_else(|_| "http://127.0.0.1:10000".to_string())
+}
+
+fn handler() -> ServerHandler<RequestContext> {
+    let encryptor =
+        EnvelopeEncryptor::local(LocalKeyProvider::single("test", vec![0x42; 32]).unwrap());
+    let store = Arc::new(InMemoryResourceStore::new(encryptor));
+    let policy: Arc<dyn Policy<RequestContext>> = Arc::new(ConstantPolicy::default());
+    ServerHandler::try_new_tokio(policy, store.clone(), store).unwrap()
+}
+
+fn ctx() -> RequestContext {
+    RequestContext {
+        recipient: Principal::anonymous(),
+    }
+}
+
+/// Register the `azure_storage_key` credential + a covering external location at
+/// `azurite://<container>`, mirroring `azurite-seed.sh`.
+async fn seed(h: &ServerHandler<RequestContext>) {
+    h.create_credential(
+        CreateCredentialRequest {
+            name: "azurite_key".to_string(),
+            purpose: Purpose::Storage as i32,
+            azure_storage_key: Some(AzureStorageKey {
+                account_name: ACCOUNT.to_string(),
+                account_key: ACCOUNT_KEY.to_string(),
+            }),
+            // The emulator account is not reachable for online validation here;
+            // we prove usability by actually performing blob I/O below.
+            skip_validation: Some(true),
+            ..Default::default()
+        },
+        ctx(),
+    )
+    .await
+    .unwrap();
+    h.create_external_location(
+        CreateExternalLocationRequest {
+            name: "azurite_loc".to_string(),
+            url: format!("azurite://{}", container()),
+            credential_name: "azurite_key".to_string(),
+            ..Default::default()
+        },
+        ctx(),
+    )
+    .await
+    .unwrap();
+}
+
+/// Vend a path credential for `url` and return its SAS token.
+async fn vend_sas(h: &ServerHandler<RequestContext>, url: &str, operation: Operation) -> String {
+    let cred = h
+        .generate_temporary_path_credentials(
+            GenerateTemporaryPathCredentialsRequest {
+                url: url.to_string(),
+                operation: operation as i32,
+                ..Default::default()
+            },
+            ctx(),
+        )
+        .await
+        .expect("vending should succeed");
+    match cred.credentials {
+        Some(Credentials::AzureUserDelegationSas(sas)) => sas.sas_token,
+        other => panic!("expected an Azure SAS credential, got {other:?}"),
+    }
+}
+
+/// Build an emulator-mode object store addressed at the container root, using a
+/// vended SAS — the same construction as the object-store crate's Azurite
+/// branch (`to_store`). Blob paths are relative to the container.
+fn azurite_store(sas: &str) -> Arc<dyn ObjectStore> {
+    // Point the emulator at the configured blob endpoint (`<endpoint>/<account>`),
+    // so the test works whether Azurite is on localhost or a CI service hostname.
+    let endpoint = format!("{}/{ACCOUNT}", blob_endpoint().trim_end_matches('/'));
+    let store = MicrosoftAzureBuilder::new()
+        .with_use_emulator(true)
+        .with_account(ACCOUNT)
+        .with_container_name(container())
+        .with_config(AzureConfigKey::Endpoint, endpoint)
+        .with_config(AzureConfigKey::SasKey, sas.to_string())
+        .build()
+        .expect("emulator store builds");
+    Arc::new(store)
+}
+
+/// A read-write vended SAS authorizes both writes and reads at its scope.
+#[tokio::test]
+#[ignore = "requires a running Azurite emulator (just integration-azurite)"]
+async fn read_write_sas_can_put_and_get() {
+    let h = handler();
+    seed(&h).await;
+
+    let prefix = "sales/orders";
+    let url = format!("azurite://{}/{prefix}", container());
+    let sas = vend_sas(&h, &url, Operation::PathReadWrite).await;
+
+    let store = azurite_store(&sas);
+    let blob = Path::from(format!("{prefix}/vended.txt"));
+    let body = b"written-with-vended-sas";
+
+    store
+        .put(&blob, PutPayload::from_static(body))
+        .await
+        .expect("read-write SAS should authorize PUT");
+    let got = store
+        .get(&blob)
+        .await
+        .expect("read-write SAS should authorize GET")
+        .bytes()
+        .await
+        .unwrap();
+    assert_eq!(&got[..], body, "round-trip body should match");
+}
+
+/// A read-only vended SAS authorizes reads but denies writes.
+#[tokio::test]
+#[ignore = "requires a running Azurite emulator (just integration-azurite)"]
+async fn read_only_sas_can_get_but_not_put() {
+    let h = handler();
+    seed(&h).await;
+
+    let prefix = "sales/orders";
+    let url = format!("azurite://{}/{prefix}", container());
+
+    // First write a blob with a read-write SAS so there is something to read.
+    let rw = vend_sas(&h, &url, Operation::PathReadWrite).await;
+    let rw_store = azurite_store(&rw);
+    let blob = Path::from(format!("{prefix}/ro-probe.txt"));
+    rw_store
+        .put(&blob, PutPayload::from_static(b"seed"))
+        .await
+        .expect("setup write should succeed");
+
+    // A read-only SAS can read it back...
+    let ro = vend_sas(&h, &url, Operation::PathRead).await;
+    let ro_store = azurite_store(&ro);
+    let got = ro_store
+        .get(&blob)
+        .await
+        .expect("read-only SAS should authorize GET")
+        .bytes()
+        .await
+        .unwrap();
+    assert_eq!(&got[..], b"seed");
+
+    // ...but cannot write.
+    let denied = Path::from(format!("{prefix}/ro-denied.txt"));
+    let res = ro_store.put(&denied, PutPayload::from_static(b"x")).await;
+    assert!(
+        res.is_err(),
+        "read-only SAS must NOT authorize PUT, but the write succeeded"
+    );
+}

--- a/dev/compose.yaml
+++ b/dev/compose.yaml
@@ -28,6 +28,9 @@ services:
     hostname: azurite
     profiles: ["azurite", "full"]
     restart: always
+    # `--blobHost 0.0.0.0` makes the blob endpoint reachable through the mapped
+    # port (the default 127.0.0.1 bind is container-local).
+    command: azurite-blob --blobHost 0.0.0.0
     networks:
       - sharing
     ports:

--- a/justfile
+++ b/justfile
@@ -293,6 +293,23 @@ integration-object-store:
     UC_INTEGRATION_URL="http://localhost:8080/api/2.1/unity-catalog/" \
     cargo test -p unitycatalog-object-store --test integration -- --ignored --test-threads=1
 
+# run the credential-vending integration test against an Azurite sidecar.
+# Boots the `azurite` compose profile (blob on localhost:10000), creates the
+# `lakehouse` container the test expects (the vended SAS cannot create
+# containers itself), then runs the `#[ignore]`d test under its feature gate.
+[group('test')]
+integration-azurite:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    docker compose -f dev/compose.yaml --profile azurite up -d --wait
+    conn="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://host.docker.internal:10000/devstoreaccount1;"
+    docker run --rm mcr.microsoft.com/azure-cli \
+        az storage container create --name lakehouse --connection-string "$conn"
+    UC_AZURITE_BLOB_ENDPOINT="http://127.0.0.1:10000" \
+    UC_AZURITE_CONTAINER="lakehouse" \
+    cargo test -p unitycatalog-server --features integration-azurite \
+        --test credential_vending_azurite -- --ignored --test-threads=1 --nocapture
+
 [group('test')]
 record-managed:
     UC_INTEGRATION_URL="$DATABRICKS_HOST" \

--- a/justfile
+++ b/justfile
@@ -303,7 +303,9 @@ integration-azurite:
     set -euo pipefail
     docker compose -f dev/compose.yaml --profile azurite up -d --wait
     conn="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://host.docker.internal:10000/devstoreaccount1;"
-    docker run --rm mcr.microsoft.com/azure-cli \
+    # Pinned azure-cli: newer `az` defaults to a Storage API version no released
+    # Azurite supports. 2.64.0's default is one Azurite accepts.
+    docker run --rm mcr.microsoft.com/azure-cli:2.64.0 \
         az storage container create --name lakehouse --connection-string "$conn"
     UC_AZURITE_BLOB_ENDPOINT="http://127.0.0.1:10000" \
     UC_AZURITE_CONTAINER="lakehouse" \


### PR DESCRIPTION
## Summary

Proves the offline-SAS credential-vending path end-to-end against a live Azurite (Azure Blob emulator): the server signs a SAS from a storage-account key (no STS/online token service), and that vended SAS actually authorizes blob I/O at the requested scope. The Rust analogue of open-lakehouse's `azurite-seed.sh`.

- `crates/server/tests/credential_vending_azurite.rs`: seeds an `azure_storage_key` credential + external location in an in-process handler, vends path credentials via `generate_temporary_path_credentials`, and uses the SAS to build an emulator-mode object store (same construction as the object-store crate's Azurite branch). Asserts a read-write SAS can PUT+GET and a read-only SAS can GET but not PUT.
- Gated behind the `integration-azurite` feature + `#[ignore]`, so it never runs in a normal `cargo test`. Reads `UC_AZURITE_BLOB_ENDPOINT` / `UC_AZURITE_CONTAINER` (defaults `http://127.0.0.1:10000` / `lakehouse`).
- CI: a mandatory `integration-azurite` job with an Azurite service container (mirrors the `integration-postgres` job — waits for the blob port, creates the container the vended SAS cannot create itself, runs under llvm-cov, uploads coverage + JUnit).
- `just integration-azurite` boots the azurite compose profile, provisions the container, and runs the test.

Now that the CLI defaults to SQLite (#219, merged), this vending path is exercised over the same store/commit-coordinator code as a real deployment.

## Test plan
- [x] `cargo test -p unitycatalog-server --features integration-azurite -- --ignored` — both tests pass against a docker Azurite container (RW PUT+GET; RO GET ok, PUT denied)
- [x] Exact CI nextest invocation (`--run-ignored all -E 'binary(credential_vending_azurite)'`) validated locally
- [x] Default build + clippy clean; CI YAML valid; justfile target parses

## Notes
- The `integration-azurite` job is intentionally mandatory (blocking), consistent with `integration-postgres`. Related: #213.

This pull request and its description were written by Isaac.
