### PR TITLE
docs: rework commit/sign flow and trim agent instructions

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,84 +1,92 @@
 ---
 name: commit
-description: This skill should be used when the user asks to "commit", "prepare a commit", "stage and commit", "commit my changes", or says the work is done and changes should be committed. Handles repos where git commit cannot be run directly by the agent (e.g. GPG signing, 2FA prompts) by preparing everything so the user pastes one command.
-version: 0.1.0
+description: This skill should be used when the user asks to "commit", "prepare a commit", "stage and commit", "commit my changes", or says the work is done and changes should be committed. Commits unsigned (no interactive GPG PIN) and defers signing to a single bulk step before opening a PR.
+version: 0.2.0
 ---
 
 # Commit Workflow
 
-For repos where `git commit` cannot be run directly by the agent (e.g. GPG PIN
-requires an interactive terminal), prepare everything so the user pastes one command.
+The commit-message contract (types, `AI-assisted-by: Isaac` trailer, granularity)
+lives in `~/.claude/CLAUDE.md` — follow it; this skill covers the mechanics.
+
+Commits here are GPG-signed, and the PIN needs an interactive terminal. The agent
+**commits unsigned** (`git commit --no-gpg-sign`, which needs no PIN), and the
+user **signs once before pushing / opening a PR**. No per-commit paste.
 
 ## Workflow
 
 ### Step 1 — Auto-fix lint
-Run the project's lint auto-fix command per CLAUDE.md
-(e.g. `cargo clippy --workspace --fix --allow-dirty` for Rust).
-
-Lint may rewrite code files. Always run this before formatting.
+`cargo clippy --workspace --fix --allow-dirty` (and `just fix-node` / `just fix-py`
+if those files changed). Lint may rewrite code; always run before formatting.
 
 ### Step 2 — Format all code
-Run the project's formatter per CLAUDE.md (e.g. `cargo fmt --all` for Rust).
+`cargo fmt --all` (plus the relevant language formatter if you touched node/py).
+Always after lint — lint rewrites may need reformatting.
 
-Always run after lint — lint rewrites may need reformatting.
+### Step 3 — Stage specific files (and split commits)
+Stage only relevant files by name — never `git add -A` / `git add .` (avoids
+generated files, `.env`, large binaries).
 
-### Step 3 — Update project documentation (if needed)
-Before staging, check whether any project documentation files need updating
-(e.g. CLAUDE.md, README) if commands, rules, or public APIs have changed.
-
-### Step 4 — Stage specific files
 ```bash
 git add <file1> <file2> ...
 ```
-Stage only relevant files by name. Never use `git add -A` or `git add .` — this can
-accidentally include generated files, `.env`, or large binaries.
 
-### Step 5 — Write commit message to file
-Derive the filename from the repo name and current branch to avoid collisions across
-sessions or worktrees:
+When the working tree spans **multiple logical changes**, make **multiple small,
+well-scoped commits** (one type/scope each) rather than one mixed commit — signing
+is a single bulk step per branch, so small commits cost nothing and give
+release-plz a richer per-crate history. Don't over-fragment. Commit generated
+output in the **same commit** as the change that produced it (see CLAUDE.md
+codegen rules).
+
+### Step 4 — Write the message, then commit unsigned
+Derive a temp filename from repo + branch to avoid collisions across worktrees:
 
 ```bash
-# Determine the path (run via Bash tool to get live values)
 REPO=$(basename $(git rev-parse --show-toplevel))
 BRANCH=$(git rev-parse --abbrev-ref HEAD | tr '/' '-')
 MSG_FILE="/tmp/commit_msg_${REPO}_${BRANCH}.txt"
 ```
 
-Write the commit message to that path using the Write tool (not echo/heredoc).
-
-**Format:**
-```
-<type>: <subject ≤72 chars, imperative mood>
-
-<body: what changed and why>
-
-AI-assisted-by: Isaac
-```
-
-**Types:** `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
-
-The `AI-assisted-by: Isaac` trailer is required on every commit.
-
-### Step 6 — Print message and provide command
-1. Print the full commit message in a code block so the user can review it
-2. Print the commit command in its own code block (substituting the actual resolved path):
+Write the message to that path with the **Write tool** (not echo/heredoc — on
+macOS/zsh a pasted multiline heredoc leaves the shell in incomplete-input state).
+Format per `~/.claude/CLAUDE.md` (`<type>: <subject>` / body / `AI-assisted-by:
+Isaac`). Then commit directly — no PIN needed:
 
 ```bash
