### PR TITLE
fix(managed): adopt staging table-id on create across all backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,11 @@ napi = { version = "3.5", default-features = false, features = [
 ] }
 napi-derive = "3.5"
 object_store = { version = "0.13.2", features = ["azure", "aws", "gcp"] }
-# Git ref pinned to trestle main, which carries the Azurite SAS fix
-# (https,http protocol + corrected service-SAS string-to-sign). Bump the rev
-# when trestle main advances; switch to the published crate once available
-# (the company proxy can't serve it for now).
-olai-http = { git = "https://github.com/open-lakehouse/trestle", rev = "29ec6f3cd8136c1731fdd260465e10ebdf4bc889" }
-olai-store = { git = "https://github.com/open-lakehouse/trestle", rev = "29ec6f3cd8136c1731fdd260465e10ebdf4bc889" }
+# Git ref pinned to trestle main, which carries the Azurite SAS fix + the
+# ObjectStore::create(id) change (external resource-id adoption). Bump the rev
+# as trestle main advances; published crate isn't usable yet (proxy offset).
+olai-http = { git = "https://github.com/open-lakehouse/trestle", rev = "173ef0013a3ef8f9f525fcbbfd7e5c1243fe027d" }
+olai-store = { git = "https://github.com/open-lakehouse/trestle", rev = "173ef0013a3ef8f9f525fcbbfd7e5c1243fe027d" }
 pbjson = { version = "0.9" }
 pbjson-types = "0.9"
 prost = { version = "0.14.1" }

--- a/crates/common/src/store.rs
+++ b/crates/common/src/store.rs
@@ -286,9 +286,15 @@ where
 {
     async fn create(&self, resource: Resource) -> Result<(Resource, ResourceRef)> {
         let object: Object = resource.try_into()?;
+        // A non-nil id means the caller pre-allocated it (e.g. a managed table
+        // adopting its staging reservation's id, or a managed volume embedding
+        // the id in its storage path); a nil id lets the store mint a fresh v7.
+        // API request types carry no id field, so callers cannot force an id
+        // through this path. Mirrors the Postgres backend's `create`.
+        let supplied_id = (!object.id.is_nil()).then_some(object.id);
         let created = self
             .store
-            .create(object.label, &object.name, object.properties)
+            .create(object.label, &object.name, object.properties, supplied_id)
             .await?;
         let id = ResourceRef::Uuid(created.id);
         Ok((created.try_into()?, id))

--- a/crates/postgres/src/graph/store.rs
+++ b/crates/postgres/src/graph/store.rs
@@ -345,8 +345,9 @@ impl olai_store::ObjectStore<ObjectLabel> for Store {
         label: ObjectLabel,
         name: &ResourceName,
         properties: Option<serde_json::Value>,
+        id: Option<Uuid>,
     ) -> olai_store::Result<olai_store::Object<ObjectLabel>> {
-        Ok(self.add_object(&label, name, properties, None).await?)
+        Ok(self.add_object(&label, name, properties, id).await?)
     }
 
     async fn update(

--- a/crates/server/src/api/delta.rs
+++ b/crates/server/src/api/delta.rs
@@ -344,19 +344,17 @@ where
             }
             contract::validate_table_id_property(&request.properties, &staging.id)?;
 
-            // Mark the staging reservation committed. Address it by the same
-            // identity the store keys it under — `StagingTable::resource_name()` is
-            // a bare `[name]`, so use that (a constructed three-part name or the
-            // logical id would not resolve).
+            // Consume the staging reservation: the table adopts its id, and the
+            // backing object store keys objects by id (a single PRIMARY KEY), so
+            // the staging object must be removed before the table claims that id —
+            // otherwise the table insert collides ("Entity already exists").
+            // Address it by the identity the store keys it under —
+            // `StagingTable::resource_name()` is a bare `[name]`.
             let staging_ident =
                 ResourceIdent::staging_table(unitycatalog_common::models::ResourceName::new([
                     staging.name.as_str(),
                 ]));
-            let committed = unitycatalog_common::models::staging_tables::v1::StagingTable {
-                stage_committed: true,
-                ..staging.clone()
-            };
-            self.update(&staging_ident, committed.into()).await?;
+            self.delete(&staging_ident).await?;
             Some(staging.id)
         } else {
             // EXTERNAL: the location must live inside a registered external location.
@@ -1272,11 +1270,13 @@ mod tests {
         // Newly created managed table has no commits yet.
         assert_eq!(resp.latest_table_version, Some(0));
 
-        // The staging reservation is now committed.
-        let staged = find_staging_table_by_location(&h, &st.staging_location)
+        // The staging reservation is consumed on create: the table adopts its
+        // id (objects are keyed by a single id PRIMARY KEY, so the staging
+        // object must be removed to free that id), so it is no longer findable.
+        let err = find_staging_table_by_location(&h, &st.staging_location)
             .await
-            .unwrap();
-        assert!(staged.stage_committed);
+            .unwrap_err();
+        assert!(matches!(err, Error::NotFound), "{err:?}");
     }
 
     #[tokio::test]

--- a/crates/sqlite/src/store.rs
+++ b/crates/sqlite/src/store.rs
@@ -601,8 +601,9 @@ impl olai_store::ObjectStore<ObjectLabel> for SqliteStore {
         label: ObjectLabel,
         name: &ResourceName,
         properties: Option<serde_json::Value>,
+        id: Option<Uuid>,
     ) -> olai_store::Result<Object> {
-        Ok(self.add_object(&label, name, properties, None).await?)
+        Ok(self.add_object(&label, name, properties, id).await?)
     }
 
     async fn update(

--- a/crates/sqlite/tests/store.rs
+++ b/crates/sqlite/tests/store.rs
@@ -76,6 +76,7 @@ async fn create_get_by_id_and_name() {
         ObjectLabel::Catalog,
         &name(&["main"]),
         Some(props.clone()),
+        None,
     )
     .await
     .unwrap();
@@ -97,10 +98,10 @@ async fn duplicate_name_is_already_exists() {
     let temp = TempDb::new("dup");
     let s = store(&temp).await;
 
-    ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["main"]), None)
+    ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["main"]), None, None)
         .await
         .unwrap();
