### PR TITLE
feat(managed): support managed Delta tables on local file:// storage

### DIFF
--- a/crates/datafusion/src/managed/create.rs
+++ b/crates/datafusion/src/managed/create.rs
@@ -25,6 +25,7 @@ use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use object_store::ObjectStore;
 use object_store::aws::AmazonS3Builder;
+use object_store::local::LocalFileSystem;
 use unitycatalog_client::DeltaV1Client;
 use unitycatalog_common::models::delta::v1::{
     DeltaCreateStagingTableRequest, DeltaCreateTableRequest, DeltaDataSourceFormat, DeltaDataType,
@@ -336,6 +337,27 @@ pub(crate) fn build_staging_store(
     staging: &DeltaStagingTableResponse,
     location: &Url,
 ) -> Result<Arc<dyn ObjectStore>, CreateManagedTableError> {
+    // Local (`file://`) staging needs no credential: the server vends a
+    // credential-less response for local managed storage, and the kernel engine
+    // addresses objects by full path, so an unrooted `LocalFileSystem` resolves
+    // them. Mirrors the server's `get_local_store` and the `unitycatalog-object-store`
+    // local branch. Short-circuit before the credential lookup, which would
+    // otherwise fail ("staging response carried no storage_credentials").
+    if location.scheme() == "file" {
+        // The table's managed directory does not exist yet (cloud stores create
+        // prefixes implicitly on first write, but a local filesystem does not, and
+        // the delta-rs table builder validates the local path exists before use).
+        // Create it so the kernel can write `0.json` and the snapshot read-back can
+        // open the location.
+        let dir = location.to_file_path().map_err(|_| {
+            CreateManagedTableError::other(format!("invalid local staging location: {location}"))
+        })?;
+        std::fs::create_dir_all(&dir).map_err(|e| {
+            CreateManagedTableError::other(format!("failed to create local table dir {dir:?}: {e}"))
+        })?;
+        return Ok(Arc::new(LocalFileSystem::new()));
+    }
+
     let cred = staging
         .storage_credentials
         .iter()

--- a/crates/server/src/api/temporary_credentials.rs
+++ b/crates/server/src/api/temporary_credentials.rs
@@ -9,11 +9,13 @@ use crate::api::CredentialHandler;
 use crate::api::credentials::CredentialHandlerExt;
 pub use crate::codegen::temporary_credentials::TemporaryCredentialHandler;
 use crate::policy::{Permission, Policy};
-use crate::services::credential_vending::{VendOperation, vend_credential};
-use crate::services::location::StorageLocationUrl;
+use crate::services::credential_vending::{VendOperation, local_path_credential, vend_credential};
+use crate::services::location::{StorageLocationScheme, StorageLocationUrl};
 use crate::services::object_store::find_external_location_for_url;
 use crate::store::ResourceStore;
 use crate::{Error, Result};
+
+use object_store::ObjectStoreScheme;
 
 /// The permission a vend operation requires from the policy.
 ///
@@ -69,6 +71,20 @@ impl<
     ) -> Result<TemporaryCredential> {
         let operation = to_vend_operation(request.operation);
         let storage_url = StorageLocationUrl::parse(&request.url)?;
+
+        // Local (`file://`) storage needs neither an external location nor a vended
+        // cloud credential: the client builds a `LocalFileSystem` addressed by full
+        // path, exactly as the server's own `get_object_store` short-circuits local
+        // storage. Without this, vending for a local managed root 404s
+        // (`find_external_location_for_url` finds no covering external location),
+        // which breaks managed-table creation on a purely-local dev server.
+        if matches!(
+            storage_url.scheme(),
+            StorageLocationScheme::ObjectStore(ObjectStoreScheme::Local)
+        ) {
+            return Ok(local_path_credential(&request.url));
+        }
+
         let ext_loc = find_external_location_for_url(&storage_url, self).await?;
         // Authorize against the concrete external location and the operation
         // actually requested, rather than the unscoped `SecuredAction` default.

--- a/crates/server/src/services/credential_vending.rs
+++ b/crates/server/src/services/credential_vending.rs
@@ -45,6 +45,21 @@ fn expiry_to_epoch_millis(expiry: Option<Instant>) -> i64 {
         .as_millis() as i64
 }
 
+/// A credential-less [`TemporaryCredential`] for a local (`file://`) location.
+///
+/// Local storage carries no secret: the client builds an unrooted
+/// `LocalFileSystem` addressed by full path (mirroring the server's
+/// `get_local_store`). The response still carries the `url` and an expiry so the
+/// shape matches a cloud vend, but `credentials` is `None` — the signal the
+/// client uses to take its local-store branch.
+pub(crate) fn local_path_credential(url: &str) -> TemporaryCredential {
+    TemporaryCredential {
+        expiration_time: expiry_to_epoch_millis(None),
+        url: url.to_owned(),
+        credentials: None,
+    }
+}
+
 fn aws_token_to_temporary_credential(
     url: &str,
     token: TemporaryToken<Arc<AwsCredential>>,

--- a/crates/sqlite/tests/store.rs
+++ b/crates/sqlite/tests/store.rs
@@ -136,9 +136,15 @@ async fn list_by_namespace_with_pagination() {
 
     // Two schemas in catalog `main`, one in catalog `other`.
     for ns_schema in ["a", "b"] {
-        ObjectStore::create(&s, ObjectLabel::Schema, &name(&["main", ns_schema]), None, None)
-            .await
-            .unwrap();
+        ObjectStore::create(
+            &s,
+            ObjectLabel::Schema,
+            &name(&["main", ns_schema]),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
     }
     ObjectStore::create(&s, ObjectLabel::Schema, &name(&["other", "c"]), None, None)
         .await


### PR DESCRIPTION
Creating a Unity Catalog managed Delta table whose managed storage root is a local file:// path failed: the staging->createTable handshake assumed cloud-backed storage with a registered external location + credential.

The server's create_staging_table reserved the staging row, then vended READ_WRITE credentials via generate_temporary_path_credentials, which calls find_external_location_for_url. With a local managed root and no external location registered, that 404s (surfaced as NoSuchTableException) — and since the staging row had already persisted, a retry then failed with "already exists". So managed-table creation could not work at all against a purely-local dev server.

Fix the local path end to end, mirroring the local short-circuit that get_object_store already has for the server's own I/O:

- server: generate_temporary_path_credentials short-circuits the file:// scheme and returns a credential-less TemporaryCredential (new local_path_credential helper) instead of requiring an external location. The table/volume vend paths need no change — the client object-store factory (for_table/for_volume) already bypasses vending for file:// by resolving the location by name.

- client: build_staging_store gains a file:// branch that builds an unrooted LocalFileSystem directly (the credential-less response carries no storage_credentials, which the cloud path requires), and creates the table's managed directory first — local filesystems don't create prefixes implicitly the way cloud stores do, and the delta-rs table builder validates the path exists before use.

Validated with the managed_table integration test pointed at a local file:// UC server: create -> append -> read round-trips (3 rows).

AI assisted by Isaac