-git commit -F /tmp/commit_msg_<repo>_<branch>.txt && rm /tmp/commit_msg_<repo>_<branch>.txt
+git commit --no-gpg-sign -F "$MSG_FILE" && rm "$MSG_FILE"
 ```
 
-3. Tell the user: "Run `/copy` to copy the command to your clipboard, then paste and run it."
+**Pre-commit hook:** this repo has an active `.pre-commit-config.yaml` (Biome,
+typos, Ruff, cargo fmt + cargo-check) that runs on every commit, signed or not,
+and can rewrite files or abort. If it rewrites files, re-stage them and retry the
+commit once. If it still fails, surface the hook output and stop — don't loop.
+The `&& rm` only runs on success, so a failed commit preserves the message file.
 
-The `&& rm` cleans up the temp file automatically after a successful commit.
-If the commit fails (e.g. hook rejection), the file is preserved for inspection.
+### Step 5 — Push and open the PR (don't wait on signing)
+Commit unsigned, then **push and open the PR in the same pass** — don't stop to
+wait for the GPG PIN mid-flow. Tell the user the commits are unsigned and will be
+signed in one bulk step at the end. Don't offer a re-sign after each commit.
 
-**Never use heredocs or `\n`-escaped strings** — on macOS/zsh, pasting multiline
-heredocs leaves the shell in an incomplete input state.
+## Signing — one bulk step at the end (after the PR is open)
+
+Signing rewrites the commits (amend), so the already-pushed branch needs a
+`--force-with-lease` re-push. That's safe on a solo feature branch and is
+preferred over splitting work across handoffs. Surface ONE combined command for
+the user to run (one GPG PIN); signatures aren't required to merge, so this can
+happen any time before merge:
+
+- One commit (HEAD):
+  ```bash
+  git commit --amend --no-edit -S && git push --force-with-lease
+  ```
+- Range (the normal case):
+  ```bash
+  git rebase --exec 'git commit --amend --no-edit -S' "$(git merge-base main HEAD)" && git push --force-with-lease
+  ```
+- Verify: `git log --format='%h %G? %s' main..HEAD` — every commit shows `G`.
 
 ## Notes
 
-- Steps 1 and 2 must run in order — lint first, then format
-- Do not skip lint even for small changes; it may catch issues
-- If lint or format changes files, include them in the staged set
-- If the project uses code generation, commit generated files separately per
-  CLAUDE.md conventions to keep review diffs readable
+- Steps 1 and 2 run in order — lint first, then format.
+- Don't skip lint even for small changes.
+- If lint or format changes files, include them in the staged set.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -55,59 +55,85 @@ To add a new resource/API surface, follow these steps:
    - Add streaming support for list operations
 
 6. **Add Python bindings**:
-   - Import new types in `python/client/src/lib.rs`
-   - Add Python client wrapper in `python/client/src/client.rs`
-   - Re-run `just generate-code` — the type stub at
-     `python/client/python/unitycatalog_client/_client.pyi` is **fully
-     regenerated** from the proto + Rust client surface (the justfile
-     `mv`s a freshly-built stub over the existing file), so do **not**
-     edit it by hand.
-   - If you added a new pyclass to `python/client/src/lib.rs`'s
-     `_client` module, also add the matching
-     `from ._client import Foo as Foo` line (and `"Foo"` in `__all__`)
-     to `python/client/python/unitycatalog_client/__init__.py` so the
-     symbol surfaces at the package root with a deliberate, typed
-     re-export. The package root has **no** `__init__.pyi`: the
-     explicit `import X as X` form is sufficient for static type
-     checkers to resolve `unitycatalog_client.X` to the typed entry
-     declared in `_client.pyi`.
+   - Import new types in `python/client/src/lib.rs`; add the client wrapper in
+     `python/client/src/client.rs`.
+   - Re-run `just generate-code` (regenerates `_client.pyi`), then re-export any
+     new pyclass at the package root — see **Hand-written PyO3 helpers** below
+     for the `from ._client import Foo as Foo` convention.
 
 ### Hand-written PyO3 helpers
 
-A small number of Python bindings are not proto-derived (e.g.
-`parse_uc_url`, ergonomic methods like `temporary_*_credential` that
-do name → UUID resolution before calling the generated RPC). These
-live in `python/client/src/{client,reference}.rs` and have PyO3 names,
-signatures, and docstrings — but Python type checkers can't read those
-attributes off the compiled `.so`, and the trestle codegen doesn't see
-them either.
+A few Python bindings are not proto-derived (e.g. `parse_uc_url`, ergonomic
+`temporary_*_credential` methods that resolve name → UUID before calling the
+generated RPC). They live in `python/client/src/{client,reference}.rs`; type
+checkers can't read their attributes off the compiled `.so` and trestle codegen
+doesn't see them. **Never hand-edit `_client.pyi`** (it is fully regenerated).
+Instead:
 
-The convention is **not** to hand-edit `_client.pyi` directly. Instead:
+- **Declare the symbol in `python/client/_client_supplement.pyi`.** `just
+  generate-code` appends this fragment to the codegen-emitted `_client.pyi`, so
+  the merged stub describes the full `_client` runtime surface. The supplement
+  lives outside the package dir so type checkers don't validate it standalone.
+- **Re-export from the package root** via the PEP 484 form `from ._client import
+  Foo as Foo` in `python/client/python/unitycatalog_client/__init__.py` — the
+  same idiom used for codegen-derived types. Do this whenever you
+  `m.add_class::<Foo>()` (or register a new exception / free function) in
+  `python/client/src/lib.rs`. Keep internal helpers (e.g. `parse_uc_url`) out of
+  the root re-export list; consumers import them from `..._client` directly.
+- **For proto-shaped surface** (a regular `Get/Update/Delete/Create/List` RPC, or
+  a `Custom(Post|Patch)` RPC the Python emitter renders), prefer extending the
+  proto so trestle generates everything end-to-end.
 
-- **Declare the symbol in `python/client/_client_supplement.pyi`.**
-  The `just generate-code` recipe appends this hand-written fragment
-  to the codegen-emitted `_client.pyi` after the move, so the merged
-  stub describes the full runtime surface of the `_client` PyO3
-  module. The supplement lives outside the package directory so
-  static type checkers don't try to validate it standalone (it is a
-  fragment, not a complete stub).
+## Releases
 
-- **Re-export from the package root via `__init__.py`** using the
-  PEP 484 `from ._client import Foo as Foo` form, exactly like the
-  codegen-derived types. The merged `_client.pyi` describes
-  hand-written and codegen-emitted names uniformly, so the same
-  re-export idiom serves both. Keep internal helpers (e.g.
-  `parse_uc_url`) out of the package-root re-export list — consumers
-  that legitimately need them can import from `unitycatalog_client._client`
-  directly.
+Releases are driven by [release-plz](https://release-plz.dev) from
+[Conventional Commits](https://www.conventionalcommits.org). You never bump versions or
+write changelogs by hand. The PR title is the squash-merge commit, so CI lints it against
+the convention (`commitlint.config.mjs`); the commit type drives the semver bump.
 
-- **For proto-shaped surface** (a regular `Get/Update/Delete/Create/List`-
-  flavoured RPC, or a `Custom(Post|Patch)`-flavoured RPC that the
-  Python emitter knows how to render), prefer extending the proto so
-  trestle generates everything end-to-end.
+**Each crate versions independently.** release-plz bumps a crate from the commits that
+touch it (and bumps its dependents automatically), so `unitycatalog-object-store` and
+`datafusion-unitycatalog` can release on their own cadence. Config: `release-plz.toml`.
 
-When you `m.add_class::<NewType>()` in `python/client/src/lib.rs`
-(or hand-register a new exception / free function), remember to add
-the matching `from ._client import NewType as NewType` line to
-`python/client/python/unitycatalog_client/__init__.py` so the symbol
-surfaces at the package root.
+Because release-plz derives the bump and changelog *from the commits*, **small,
+well-scoped commits with the right `type(scope):`** (per `~/.claude/CLAUDE.md`)
+directly produce an accurate per-crate history. Prefer several focused commits
+over one mixed commit; keep generated output in the same commit as its source.
+
+**How a release happens:**
+
+1. Merge PRs to `main` with conventional-commit titles (`feat:`, `fix:`, `feat(scope)!:`
+   for breaking changes).
+2. release-plz opens/updates a **Release PR** that bumps the affected crates' versions
+   and updates their changelogs. Review it like any PR.
+3. **Merging the Release PR** publishes: release-plz tags each changed crate
+   (`<crate>-v<version>`) and creates its GitHub Release. The tag then triggers the build
+   workflow that attaches artifacts.
+
+**Tags that trigger artifact builds:**
+
+| Tag                          | Builds & attaches            | Workflow                            |
+|------------------------------|------------------------------|-------------------------------------|
+| `unitycatalog-cli-v*`        | `uc` binaries + GHCR image   | release.yml, docker-release.yml     |
+| `unitycatalog-client-py-v*`  | Python wheels (Linux + macOS)| python-release.yml                  |
+
+Other crates get a tag + GitHub Release (changelog) but no extra artifact build. The crates
+are not published to crates.io (`publish = false`); release-plz only tags and releases them.
+
+**Notes:**
+
+- Versions live committed in each `Cargo.toml`; release-plz writes them via the Release PR.
+  Never edit a version manually and never use a placeholder — artifacts build from the
+  committed version at a real commit SHA, which the provenance attestations bind to.
+- Release notes are generated by git-cliff (`cliff.toml`); the artifact workflows *append*
+  download/verify instructions to that body. To change note formatting, edit `cliff.toml`.
+- release-plz needs a `RELEASE_PLZ_TOKEN` secret (PAT/App token) so the tags it creates
+  trigger the downstream workflows — the default `GITHUB_TOKEN` cannot.
+
+## AI-assisted contributions
+
+AI-assisted changes are welcome. Understand the diff before submitting it, match
+the surrounding style, and don't include code you can't explain. Every commit
+carries the `AI-assisted-by: Isaac` trailer and PR bodies end with the
+attribution line — both are defined in `~/.claude/CLAUDE.md`. The commit/sign
+mechanics live in the `/commit` skill (`.claude/skills/commit/SKILL.md`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Tabs are synced across the entire site via Starlight's built-in `localStorage` p
 
 **Rust**: Follow standard Rust conventions with 4-space indentation.
 Use `cargo fmt` for formatting and `cargo clippy` for linting.
-Requires Rust **1.85+** with Edition **2024** (configured in workspace `Cargo.toml`).
+Edition and MSRV are pinned in the workspace `Cargo.toml` — read them there.
 
 **JavaScript/TypeScript**: 2-space indentation, managed by Biome formatter/linter.
 
@@ -165,28 +165,40 @@ Pre-commit hooks enforce formatting with Biome, Ruff, and typos checking.
 
 ## Commit & Pull Request Guidelines
 
-GPG commit signing is required. **Never run `git commit` directly** — the GPG PIN prompt needs an interactive terminal and will time out.
+The commit-message contract and signing flow are machine-wide — see
+`~/.claude/CLAUDE.md`. In short: commit **unsigned** as you go via the `/commit`
+skill (`.claude/skills/commit/SKILL.md`); **sign the whole branch once before
+opening a PR**. Prefer small, well-scoped commits — release-plz reads them.
 
-Use the `/commit` skill (`.claude/skills/commit/SKILL.md`) for the full pre-commit workflow: clippy → fmt → stage → commit message file → paste command.
+Repo-specific rules:
+- **Generated code in the same commit** as the change that produced it (run
+  `just generate` after proto changes) so reviewers trace generation to output
+  in one diff. Stage by name; never `git add -A`.
 
-**Code Generation**: Many files are auto-generated. Run `just generate` after proto changes and commit generated code in the same commit as the changes that produced them — this keeps generation logic and its output traceable together.
+### Quick pre-push check (mimics CI)
+
+```bash
+cargo fmt --all --check \
+  && cargo clippy --workspace --all-targets --all-features -- -D warnings \
+  && cargo nextest run --workspace --all-features --profile ci -E 'not binary(commit_coordinator)' \
+  && cargo test --workspace --all-features --doc
+```
 
 ### Pull Request workflow
 
-1. **Create a feature branch** before starting any implementation — never work on `main`:
-   ```bash
-   git checkout -b feat/<short-description>
-   ```
-
-2. **Create follow-up issues** (via `gh issue create`) *before* opening the PR so they can be referenced in the PR body. Common follow-up patterns:
-   - Migrations deferred to keep the PR focused
-   - Related work in sibling crates not touched by this PR
-
-3. **Open the PR** with `gh pr create` targeting `main`:
-   - Title format: `<type>: <description> (#<issue>)` — reference the issue being closed
-   - Body: bullet-point summary, test plan checklist, `Closes #N` line, follow-up issue references, and the `AI-assisted by Isaac` attribution line
-
-4. **Commit generated code together** with the changes that produced them. Stage hand-written changes and their generated output in the same commit so reviewers can trace generation logic to its output in one diff.
+1. **Create a feature branch** before any implementation — never work on `main`
+   (`git checkout -b feat/<short-description>`).
+2. **Create follow-up issues** (`gh issue create`) *before* opening the PR so the
+   body can reference them — e.g. deferred migrations, sibling-crate work.
+3. **Commit (unsigned) → push → open the PR in one pass** — don't wait on
+   signing mid-flow (signatures aren't required to merge). `gh pr create`, target
+   `main`:
+   - Title: `<type>: <description> (#<issue>)` — reference the closed issue.
+   - Body: bullet summary, test-plan checklist, `Closes #N`, follow-up refs, and
+     the `This pull request was AI-assisted by Isaac.` line.
+4. **Sign once at the end** — surface the combined sign + `--force-with-lease`
+   command from `~/.claude` for the user to run (one PIN); can happen any time
+   before merge. See the `/commit` skill.
 
 ### GitHub Issues workflow
 


### PR DESCRIPTION
## Summary

Lower-friction commit/sign workflow for AI-assisted work, plus a trim of the agent instructions.

- **Commit/sign flow:** the agent now commits **unsigned** (`git commit --no-gpg-sign`, no interactive GPG PIN), pushes, and opens the PR in one pass. The user signs the whole branch **once at the end** with a single combined sign + `--force-with-lease` push — no per-commit paste, no waiting on the PIN mid-flow. Signatures aren't required to merge.
- **`/commit` skill** rewritten for this flow, including pre-commit hook handling and guidance to prefer small, well-scoped commits (richer release-plz history).
- **`CLAUDE.md` trimmed:** commit/PR section points at the machine-wide `~/.claude` contract; added a CI-mirroring pre-push one-liner; replaced the hard-coded MSRV with a pointer to the workspace `Cargo.toml`; unified the AI attribution string.
- **`CONTRIBUTING.md`:** collapsed the triplicated PyO3 re-export rule to one statement; added an AI-assisted-contributions note.

The shared, repo-agnostic contract (signing flow, commit-message contract, attribution) was hoisted to a machine-wide `~/.claude/CLAUDE.md` (not in this repo); the sibling repos `trestle` and `open-lakehouse` get matching updates in their own PRs.

## Test plan

- [x] `git commit --no-gpg-sign` produces an unsigned commit (`N`) with no PIN prompt — verified live and reverted.
- [x] Attribution strings consistent across `CLAUDE.md`, `CONTRIBUTING.md`, and the skill; no stale "Never run git commit" wording remains.
- [x] Pre-push one-liner matches the actual CI invocations in `.github/workflows/ci.yaml`.
- [ ] Reviewer sanity-check of the trimmed docs.

This pull request was AI-assisted by Isaac.