-    let err = ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["main"]), None)
+    let err = ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["main"]), None, None)
         .await
         .unwrap_err();
     assert!(
@@ -114,7 +115,7 @@ async fn update_and_delete() {
     let temp = TempDb::new("update");
     let s = store(&temp).await;
 
-    let created = ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["main"]), None)
+    let created = ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["main"]), None, None)
         .await
         .unwrap();
     let updated = ObjectStore::update(&s, &created.id, Some(serde_json::json!({"k": "v"})))
@@ -135,11 +136,11 @@ async fn list_by_namespace_with_pagination() {
 
     // Two schemas in catalog `main`, one in catalog `other`.
     for ns_schema in ["a", "b"] {
-        ObjectStore::create(&s, ObjectLabel::Schema, &name(&["main", ns_schema]), None)
+        ObjectStore::create(&s, ObjectLabel::Schema, &name(&["main", ns_schema]), None, None)
             .await
             .unwrap();
     }
-    ObjectStore::create(&s, ObjectLabel::Schema, &name(&["other", "c"]), None)
+    ObjectStore::create(&s, ObjectLabel::Schema, &name(&["other", "c"]), None, None)
         .await
         .unwrap();
 
@@ -184,10 +185,10 @@ async fn associations_create_inverse_and_cascade() {
     let temp = TempDb::new("assoc");
     let s = store(&temp).await;
 
-    let catalog = ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["main"]), None)
+    let catalog = ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["main"]), None, None)
         .await
         .unwrap();
-    let schema = ObjectStore::create(&s, ObjectLabel::Schema, &name(&["main", "s"]), None)
+    let schema = ObjectStore::create(&s, ObjectLabel::Schema, &name(&["main", "s"]), None, None)
         .await
         .unwrap();
 
@@ -235,10 +236,10 @@ async fn remove_association_removes_inverse() {
     let temp = TempDb::new("assoc-remove");
     let s = store(&temp).await;
 
-    let a = ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["a"]), None)
+    let a = ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["a"]), None, None)
         .await
         .unwrap();
-    let b = ObjectStore::create(&s, ObjectLabel::Schema, &name(&["a", "b"]), None)
+    let b = ObjectStore::create(&s, ObjectLabel::Schema, &name(&["a", "b"]), None, None)
         .await
         .unwrap();
     AssociationStore::add(&s, a.id, b.id, "parent_of", None)
@@ -288,7 +289,7 @@ async fn data_persists_across_reopen() {
     let temp = TempDb::new("persist");
     let created_id = {
         let s = store(&temp).await;
-        let c = ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["main"]), None)
+        let c = ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["main"]), None, None)
             .await
             .unwrap();
         s.put_secret("k", Bytes::from_static(b"v")).await.unwrap();
@@ -309,10 +310,10 @@ async fn name_matching_is_ascii_case_insensitive() {
     let temp = TempDb::new("nocase");
     let s = store(&temp).await;
 
-    ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["main"]), None)
+    ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["main"]), None, None)
         .await
         .unwrap();
-    let err = ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["MAIN"]), None)
+    let err = ObjectStore::create(&s, ObjectLabel::Catalog, &name(&["MAIN"]), None, None)
         .await
         .unwrap_err();
     assert!(


### PR DESCRIPTION
Creating a managed Delta table failed against the SQLite backend with a 409 assert-table-uuid (the committer's _delta_log/0.json uuid didn't match the catalog's table uuid) and then a 404 "Entity already exists".

Two coupled causes:
- The generic ObjectStoreAdapter::create dropped the adopted staging id (the olai_store ObjectStore::create trait had no id parameter), so the store minted a fresh id. Thread an Option<Uuid> through the adapter and the SQLite + Postgres graph stores, mirroring the Postgres ResourceStore path that already extracted a supplied id. (Trait change is in trestle 173ef00, pinned here.)
- createTable kept the staging object and inserted the table with the same adopted id, colliding on the objects.id primary key. Consume (delete) the staging reservation instead of marking it committed; update the happy-path test to assert it's gone.

Bumps olai-http/olai-store to the trestle main rev carrying the trait change.

AI assisted by Isaac

**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->